### PR TITLE
Ensure core ID for topology.Node is correct

### DIFF
--- a/topology_linux.go
+++ b/topology_linux.go
@@ -113,7 +113,9 @@ func coresForNode(nodeId NodeId) ([]*ProcessorCore, error) {
 		if err != nil {
 			continue
 		}
-		coreIdInt, _ := strconv.Atoi(string(coreIdContents))
+		// coreIdContents is a []byte with the last byte being a newline rune
+		coreIdStr := string(coreIdContents[:len(coreIdContents)-1])
+		coreIdInt, _ := strconv.Atoi(coreIdStr)
 		coreId := ProcessorId(coreIdInt)
 
 		core := findCoreById(coreId)


### PR DESCRIPTION
The root cause of the bug from issue #14 was the same issue from #11.
When processing the NUMA node core_id map from sysfs on Linux, we were
not appropriately removing the trailing newline from the []byte read
from ioutil.Readfile().

This fixes that issue and adds printing of core and cache information
for the TopologyInfo struct.

Closes Issue #14