### PR TITLE
Fix broken SMP/NUMA topology cache construction

### DIFF
--- a/topology.go
+++ b/topology.go
@@ -2,6 +2,8 @@ package ghw
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 )
 
 type Architecture int
@@ -53,10 +55,19 @@ func (c *MemoryCache) String() string {
 		typeStr = "d"
 	}
 	cacheIdStr := fmt.Sprintf("L%d%s", c.Level, typeStr)
+	processorMapStr := ""
+	if c.LogicalProcessors != nil {
+		lpStrings := make([]string, len(c.LogicalProcessors))
+		for x, lpid := range c.LogicalProcessors {
+			lpStrings[x] = strconv.Itoa(int(lpid))
+		}
+		processorMapStr = " shared with logical processors: " + strings.Join(lpStrings, ",")
+	}
 	return fmt.Sprintf(
-		"%s cache (%d KB)",
+		"%s cache (%d KB)%s",
 		cacheIdStr,
 		sizeKb,
+		processorMapStr,
 	)
 }
 


### PR DESCRIPTION
The root of the segfault was doing an append() on a pre-sized array, but
in diagnosing that issue, I noted that the parsing of sysfs files that
contained cache type, cache size and the shared logical processor map
was improperly leaving newline characters in the resulting []byte that
were read from the sysfs files, resulting in incorrect zeroed values.

Closes Issue #11