### PR TITLE
add NUMA node affinity to GraphicsCard struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,6 +874,9 @@ Each `ghw.GraphicsCard` struct contains the following fields:
 * `ghw.GraphicsCard.DeviceInfo` is a pointer to a `ghw.PCIDeviceInfo` struct
   describing the graphics card. This may be `nil` if no PCI device information
   could be determined for the card.
+* `ghw.GraphicsCard.Nodes` is an array of pointers to `ghw.Node` structs, one
+  for each NUMA node that the GPU/graphics card is affined to. On non-NUMA
+  systems, this will always be an empty array.
 
 ```go
 package main
@@ -908,6 +911,9 @@ gpu (1 graphics card)
 **NOTE**: You can [read more](#pci) about the fields of the `ghw.PCIDeviceInfo`
 struct if you'd like to dig deeper into PCI subsystem and programming interface
 information
+
+**NOTE**: You can [read more](#topology) about the fields of the `ghw.Node`
+struct if you'd like to dig deeper into NUMA/topology subsystem
 
 ## Developers
 

--- a/gpu.go
+++ b/gpu.go
@@ -8,6 +8,7 @@ package ghw
 
 import (
 	"fmt"
+	"strconv"
 )
 
 type GraphicsCard struct {
@@ -19,6 +20,9 @@ type GraphicsCard struct {
 	// pointer to a PCIDeviceInfo struct that describes the vendor and product
 	// model, etc
 	DeviceInfo *PCIDeviceInfo
+	// Array of NUMA nodes that the graphics card is affined to. Will be empty
+	// if the architecture is not NUMA.
+	Nodes []*Node
 }
 
 func (card *GraphicsCard) String() string {
@@ -26,9 +30,23 @@ func (card *GraphicsCard) String() string {
 	if card.DeviceInfo != nil {
 		deviceStr = card.DeviceInfo.String()
 	}
+	nodeStr := ""
+	if len(card.Nodes) > 0 {
+		x := 0
+		nodeStr = " NUMA nodes ["
+		for _, node := range card.Nodes {
+			if x > 0 {
+				nodeStr += ","
+			}
+			nodeStr += strconv.Itoa(int(node.Id))
+			x++
+		}
+		nodeStr += "] "
+	}
 	return fmt.Sprintf(
-		"card #%d @%s",
+		"card #%d %s@%s",
 		card.Index,
+		nodeStr,
 		deviceStr,
 	)
 }

--- a/gpu_test.go
+++ b/gpu_test.go
@@ -34,5 +34,10 @@ func TestGPU(t *testing.T) {
 				t.Fatalf("Expected card with address %s to have non-nil DeviceInfo.", card.Address)
 			}
 		}
+		// The Nodes attribute should at least be filled with empty arrays of
+		// Node pointers
+		if card.Nodes == nil {
+			t.Fatalf("Expected card with address %s to have non-nil Nodes.", card.Address)
+		}
 	}
 }


### PR DESCRIPTION
Queries the `/sys/class/drm/card$CARD_INDEX/device/numa_nodes` file for the NUMA nodes that a card is affined to, adding a `ghw.GraphicsCard.Nodes` field for storing an array of pointers to the `ghw.Node` structs.

Issue #4