### PR TITLE
implement `PCIInfo.GetDeviceInfo()`

### DIFF
--- a/pci.go
+++ b/pci.go
@@ -48,12 +48,12 @@ type PCIVendorInfo struct {
 }
 
 type PCIDeviceInfo struct {
-	Vendor           PCIVendorInfo
-	SubsystemVendor  PCIVendorInfo // optional subvendor information
-	Product          PCIProductInfo
-	SubsystemProduct PCIProductInfo // optional sub-device information
-	Class            PCIClassInfo
-	Subclass         PCIClassInfo // optional sub-class for the device
+	Vendor               *PCIVendorInfo
+	Product              *PCIProductInfo
+	Subsystem            *PCIProductInfo // optional subvendor/sub-device information
+	Class                *PCIClassInfo
+	Subclass             *PCISubclassInfo             // optional sub-class for the device
+	ProgrammingInterface *PCIProgrammingInterfaceInfo // optional programming interface
 }
 
 type PCIInfo struct {

--- a/pci_linux.go
+++ b/pci_linux.go
@@ -9,8 +9,14 @@ package ghw
 
 import (
 	"bufio"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
+)
+
+const (
+	PATH_SYSFS_PCI_DEVICES = "/sys/bus/pci/devices"
 )
 
 var (
@@ -188,4 +194,141 @@ func parsePCIIdsFile(info *PCIInfo, scanner *bufio.Scanner) error {
 		}
 	}
 	return nil
+}
+
+func getPCIDeviceModaliasPath(address string) string {
+	pciAddr := PCIAddressFromString(address)
+	if pciAddr == nil {
+		return ""
+	}
+	return filepath.Join(
+		PATH_SYSFS_PCI_DEVICES,
+		pciAddr.Domain+":"+pciAddr.Bus+":"+pciAddr.Slot+"."+pciAddr.Function,
+		"modalias",
+	)
+}
+
+// Returns a pointer to a PCIDeviceInfo struct that describes the PCI device at
+// the requested address. If no such device could be found, returns nil
+func (info *PCIInfo) GetDeviceInfo(address string) *PCIDeviceInfo {
+	fp := getPCIDeviceModaliasPath(address)
+	if fp == "" {
+		return nil
+	}
+	if _, err := os.Stat(fp); err != nil {
+		return nil
+	}
+	data, err := ioutil.ReadFile(fp)
+	if err != nil {
+		return nil
+	}
+	// The modalias file is an encoded file that looks like this:
+	//
+	// $ cat /sys/devices/pci0000\:00/0000\:00\:03.0/0000\:03\:00.0/modalias
+	// pci:v000010DEd00001C82sv00001043sd00008613bc03sc00i00
+	//
+	// It is interpreted like so:
+	//
+	// pci: -- ignore
+	// v000010DE -- PCI vendor ID
+	// d00001C82 -- PCI device ID (the product/model ID)
+	// sv00001043 -- PCI subsystem vendor ID
+	// sd00008613 -- PCI subsystem device ID (subdevice product/model ID)
+	// bc03 -- PCI base class
+	// sc00 -- PCI subclass
+	// i00 -- programming interface
+	vendorId := strings.ToLower(string(data[9:13]))
+	productId := strings.ToLower(string(data[18:22]))
+	subvendorId := strings.ToLower(string(data[28:32]))
+	subproductId := strings.ToLower(string(data[38:42]))
+	classId := string(data[44:46])
+	subclassId := string(data[48:50])
+	progIfaceId := string(data[51:53])
+
+	// Find the vendor
+	vendor := info.Vendors[vendorId]
+	if vendor == nil {
+		vendor = &PCIVendorInfo{
+			Id:       vendorId,
+			Name:     "UNKNOWN",
+			Products: []*PCIProductInfo{},
+		}
+	}
+
+	// Find the product
+	product := info.Products[vendorId+productId]
+	if product == nil {
+		product = &PCIProductInfo{
+			Id:         productId,
+			Name:       "UNKNOWN",
+			Subsystems: []*PCIProductInfo{},
+		}
+	}
+
+	// Find the subsystem information
+	subvendor := info.Vendors[subvendorId]
+	var subsystem *PCIProductInfo
+	if subvendor != nil && product != nil {
+		for _, p := range product.Subsystems {
+			if p.Id == subproductId {
+				subsystem = p
+			}
+		}
+	}
+	if subsystem == nil {
+		subsystem = &PCIProductInfo{
+			VendorId: subvendorId,
+			Id:       subproductId,
+			Name:     "UNKNOWN",
+		}
+	}
+
+	// Find the class and subclass
+	class := info.Classes[classId]
+	var subclass *PCISubclassInfo
+	if class != nil {
+		for _, sc := range class.Subclasses {
+			if sc.Id == subclassId {
+				subclass = sc
+			}
+		}
+	} else {
+		class = &PCIClassInfo{
+			Id:         classId,
+			Name:       "UNKNOWN",
+			Subclasses: []*PCISubclassInfo{},
+		}
+	}
+
+	// Find the programming interface
+	var progIface *PCIProgrammingInterfaceInfo
+	if subclass != nil {
+		for _, pi := range subclass.ProgrammingInterfaces {
+			if pi.Id == progIfaceId {
+				progIface = pi
+			}
+		}
+	} else {
+		subclass = &PCISubclassInfo{
+			Id:   subclassId,
+			Name: "UNKNOWN",
+			ProgrammingInterfaces: []*PCIProgrammingInterfaceInfo{},
+		}
+	}
+
+	if progIface == nil {
+		progIface = &PCIProgrammingInterfaceInfo{
+			Id:   progIfaceId,
+			Name: "UNKNOWN",
+		}
+	}
+
+	return &PCIDeviceInfo{
+		Vendor:               vendor,
+		Subsystem:            subsystem,
+		Product:              product,
+		Class:                class,
+		Subclass:             subclass,
+		ProgrammingInterface: progIface,
+	}
 }

--- a/pci_test.go
+++ b/pci_test.go
@@ -8,8 +8,60 @@ package ghw
 
 import (
 	"os"
+	"reflect"
 	"testing"
 )
+
+func TestPCIAddressFromString(t *testing.T) {
+
+	tests := []struct {
+		addrStr  string
+		expected *PCIAddress
+	}{
+		{
+			addrStr: "00:00.0",
+			expected: &PCIAddress{
+				Domain:   "0000",
+				Bus:      "00",
+				Slot:     "00",
+				Function: "0",
+			},
+		},
+		{
+			addrStr: "0000:00:00.0",
+			expected: &PCIAddress{
+				Domain:   "0000",
+				Bus:      "00",
+				Slot:     "00",
+				Function: "0",
+			},
+		},
+		{
+			addrStr: "0000:03:00.0",
+			expected: &PCIAddress{
+				Domain:   "0000",
+				Bus:      "03",
+				Slot:     "00",
+				Function: "0",
+			},
+		},
+		{
+			addrStr: "0000:03:00.A",
+			expected: &PCIAddress{
+				Domain:   "0000",
+				Bus:      "03",
+				Slot:     "00",
+				Function: "a",
+			},
+		},
+	}
+	for x, test := range tests {
+		got := PCIAddressFromString(test.addrStr)
+		if !reflect.DeepEqual(got, test.expected) {
+			t.Fatalf("Test #%d failed. Expected %v but got %v", x, test.expected, got)
+		}
+	}
+}
 
 func TestPCI(t *testing.T) {
 	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_PCI"); ok {


### PR DESCRIPTION
Adds a method to `ghw.PCIInfo` that queries a particular PCI device in sysfs and populates a `ghw.PCIDeviceInfo` struct with information about the device at the supplied address.

Issue #26
Issue #24 