### PR TITLE
Adds basic GPU module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: go
 # Using sudo triggers a real virtual machine as opposed to a container, which
 # allows ghw to actually determine things like host memory or block storage...
 sudo: required
+env:
+  - GHW_TESTING_SKIP_GPU=1
 script:
   - make test
   - go run ghwc/main.go

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ information about the host computer:
 * [Topology](#topology)
 * [Network](#network)
 * [PCI](#pci)
+* [GPU](#gpu)
 
 ### Memory
 
@@ -225,11 +226,11 @@ Example output from my personal workstation:
 ```
 block storage (1 disk, 2TB physical storage)
  /dev/sda (2TB) [SCSI]  LSI - SN #3600508e000000000f8253aac9a1abd0c
-  /dev/sda1 (100MB) 
-  /dev/sda2 (187GB) 
-  /dev/sda3 (449MB) 
-  /dev/sda4 (1KB) 
-  /dev/sda5 (15GB) 
+  /dev/sda1 (100MB)
+  /dev/sda2 (187GB)
+  /dev/sda3 (449MB)
+  /dev/sda4 (1KB)
+  /dev/sda5 (15GB)
   /dev/sda6 (2TB) [ext4] mounted@/
 ```
 
@@ -822,6 +823,60 @@ Class: Display controller [03]
 Subclass: VGA compatible controller [00]
 Programming Interface: VGA controller [00]
 ```
+
+### GPU
+
+Information about the host computer's graphics hardware is returned from the
+`ghw.GPU()` function. This function returns a pointer to a `ghw.GPUInfo`
+struct.
+
+The `ghw.GPUInfo` struct contains one field:
+
+* `ghw.GPUInfo.GraphicCards` is an array of pointers to `ghw.GraphicsCard`
+  structs, one for each graphics card found for the systen
+
+Each `ghw.GraphicsCard` struct contains the following fields:
+
+* `ghw.GraphicsCard.Index` is the system's numeric zero-based index for the
+  card on the bus
+* `ghw.GraphicsCard.Address` is the PCI address for the graphics card
+* `ghw.GraphicsCard.DeviceInfo` is a pointer to a `ghw.PCIDeviceInfo` struct
+  describing the graphics card. This may be `nil` if no PCI device information
+  could be determined for the card.
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/jaypipes/ghw"
+)
+
+func main() {
+	gpu, err := ghw.GPU())
+	if err != nil {
+		fmt.Printf("Error getting GPU info: %v", err)
+	}
+
+	fmt.Printf("%v\n", gpu)
+
+	for _, card := range gpu.GraphicsCards {
+		fmt.Printf(" %v\n", card)
+	}
+}
+```
+
+Example output from my personal workstation:
+
+```
+gpu (1 graphics card)
+ card #0 @0000:03:00.0 -> class: 'Display controller' vendor: 'NVIDIA Corporation' product: 'GP107 [GeForce GTX 1050 Ti]'
+```
+
+**NOTE**: You can [read more](#pci) about the fields of the `ghw.PCIDeviceInfo`
+struct if you'd like to dig deeper into PCI subsystem and programming interface
+information
 
 ## Developers
 

--- a/ghwc/main.go
+++ b/ghwc/main.go
@@ -33,6 +33,7 @@ func init() {
 	rootCommand.AddCommand(blockCommand)
 	rootCommand.AddCommand(topologyCommand)
 	rootCommand.AddCommand(netCommand)
+	rootCommand.AddCommand(gpuCommand)
 	rootCommand.SilenceUsage = true
 }
 
@@ -61,6 +62,10 @@ func showAll(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	err = showNetwork(cmd, args)
+	if err != nil {
+		return err
+	}
+	err = showGPU(cmd, args)
 	if err != nil {
 		return err
 	}
@@ -148,6 +153,22 @@ func showNetwork(cmd *cobra.Command, args []string) error {
 
 	for _, nic := range net.NICs {
 		fmt.Printf(" %v\n", nic)
+	}
+	return nil
+}
+
+var gpuCommand = &cobra.Command{
+	Use:   "gpu",
+	Short: "Show graphics/GPU information for the host system",
+	RunE:  showGPU,
+}
+
+func showGPU(cmd *cobra.Command, args []string) error {
+	gpu := info.GPU
+	fmt.Printf("%v\n", gpu)
+
+	for _, card := range gpu.GraphicsCards {
+		fmt.Printf(" %v\n", card)
 	}
 	return nil
 }

--- a/gpu.go
+++ b/gpu.go
@@ -21,6 +21,14 @@ type GraphicsCard struct {
 	DeviceInfo *PCIDeviceInfo
 }
 
+func (card *GraphicsCard) String() string {
+	return fmt.Sprintf(
+		"card #%d @%s",
+		card.Index,
+		card.Address,
+	)
+}
+
 type GPUInfo struct {
 	GraphicsCards []*GraphicsCard
 }

--- a/gpu.go
+++ b/gpu.go
@@ -1,0 +1,47 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ghw
+
+import (
+	"fmt"
+)
+
+type GraphicsCard struct {
+	// the PCI address where the graphics card can be found
+	Address string
+	// The "index" of the card on the bus (generally not useful information,
+	// but might as well include it)
+	Index int
+	// pointer to a PCIDeviceInfo struct that describes the vendor and product
+	// model, etc
+	DeviceInfo *PCIDeviceInfo
+}
+
+type GPUInfo struct {
+	GraphicsCards []*GraphicsCard
+}
+
+func GPU() (*GPUInfo, error) {
+	info := &GPUInfo{}
+	err := gpuFillInfo(info)
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+func (i *GPUInfo) String() string {
+	numCardsStr := "cards"
+	if len(i.GraphicsCards) == 1 {
+		numCardsStr = "card"
+	}
+	return fmt.Sprintf(
+		"gpu (%d graphics %s)",
+		len(i.GraphicsCards),
+		numCardsStr,
+	)
+}

--- a/gpu.go
+++ b/gpu.go
@@ -22,10 +22,14 @@ type GraphicsCard struct {
 }
 
 func (card *GraphicsCard) String() string {
+	deviceStr := card.Address
+	if card.DeviceInfo != nil {
+		deviceStr = card.DeviceInfo.String()
+	}
 	return fmt.Sprintf(
 		"card #%d @%s",
 		card.Index,
-		card.Address,
+		deviceStr,
 	)
 }
 

--- a/gpu_linux.go
+++ b/gpu_linux.go
@@ -82,6 +82,21 @@ func gpuFillInfo(info *GPUInfo) error {
 		}
 		cards = append(cards, card)
 	}
+	gpuFillPCIDeviceInfo(cards)
 	info.GraphicsCards = cards
 	return nil
+}
+
+// Loops through each GraphicsCard struct and attempts to fill the DeviceInfo
+// attribute with PCI device information
+func gpuFillPCIDeviceInfo(cards []*GraphicsCard) {
+	pci, err := PCI()
+	if err != nil {
+		return
+	}
+	for _, card := range cards {
+		if card.DeviceInfo == nil {
+			card.DeviceInfo = pci.GetDeviceInfo(card.Address)
+		}
+	}
 }

--- a/gpu_linux.go
+++ b/gpu_linux.go
@@ -8,6 +8,7 @@
 package ghw
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -48,7 +49,14 @@ func gpuFillInfo(info *GPUInfo) error {
 	// directory using the `ghw.PCIInfo.GetDeviceInfo()` function.
 	links, err := ioutil.ReadDir(PATH_SYSFS_CLASS_DRM)
 	if err != nil {
-		return err
+		fmt.Fprintf(os.Stderr, `************************ WARNING ***********************************
+/sys/class/drm does not exist on this system (likely the host system is a
+virtual machine or container with no graphics). Therefore,
+GPUInfo.GraphicsCards will be an empty array.
+********************************************************************
+`,
+		)
+		return nil
 	}
 	cards := make([]*GraphicsCard, 0)
 	for _, link := range links {

--- a/gpu_linux.go
+++ b/gpu_linux.go
@@ -1,0 +1,87 @@
+// +build linux
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ghw
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	PATH_SYSFS_CLASS_DRM = "/sys/class/drm"
+)
+
+func gpuFillInfo(info *GPUInfo) error {
+	// In Linux, each graphics card is listed under the /sys/class/drm
+	// directory as a symbolic link named "cardN", where N is a zero-based
+	// index of the card in the system. "DRM" stands for Direct Rendering
+	// Manager and is the Linux subsystem that is responsible for graphics I/O
+	//
+	// Each card may have multiple symbolic
+	// links in this directory representing the interfaces from the graphics
+	// card over a particular wire protocol (HDMI, DisplayPort, etc). These
+	// symbolic links are named cardN-<INTERFACE_TYPE>-<DISPLAY_ID>. For
+	// instance, on one of my local workstations with an NVIDIA GTX 1050ti
+	// graphics card with one HDMI, one DisplayPort, and one DVI interface to
+	// the card, I see the following in /sys/class/drm:
+	//
+	// $ ll /sys/class/drm/
+	// total 0
+	// drwxr-xr-x  2 root root    0 Jul 16 11:50 ./
+	// drwxr-xr-x 75 root root    0 Jul 16 11:50 ../
+	// lrwxrwxrwx  1 root root    0 Jul 16 11:50 card0 -> ../../devices/pci0000:00/0000:00:03.0/0000:03:00.0/drm/card0/
+	// lrwxrwxrwx  1 root root    0 Jul 16 11:50 card0-DP-1 -> ../../devices/pci0000:00/0000:00:03.0/0000:03:00.0/drm/card0/card0-DP-1/
+	// lrwxrwxrwx  1 root root    0 Jul 16 11:50 card0-DVI-D-1 -> ../../devices/pci0000:00/0000:00:03.0/0000:03:00.0/drm/card0/card0-DVI-D-1/
+	// lrwxrwxrwx  1 root root    0 Jul 16 11:50 card0-HDMI-A-1 -> ../../devices/pci0000:00/0000:00:03.0/0000:03:00.0/drm/card0/card0-HDMI-A-1/
+	//
+	// In this routine, we are only interested in the first link (card0), which
+	// we follow to gather information about the actual device from the PCI
+	// subsystem (we query the modalias file of the PCI device's sysfs
+	// directory using the `ghw.PCIInfo.GetDeviceInfo()` function.
+	links, err := ioutil.ReadDir(PATH_SYSFS_CLASS_DRM)
+	if err != nil {
+		return err
+	}
+	cards := make([]*GraphicsCard, 0)
+	for _, link := range links {
+		lname := link.Name()
+		if !strings.HasPrefix(lname, "card") {
+			continue
+		}
+		if strings.ContainsRune(lname, '-') {
+			continue
+		}
+		// Grab the card's zero-based integer index
+		lnameBytes := []byte(lname)
+		cardIdx, err := strconv.Atoi(string(lnameBytes[4:]))
+		if err != nil {
+			cardIdx = -1
+		}
+
+		// Calculate the card's PCI address by looking at the symbolic link's
+		// target
+		lpath := filepath.Join(PATH_SYSFS_CLASS_DRM, lname)
+		dest, err := os.Readlink(lpath)
+		if err != nil {
+			continue
+		}
+		pathParts := strings.Split(dest, "/")
+		numParts := len(pathParts)
+		pciAddress := pathParts[numParts-3]
+		card := &GraphicsCard{
+			Address: pciAddress,
+			Index:   cardIdx,
+		}
+		cards = append(cards, card)
+	}
+	info.GraphicsCards = cards
+	return nil
+}

--- a/gpu_test.go
+++ b/gpu_test.go
@@ -23,4 +23,13 @@ func TestGPU(t *testing.T) {
 	if len(info.GraphicsCards) == 0 {
 		t.Fatalf("Expected >0 GPU cards, but found 0.")
 	}
+
+	for _, card := range info.GraphicsCards {
+		if card.Address != "" {
+			di := card.DeviceInfo
+			if di == nil {
+				t.Fatalf("Expected card with address %s to have non-nil DeviceInfo.", card.Address)
+			}
+		}
+	}
 }

--- a/gpu_test.go
+++ b/gpu_test.go
@@ -15,6 +15,9 @@ func TestGPU(t *testing.T) {
 	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_GPU"); ok {
 		t.Skip("Skipping GPU tests.")
 	}
+	if _, err := os.Stat("/sys/class/drm"); os.IsNotExist(err) {
+		t.Skip("Skipping GPU tests. The environment has no /sys/class/drm directory.")
+	}
 	info, err := GPU()
 	if err != nil {
 		t.Fatalf("Expected no error creating GPUInfo, but got %v", err)

--- a/gpu_test.go
+++ b/gpu_test.go
@@ -1,0 +1,26 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ghw
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGPU(t *testing.T) {
+	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_GPU"); ok {
+		t.Skip("Skipping GPU tests.")
+	}
+	info, err := GPU()
+	if err != nil {
+		t.Fatalf("Expected no error creating GPUInfo, but got %v", err)
+	}
+
+	if len(info.GraphicsCards) == 0 {
+		t.Fatalf("Expected >0 GPU cards, but found 0.")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ type HostInfo struct {
 	CPU      *CPUInfo
 	Topology *TopologyInfo
 	Network  *NetworkInfo
+	GPU      *GPUInfo
 }
 
 func Host() (*HostInfo, error) {
@@ -41,5 +42,10 @@ func Host() (*HostInfo, error) {
 		return nil, err
 	}
 	info.Network = net
+	gpu, err := GPU()
+	if err != nil {
+		return nil, err
+	}
+	info.GPU = gpu
 	return info, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -68,4 +68,9 @@ func TestHost(t *testing.T) {
 	if len(topology.Nodes) < 1 {
 		t.Fatalf("Expected >0 nodes , but got %d", len(topology.Nodes))
 	}
+
+	gpu := host.GPU
+	if gpu == nil {
+		t.Fatalf("Expected non-nil GPU but got nil.")
+	}
 }

--- a/pci.go
+++ b/pci.go
@@ -72,7 +72,7 @@ func (di *PCIDeviceInfo) String() string {
 		className = di.Class.Name
 	}
 	return fmt.Sprintf(
-		"%s (class: %s vendor: %s product: %s)",
+		"%s -> class: '%s' vendor: '%s' product: '%s'",
 		di.Address,
 		className,
 		vendorName,

--- a/pci.go
+++ b/pci.go
@@ -7,6 +7,7 @@
 package ghw
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -48,12 +49,35 @@ type PCIVendorInfo struct {
 }
 
 type PCIDeviceInfo struct {
+	Address              string // The PCI address of the device
 	Vendor               *PCIVendorInfo
 	Product              *PCIProductInfo
 	Subsystem            *PCIProductInfo // optional subvendor/sub-device information
 	Class                *PCIClassInfo
 	Subclass             *PCISubclassInfo             // optional sub-class for the device
 	ProgrammingInterface *PCIProgrammingInterfaceInfo // optional programming interface
+}
+
+func (di *PCIDeviceInfo) String() string {
+	vendorName := "<unknown>"
+	if di.Vendor != nil {
+		vendorName = di.Vendor.Name
+	}
+	productName := "<unknown>"
+	if di.Product != nil {
+		productName = di.Product.Name
+	}
+	className := "<unknown>"
+	if di.Class != nil {
+		className = di.Class.Name
+	}
+	return fmt.Sprintf(
+		"%s (class: %s vendor: %s product: %s)",
+		di.Address,
+		className,
+		vendorName,
+		productName,
+	)
 }
 
 type PCIInfo struct {

--- a/pci_linux.go
+++ b/pci_linux.go
@@ -324,6 +324,7 @@ func (info *PCIInfo) GetDeviceInfo(address string) *PCIDeviceInfo {
 	}
 
 	return &PCIDeviceInfo{
+		Address:              address,
 		Vendor:               vendor,
 		Subsystem:            subsystem,
 		Product:              product,


### PR DESCRIPTION
For now, the `ghw.GPUInfo` struct is fairly simple, containing a single field called `GraphicsCards` which is an array of `ghw.GraphicsCard` struct pointers. Each of those contains a `ghw.PCIDeviceInfo` that can be used to gather information about the graphics card.

Still to do is gather information about the graphics drivers in use and capabilities of GPUs, vGPUs, etc.

Issue #4