### PR TITLE
Topology module fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ The `ghw.TopologyInfo` struct contains two fields:
 
 Each `ghw.Node` struct contains the following fields:
 
-* `ghw.Node.Id` is the system's identifier for the node
+* `ghw.Node.Id` is the system's `uint32` identifier for the node
 * `ghw.Node.Cores` is an array of pointers to `ghw.ProcessorCore` structs that
   are contained in this node
 * `ghw.Node.Caches` is an array of pointers to `ghw.MemoryCache` structs that

--- a/README.md
+++ b/README.md
@@ -275,16 +275,16 @@ The `ghw.TopologyInfo` struct contains two fields:
 
 * `ghw.TopologyInfo.Architecture` contains an enum with the value `ghw.NUMA` or
   `ghw.SMP` depending on what the topology of the system is
-* `ghw.TopologyInfo.Nodes` is an array of pointers to `ghw.Node` structs, one
-  for each topology node (typically physical processor package) found by the
-  system
+* `ghw.TopologyInfo.Nodes` is an array of pointers to `ghw.TopologyNode`
+  structs, one for each topology node (typically physical processor package)
+  found by the system
 
-Each `ghw.Node` struct contains the following fields:
+Each `ghw.TopologyNode` struct contains the following fields:
 
-* `ghw.Node.Id` is the system's `uint32` identifier for the node
-* `ghw.Node.Cores` is an array of pointers to `ghw.ProcessorCore` structs that
+* `ghw.TopologyNode.Id` is the system's `uint32` identifier for the node
+* `ghw.TopologyNode.Cores` is an array of pointers to `ghw.ProcessorCore` structs that
   are contained in this node
-* `ghw.Node.Caches` is an array of pointers to `ghw.MemoryCache` structs that
+* `ghw.TopologyNode.Caches` is an array of pointers to `ghw.MemoryCache` structs that
   represent the low-level caches associated with processors and cores on the
   system
 
@@ -874,9 +874,9 @@ Each `ghw.GraphicsCard` struct contains the following fields:
 * `ghw.GraphicsCard.DeviceInfo` is a pointer to a `ghw.PCIDevice` struct
   describing the graphics card. This may be `nil` if no PCI device information
   could be determined for the card.
-* `ghw.GraphicsCard.Nodes` is an array of pointers to `ghw.Node` structs, one
-  for each NUMA node that the GPU/graphics card is affined to. On non-NUMA
-  systems, this will always be an empty array.
+* `ghw.GraphicsCard.Nodes` is an array of pointers to `ghw.TopologyNode`
+  structs, one for each NUMA node that the GPU/graphics card is affined to. On
+  non-NUMA systems, this will always be an empty array.
 
 ```go
 package main
@@ -912,8 +912,9 @@ gpu (1 graphics card)
 struct if you'd like to dig deeper into PCI subsystem and programming interface
 information
 
-**NOTE**: You can [read more](#topology) about the fields of the `ghw.Node`
-struct if you'd like to dig deeper into NUMA/topology subsystem
+**NOTE**: You can [read more](#topology) about the fields of the
+`ghw.TopologyNode` struct if you'd like to dig deeper into the NUMA/topology
+subsystem
 
 ## Developers
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ information about the CPUs on the host system.
 
 Each `ghw.Processor` struct contains a number of fields:
 
-* `ghw.Processor.Id` is the physical processor ID according to the system
+* `ghw.Processor.Id` is the physical processor `uint32` ID according to the
+  system
 * `ghw.Processor.NumCores` is the number of physical cores in the processor
   package
 * `ghw.Processor.NumThreads` is the number of hardware threads in the processor
@@ -104,10 +105,10 @@ Each `ghw.Processor` struct contains a number of fields:
 
 A `ghw.ProcessorCore` has the following fields:
 
-* `ghw.ProcessorCore.Id` is the identifier that the host gave this core. Note
-  that this does *not* necessarily equate to a zero-based index of the core
-  within a physical package. For example, the core IDs for an Intel Core i7
-  are 0, 1, 2, 8, 9, and 10
+* `ghw.ProcessorCore.Id` is the `uint32` identifier that the host gave this
+  core. Note that this does *not* necessarily equate to a zero-based index of
+  the core within a physical package. For example, the core IDs for an Intel Core
+  i7 are 0, 1, 2, 8, 9, and 10
 * `ghw.ProcessorCore.Index` is the zero-based index of the core on the physical
   processor package
 * `ghw.ProcessorCore.NumThreads` is the number of hardware threads associated

--- a/cpu.go
+++ b/cpu.go
@@ -10,13 +10,11 @@ import (
 	"fmt"
 )
 
-type ProcessorId uint32
-
 type ProcessorCore struct {
-	Id                ProcessorId
+	Id                uint32
 	Index             int
 	NumThreads        uint32
-	LogicalProcessors []ProcessorId
+	LogicalProcessors []uint32
 }
 
 func (c *ProcessorCore) String() string {
@@ -29,7 +27,7 @@ func (c *ProcessorCore) String() string {
 }
 
 type Processor struct {
-	Id           ProcessorId
+	Id           uint32
 	NumCores     uint32
 	NumThreads   uint32
 	Vendor       string

--- a/cpu_linux.go
+++ b/cpu_linux.go
@@ -9,7 +9,10 @@ package ghw
 
 import (
 	"bufio"
+	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -143,4 +146,75 @@ func Processors() []*Processor {
 		procs = append(procs, p)
 	}
 	return procs
+}
+
+func coresForNode(nodeId uint32) ([]*ProcessorCore, error) {
+	// The /sys/devices/system/node/nodeX directory contains a subdirectory
+	// called 'cpuX' for each logical processor assigned to the node. Each of
+	// those subdirectories contains a topology subdirectory which has a
+	// core_id file that indicates the 0-based identifier of the physical core
+	// the logical processor (hardware thread) is on.
+	path := filepath.Join(
+		PATH_DEVICES_SYSTEM_NODE,
+		fmt.Sprintf("node%d", nodeId),
+	)
+	cores := make([]*ProcessorCore, 0)
+
+	findCoreById := func(cid ProcessorId) *ProcessorCore {
+		for _, c := range cores {
+			if c.Id == cid {
+				return c
+			}
+		}
+
+		c := &ProcessorCore{
+			Id:                cid,
+			Index:             len(cores),
+			LogicalProcessors: make([]ProcessorId, 0),
+		}
+		cores = append(cores, c)
+		return c
+	}
+
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range files {
+		filename := file.Name()
+		if !strings.HasPrefix(filename, "cpu") {
+			continue
+		}
+		if filename == "cpumap" || filename == "cpulist" {
+			// There are two files in the node directory that start with 'cpu'
+			// but are not subdirectories ('cpulist' and 'cpumap'). Ignore
+			// these files.
+			continue
+		}
+		// Grab the logical processor ID by cutting the integer from the
+		// /sys/devices/system/node/nodeX/cpuX filename
+		cpuPath := filepath.Join(path, filename)
+		lpId, _ := strconv.Atoi(filename[3:])
+		coreIdPath := filepath.Join(cpuPath, "topology", "core_id")
+		coreIdContents, err := ioutil.ReadFile(coreIdPath)
+		if err != nil {
+			continue
+		}
+		// coreIdContents is a []byte with the last byte being a newline rune
+		coreIdStr := string(coreIdContents[:len(coreIdContents)-1])
+		coreIdInt, _ := strconv.Atoi(coreIdStr)
+		coreId := ProcessorId(coreIdInt)
+
+		core := findCoreById(coreId)
+		core.LogicalProcessors = append(
+			core.LogicalProcessors,
+			ProcessorId(lpId),
+		)
+	}
+
+	for _, c := range cores {
+		c.NumThreads = uint32(len(c.LogicalProcessors))
+	}
+
+	return cores, nil
 }

--- a/cpu_linux.go
+++ b/cpu_linux.go
@@ -67,13 +67,13 @@ func Processors() []*Processor {
 
 	// Build a set of physical processor IDs which represent the physical
 	// package of the CPU
-	setPhysicalIds := make(map[ProcessorId]bool, 0)
+	setPhysicalIds := make(map[uint32]bool, 0)
 	for _, attrs := range procAttrs {
 		pid, err := strconv.Atoi(attrs["physical id"])
 		if err != nil {
 			continue
 		}
-		setPhysicalIds[ProcessorId(pid)] = true
+		setPhysicalIds[uint32(pid)] = true
 	}
 
 	for pid, _ := range setPhysicalIds {
@@ -88,7 +88,7 @@ func Processors() []*Processor {
 			if err != nil {
 				continue
 			}
-			if pid == ProcessorId(lppid) {
+			if pid == uint32(lppid) {
 				lps = append(lps, x)
 			}
 		}
@@ -121,20 +121,20 @@ func Processors() []*Processor {
 			}
 			var core *ProcessorCore
 			for _, c := range cores {
-				if c.Id == ProcessorId(coreId) {
+				if c.Id == uint32(coreId) {
 					c.LogicalProcessors = append(
 						c.LogicalProcessors,
-						ProcessorId(lpid),
+						uint32(lpid),
 					)
 					c.NumThreads = uint32(len(c.LogicalProcessors))
 					core = c
 				}
 			}
 			if core == nil {
-				coreLps := make([]ProcessorId, 1)
-				coreLps[0] = ProcessorId(lpid)
+				coreLps := make([]uint32, 1)
+				coreLps[0] = uint32(lpid)
 				core = &ProcessorCore{
-					Id:                ProcessorId(coreId),
+					Id:                uint32(coreId),
 					Index:             len(cores),
 					NumThreads:        1,
 					LogicalProcessors: coreLps,
@@ -160,7 +160,7 @@ func coresForNode(nodeId uint32) ([]*ProcessorCore, error) {
 	)
 	cores := make([]*ProcessorCore, 0)
 
-	findCoreById := func(cid ProcessorId) *ProcessorCore {
+	findCoreById := func(cid uint32) *ProcessorCore {
 		for _, c := range cores {
 			if c.Id == cid {
 				return c
@@ -170,7 +170,7 @@ func coresForNode(nodeId uint32) ([]*ProcessorCore, error) {
 		c := &ProcessorCore{
 			Id:                cid,
 			Index:             len(cores),
-			LogicalProcessors: make([]ProcessorId, 0),
+			LogicalProcessors: make([]uint32, 0),
 		}
 		cores = append(cores, c)
 		return c
@@ -203,12 +203,12 @@ func coresForNode(nodeId uint32) ([]*ProcessorCore, error) {
 		// coreIdContents is a []byte with the last byte being a newline rune
 		coreIdStr := string(coreIdContents[:len(coreIdContents)-1])
 		coreIdInt, _ := strconv.Atoi(coreIdStr)
-		coreId := ProcessorId(coreIdInt)
+		coreId := uint32(coreIdInt)
 
 		core := findCoreById(coreId)
 		core.LogicalProcessors = append(
 			core.LogicalProcessors,
-			ProcessorId(lpId),
+			uint32(lpId),
 		)
 	}
 

--- a/gpu.go
+++ b/gpu.go
@@ -20,9 +20,9 @@ type GraphicsCard struct {
 	// pointer to a PCIDevice struct that describes the vendor and product
 	// model, etc
 	DeviceInfo *PCIDevice
-	// Array of NUMA nodes that the graphics card is affined to. Will be empty
+	// Array of topology nodes that the graphics card is affined to. Will be empty
 	// if the architecture is not NUMA.
-	Nodes []*Node
+	Nodes []*TopologyNode
 }
 
 func (card *GraphicsCard) String() string {

--- a/gpu_linux.go
+++ b/gpu_linux.go
@@ -119,14 +119,14 @@ func gpuFillNUMANodes(cards []*GraphicsCard) {
 	if err != nil {
 		for _, card := range cards {
 			if topo.Architecture != NUMA {
-				card.Nodes = make([]*Node, 0)
+				card.Nodes = make([]*TopologyNode, 0)
 			}
 		}
 		return
 	}
 	for _, card := range cards {
 		if topo.Architecture != NUMA {
-			card.Nodes = make([]*Node, 0)
+			card.Nodes = make([]*TopologyNode, 0)
 			continue
 		}
 		// Each graphics card on a NUMA system will have a pseudo-file
@@ -148,10 +148,10 @@ Setting graphics card's Nodes attribute to empty array.
 ********************************************************************
 `,
 			)
-			card.Nodes = make([]*Node, 0)
+			card.Nodes = make([]*TopologyNode, 0)
 			continue
 		}
-		cardNodes := make([]*Node, 0)
+		cardNodes := make([]*TopologyNode, 0)
 		nodeIndexes := strings.Split(string(numaContents), ",")
 		for _, nodeIndex := range nodeIndexes {
 			for _, node := range topo.Nodes {

--- a/memory_cache.go
+++ b/memory_cache.go
@@ -20,15 +20,21 @@ const (
 	DATA
 )
 
-type SortByMemoryCacheLevel []*MemoryCache
+type SortByMemoryCacheLevelTypeFirstProcessor []*MemoryCache
 
-func (a SortByMemoryCacheLevel) Len() int      { return len(a) }
-func (a SortByMemoryCacheLevel) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a SortByMemoryCacheLevel) Less(i, j int) bool {
+func (a SortByMemoryCacheLevelTypeFirstProcessor) Len() int      { return len(a) }
+func (a SortByMemoryCacheLevelTypeFirstProcessor) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a SortByMemoryCacheLevelTypeFirstProcessor) Less(i, j int) bool {
 	if a[i].Level < a[j].Level {
 		return true
 	} else if a[i].Level == a[j].Level {
-		return a[i].Type < a[j].Type
+		if a[i].Type < a[j].Type {
+			return true
+		} else if a[i].Type == a[j].Type {
+			// NOTE(jaypipes): len(LogicalProcessors) is always >0 and is always
+			// sorted lowest LP ID to highest LP ID
+			return a[i].LogicalProcessors[0] < a[j].LogicalProcessors[0]
+		}
 	}
 	return false
 }

--- a/memory_cache.go
+++ b/memory_cache.go
@@ -39,7 +39,7 @@ type MemoryCache struct {
 	SizeBytes uint64
 	// The set of logical processors (hardware threads) that have access to the
 	// cache
-	LogicalProcessors []ProcessorId
+	LogicalProcessors []uint32
 }
 
 func (c *MemoryCache) String() string {

--- a/memory_cache.go
+++ b/memory_cache.go
@@ -33,6 +33,12 @@ func (a SortByMemoryCacheLevel) Less(i, j int) bool {
 	return false
 }
 
+type SortByLogicalProcessorId []uint32
+
+func (a SortByLogicalProcessorId) Len() int           { return len(a) }
+func (a SortByLogicalProcessorId) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a SortByLogicalProcessorId) Less(i, j int) bool { return a[i] < a[j] }
+
 type MemoryCache struct {
 	Level     uint8
 	Type      MemoryCacheType

--- a/memory_cache.go
+++ b/memory_cache.go
@@ -1,0 +1,68 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ghw
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type MemoryCacheType int
+
+const (
+	UNIFIED MemoryCacheType = iota
+	INSTRUCTION
+	DATA
+)
+
+type SortByMemoryCacheLevel []*MemoryCache
+
+func (a SortByMemoryCacheLevel) Len() int      { return len(a) }
+func (a SortByMemoryCacheLevel) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a SortByMemoryCacheLevel) Less(i, j int) bool {
+	if a[i].Level < a[j].Level {
+		return true
+	} else if a[i].Level == a[j].Level {
+		return a[i].Type < a[j].Type
+	}
+	return false
+}
+
+type MemoryCache struct {
+	Level     uint8
+	Type      MemoryCacheType
+	SizeBytes uint64
+	// The set of logical processors (hardware threads) that have access to the
+	// cache
+	LogicalProcessors []ProcessorId
+}
+
+func (c *MemoryCache) String() string {
+	sizeKb := c.SizeBytes / uint64(KB)
+	typeStr := ""
+	if c.Type == INSTRUCTION {
+		typeStr = "i"
+	} else if c.Type == DATA {
+		typeStr = "d"
+	}
+	cacheIdStr := fmt.Sprintf("L%d%s", c.Level, typeStr)
+	processorMapStr := ""
+	if c.LogicalProcessors != nil {
+		lpStrings := make([]string, len(c.LogicalProcessors))
+		for x, lpid := range c.LogicalProcessors {
+			lpStrings[x] = strconv.Itoa(int(lpid))
+		}
+		processorMapStr = " shared with logical processors: " + strings.Join(lpStrings, ",")
+	}
+	return fmt.Sprintf(
+		"%s cache (%d KB)%s",
+		cacheIdStr,
+		sizeKb,
+		processorMapStr,
+	)
+}

--- a/memory_cache_linux.go
+++ b/memory_cache_linux.go
@@ -117,14 +117,14 @@ func cachesForNode(nodeId uint32) ([]*MemoryCache, error) {
 					Level:             uint8(level),
 					Type:              cacheType,
 					SizeBytes:         uint64(size) * uint64(KB),
-					LogicalProcessors: make([]ProcessorId, 0),
+					LogicalProcessors: make([]uint32, 0),
 				}
 				caches[cacheKey] = cache
 			}
 			cache := caches[cacheKey]
 			cache.LogicalProcessors = append(
 				cache.LogicalProcessors,
-				ProcessorId(lpId),
+				uint32(lpId),
 			)
 		}
 	}

--- a/memory_cache_linux.go
+++ b/memory_cache_linux.go
@@ -1,0 +1,140 @@
+// +build linux
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ghw
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func cachesForNode(nodeId uint32) ([]*MemoryCache, error) {
+	// The /sys/devices/node/nodeX directory contains a subdirectory called
+	// 'cpuX' for each logical processor assigned to the node. Each of those
+	// subdirectories containers a 'cache' subdirectory which contains a number
+	// of subdirectories beginning with 'index' and ending in the cache's
+	// internal 0-based identifier. Those subdirectories contain a number of
+	// files, including 'shared_cpu_list', 'size', and 'type' which we use to
+	// determine cache characteristics.
+	path := filepath.Join(
+		PATH_DEVICES_SYSTEM_NODE,
+		fmt.Sprintf("node%d", nodeId),
+	)
+	caches := make(map[string]*MemoryCache, 0)
+
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range files {
+		filename := file.Name()
+		if !strings.HasPrefix(filename, "cpu") {
+			continue
+		}
+		if filename == "cpumap" || filename == "cpulist" {
+			// There are two files in the node directory that start with 'cpu'
+			// but are not subdirectories ('cpulist' and 'cpumap'). Ignore
+			// these files.
+			continue
+		}
+		// Grab the logical processor ID by cutting the integer from the
+		// /sys/devices/system/node/nodeX/cpuX filename
+		cpuPath := filepath.Join(path, filename)
+		lpId, _ := strconv.Atoi(filename[3:])
+
+		// Inspect the caches for each logical processor. There will be a
+		// /sys/devices/system/node/nodeX/cpuX/cache directory containing a
+		// number of directories beginning with the prefix "index" followed by
+		// a number. The number indicates the level of the cache, which
+		// indicates the "distance" from the processor. Each of these
+		// directories contains information about the size of that level of
+		// cache and the processors mapped to it.
+		cachePath := filepath.Join(cpuPath, "cache")
+		cacheDirFiles, err := ioutil.ReadDir(cachePath)
+		if err != nil {
+			return nil, err
+		}
+		for _, cacheDirFile := range cacheDirFiles {
+			cacheDirFileName := cacheDirFile.Name()
+			if !strings.HasPrefix(cacheDirFileName, "index") {
+				continue
+			}
+
+			typePath := filepath.Join(cachePath, cacheDirFileName, "type")
+			cacheTypeContents, err := ioutil.ReadFile(typePath)
+			if err != nil {
+				continue
+			}
+			cacheType := UNIFIED
+			switch string(cacheTypeContents[:len(cacheTypeContents)-1]) {
+			case "Data":
+				cacheType = DATA
+			case "Instruction":
+				cacheType = INSTRUCTION
+			default:
+				cacheType = UNIFIED
+			}
+
+			levelPath := filepath.Join(cachePath, cacheDirFileName, "level")
+			levelContents, err := ioutil.ReadFile(levelPath)
+			if err != nil {
+				continue
+			}
+			// levelContents is now a []byte with the last byte being a newline
+			// character. Trim that off and convert the contents to an integer.
+			level, _ := strconv.Atoi(string(levelContents[:len(levelContents)-1]))
+
+			sizePath := filepath.Join(cachePath, cacheDirFileName, "size")
+			sizeContents, err := ioutil.ReadFile(sizePath)
+			if err != nil {
+				continue
+			}
+			// size comes as XK\n, so we trim off the K and the newline.
+			size, _ := strconv.Atoi(string(sizeContents[:len(sizeContents)-2]))
+
+			scpuPath := filepath.Join(
+				cachePath,
+				cacheDirFileName,
+				"shared_cpu_map",
+			)
+			sharedCpuMap, err := ioutil.ReadFile(scpuPath)
+			if err != nil {
+				continue
+			}
+			// The cache information is repeated for each node, so here, we
+			// just ensure that we only have a one MemoryCache object for each
+			// unique combination of level, type and processor map
+			cacheKey := fmt.Sprintf("%d-%d-%s", level, cacheType, sharedCpuMap[:len(sharedCpuMap)-1])
+			if cache, ok := caches[cacheKey]; !ok {
+				cache = &MemoryCache{
+					Level:             uint8(level),
+					Type:              cacheType,
+					SizeBytes:         uint64(size) * uint64(KB),
+					LogicalProcessors: make([]ProcessorId, 0),
+				}
+				caches[cacheKey] = cache
+			}
+			cache := caches[cacheKey]
+			cache.LogicalProcessors = append(
+				cache.LogicalProcessors,
+				ProcessorId(lpId),
+			)
+		}
+	}
+
+	cacheVals := make([]*MemoryCache, len(caches))
+	x := 0
+	for _, c := range caches {
+		cacheVals[x] = c
+		x++
+	}
+
+	return cacheVals, nil
+}

--- a/memory_cache_linux.go
+++ b/memory_cache_linux.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -132,6 +133,8 @@ func cachesForNode(nodeId uint32) ([]*MemoryCache, error) {
 	cacheVals := make([]*MemoryCache, len(caches))
 	x := 0
 	for _, c := range caches {
+		// ensure the cache's processor set is sorted by logical process ID
+		sort.Sort(SortByLogicalProcessorId(c.LogicalProcessors))
 		cacheVals[x] = c
 		x++
 	}

--- a/topology.go
+++ b/topology.go
@@ -9,8 +9,6 @@ package ghw
 import (
 	"fmt"
 	"sort"
-	"strconv"
-	"strings"
 )
 
 type Architecture int
@@ -34,61 +32,6 @@ func (n *Node) String() string {
 	)
 }
 
-type MemoryCacheType int
-
-const (
-	UNIFIED MemoryCacheType = iota
-	INSTRUCTION
-	DATA
-)
-
-type ByCacheLevel []*MemoryCache
-
-func (a ByCacheLevel) Len() int      { return len(a) }
-func (a ByCacheLevel) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a ByCacheLevel) Less(i, j int) bool {
-	if a[i].Level < a[j].Level {
-		return true
-	} else if a[i].Level == a[j].Level {
-		return a[i].Type < a[j].Type
-	}
-	return false
-}
-
-type MemoryCache struct {
-	Level     uint8
-	Type      MemoryCacheType
-	SizeBytes uint64
-	// The set of logical processors (hardware threads) that have access to the
-	// cache
-	LogicalProcessors []ProcessorId
-}
-
-func (c *MemoryCache) String() string {
-	sizeKb := c.SizeBytes / uint64(KB)
-	typeStr := ""
-	if c.Type == INSTRUCTION {
-		typeStr = "i"
-	} else if c.Type == DATA {
-		typeStr = "d"
-	}
-	cacheIdStr := fmt.Sprintf("L%d%s", c.Level, typeStr)
-	processorMapStr := ""
-	if c.LogicalProcessors != nil {
-		lpStrings := make([]string, len(c.LogicalProcessors))
-		for x, lpid := range c.LogicalProcessors {
-			lpStrings[x] = strconv.Itoa(int(lpid))
-		}
-		processorMapStr = " shared with logical processors: " + strings.Join(lpStrings, ",")
-	}
-	return fmt.Sprintf(
-		"%s cache (%d KB)%s",
-		cacheIdStr,
-		sizeKb,
-		processorMapStr,
-	)
-}
-
 type TopologyInfo struct {
 	Architecture Architecture
 	Nodes        []*Node
@@ -98,7 +41,7 @@ func Topology() (*TopologyInfo, error) {
 	info := &TopologyInfo{}
 	err := topologyFillInfo(info)
 	for _, node := range info.Nodes {
-		sort.Sort(ByCacheLevel(node.Caches))
+		sort.Sort(SortByMemoryCacheLevel(node.Caches))
 	}
 	if err != nil {
 		return nil, err

--- a/topology.go
+++ b/topology.go
@@ -18,13 +18,20 @@ const (
 	NUMA
 )
 
-type Node struct {
+// A TopologyNode is an abstract construct representing a collection of
+// processors and various levels of memory cache that those processors share.
+// In a NUMA architecture, there are multiple NUMA nodes, abstracted here as
+// multiple TopologyNode structs. In an SMP architecture, a single TopologyNode
+// will be available in the TopologyInfo struct and this single struct can be
+// used to describe the levels of memory caching available to the single
+// physical processor package's physical processor cores
+type TopologyNode struct {
 	Id     uint32
 	Cores  []*ProcessorCore
 	Caches []*MemoryCache
 }
 
-func (n *Node) String() string {
+func (n *TopologyNode) String() string {
 	return fmt.Sprintf(
 		"node #%d (%d cores)",
 		n.Id,
@@ -34,7 +41,7 @@ func (n *Node) String() string {
 
 type TopologyInfo struct {
 	Architecture Architecture
-	Nodes        []*Node
+	Nodes        []*TopologyNode
 }
 
 func Topology() (*TopologyInfo, error) {

--- a/topology.go
+++ b/topology.go
@@ -48,7 +48,7 @@ func Topology() (*TopologyInfo, error) {
 	info := &TopologyInfo{}
 	err := topologyFillInfo(info)
 	for _, node := range info.Nodes {
-		sort.Sort(SortByMemoryCacheLevel(node.Caches))
+		sort.Sort(SortByMemoryCacheLevelTypeFirstProcessor(node.Caches))
 	}
 	if err != nil {
 		return nil, err

--- a/topology.go
+++ b/topology.go
@@ -20,10 +20,8 @@ const (
 	NUMA
 )
 
-type NodeId uint32
-
 type Node struct {
-	Id     NodeId
+	Id     uint32
 	Cores  []*ProcessorCore
 	Caches []*MemoryCache
 }

--- a/topology_linux.go
+++ b/topology_linux.go
@@ -8,9 +8,7 @@
 package ghw
 
 import (
-	"fmt"
 	"io/ioutil"
-	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -64,75 +62,4 @@ func Nodes() ([]*Node, error) {
 		nodes = append(nodes, node)
 	}
 	return nodes, nil
-}
-
-func coresForNode(nodeId uint32) ([]*ProcessorCore, error) {
-	// The /sys/devices/system/node/nodeX directory contains a subdirectory
-	// called 'cpuX' for each logical processor assigned to the node. Each of
-	// those subdirectories contains a topology subdirectory which has a
-	// core_id file that indicates the 0-based identifier of the physical core
-	// the logical processor (hardware thread) is on.
-	path := filepath.Join(
-		PATH_DEVICES_SYSTEM_NODE,
-		fmt.Sprintf("node%d", nodeId),
-	)
-	cores := make([]*ProcessorCore, 0)
-
-	findCoreById := func(cid ProcessorId) *ProcessorCore {
-		for _, c := range cores {
-			if c.Id == cid {
-				return c
-			}
-		}
-
-		c := &ProcessorCore{
-			Id:                cid,
-			Index:             len(cores),
-			LogicalProcessors: make([]ProcessorId, 0),
-		}
-		cores = append(cores, c)
-		return c
-	}
-
-	files, err := ioutil.ReadDir(path)
-	if err != nil {
-		return nil, err
-	}
-	for _, file := range files {
-		filename := file.Name()
-		if !strings.HasPrefix(filename, "cpu") {
-			continue
-		}
-		if filename == "cpumap" || filename == "cpulist" {
-			// There are two files in the node directory that start with 'cpu'
-			// but are not subdirectories ('cpulist' and 'cpumap'). Ignore
-			// these files.
-			continue
-		}
-		// Grab the logical processor ID by cutting the integer from the
-		// /sys/devices/system/node/nodeX/cpuX filename
-		cpuPath := filepath.Join(path, filename)
-		lpId, _ := strconv.Atoi(filename[3:])
-		coreIdPath := filepath.Join(cpuPath, "topology", "core_id")
-		coreIdContents, err := ioutil.ReadFile(coreIdPath)
-		if err != nil {
-			continue
-		}
-		// coreIdContents is a []byte with the last byte being a newline rune
-		coreIdStr := string(coreIdContents[:len(coreIdContents)-1])
-		coreIdInt, _ := strconv.Atoi(coreIdStr)
-		coreId := ProcessorId(coreIdInt)
-
-		core := findCoreById(coreId)
-		core.LogicalProcessors = append(
-			core.LogicalProcessors,
-			ProcessorId(lpId),
-		)
-	}
-
-	for _, c := range cores {
-		c.NumThreads = uint32(len(c.LogicalProcessors))
-	}
-
-	return cores, nil
 }

--- a/topology_linux.go
+++ b/topology_linux.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	PathSysDevicesSystemNode = "/sys/devices/system/node/"
+	PATH_DEVICES_SYSTEM_NODE = "/sys/devices/system/node/"
 )
 
 func topologyFillInfo(info *TopologyInfo) error {
@@ -36,7 +36,7 @@ func topologyFillInfo(info *TopologyInfo) error {
 func Nodes() ([]*Node, error) {
 	nodes := make([]*Node, 0)
 
-	files, err := ioutil.ReadDir(PathSysDevicesSystemNode)
+	files, err := ioutil.ReadDir(PATH_DEVICES_SYSTEM_NODE)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func coresForNode(nodeId uint32) ([]*ProcessorCore, error) {
 	// core_id file that indicates the 0-based identifier of the physical core
 	// the logical processor (hardware thread) is on.
 	path := filepath.Join(
-		PathSysDevicesSystemNode,
+		PATH_DEVICES_SYSTEM_NODE,
 		fmt.Sprintf("node%d", nodeId),
 	)
 	cores := make([]*ProcessorCore, 0)
@@ -135,128 +135,4 @@ func coresForNode(nodeId uint32) ([]*ProcessorCore, error) {
 	}
 
 	return cores, nil
-}
-
-func cachesForNode(nodeId uint32) ([]*MemoryCache, error) {
-	// The /sys/devices/node/nodeX directory contains a subdirectory called
-	// 'cpuX' for each logical processor assigned to the node. Each of those
-	// subdirectories containers a 'cache' subdirectory which contains a number
-	// of subdirectories beginning with 'index' and ending in the cache's
-	// internal 0-based identifier. Those subdirectories contain a number of
-	// files, including 'shared_cpu_list', 'size', and 'type' which we use to
-	// determine cache characteristics.
-	path := filepath.Join(
-		PathSysDevicesSystemNode,
-		fmt.Sprintf("node%d", nodeId),
-	)
-	caches := make(map[string]*MemoryCache, 0)
-
-	files, err := ioutil.ReadDir(path)
-	if err != nil {
-		return nil, err
-	}
-	for _, file := range files {
-		filename := file.Name()
-		if !strings.HasPrefix(filename, "cpu") {
-			continue
-		}
-		if filename == "cpumap" || filename == "cpulist" {
-			// There are two files in the node directory that start with 'cpu'
-			// but are not subdirectories ('cpulist' and 'cpumap'). Ignore
-			// these files.
-			continue
-		}
-		// Grab the logical processor ID by cutting the integer from the
-		// /sys/devices/system/node/nodeX/cpuX filename
-		cpuPath := filepath.Join(path, filename)
-		lpId, _ := strconv.Atoi(filename[3:])
-
-		// Inspect the caches for each logical processor. There will be a
-		// /sys/devices/system/node/nodeX/cpuX/cache directory containing a
-		// number of directories beginning with the prefix "index" followed by
-		// a number. The number indicates the level of the cache, which
-		// indicates the "distance" from the processor. Each of these
-		// directories contains information about the size of that level of
-		// cache and the processors mapped to it.
-		cachePath := filepath.Join(cpuPath, "cache")
-		cacheDirFiles, err := ioutil.ReadDir(cachePath)
-		if err != nil {
-			return nil, err
-		}
-		for _, cacheDirFile := range cacheDirFiles {
-			cacheDirFileName := cacheDirFile.Name()
-			if !strings.HasPrefix(cacheDirFileName, "index") {
-				continue
-			}
-
-			typePath := filepath.Join(cachePath, cacheDirFileName, "type")
-			cacheTypeContents, err := ioutil.ReadFile(typePath)
-			if err != nil {
-				continue
-			}
-			cacheType := UNIFIED
-			switch string(cacheTypeContents[:len(cacheTypeContents)-1]) {
-			case "Data":
-				cacheType = DATA
-			case "Instruction":
-				cacheType = INSTRUCTION
-			default:
-				cacheType = UNIFIED
-			}
-
-			levelPath := filepath.Join(cachePath, cacheDirFileName, "level")
-			levelContents, err := ioutil.ReadFile(levelPath)
-			if err != nil {
-				continue
-			}
-			// levelContents is now a []byte with the last byte being a newline
-			// character. Trim that off and convert the contents to an integer.
-			level, _ := strconv.Atoi(string(levelContents[:len(levelContents)-1]))
-
-			sizePath := filepath.Join(cachePath, cacheDirFileName, "size")
-			sizeContents, err := ioutil.ReadFile(sizePath)
-			if err != nil {
-				continue
-			}
-			// size comes as XK\n, so we trim off the K and the newline.
-			size, _ := strconv.Atoi(string(sizeContents[:len(sizeContents)-2]))
-
-			scpuPath := filepath.Join(
-				cachePath,
-				cacheDirFileName,
-				"shared_cpu_map",
-			)
-			sharedCpuMap, err := ioutil.ReadFile(scpuPath)
-			if err != nil {
-				continue
-			}
-			// The cache information is repeated for each node, so here, we
-			// just ensure that we only have a one MemoryCache object for each
-			// unique combination of level, type and processor map
-			cacheKey := fmt.Sprintf("%d-%d-%s", level, cacheType, sharedCpuMap[:len(sharedCpuMap)-1])
-			if cache, ok := caches[cacheKey]; !ok {
-				cache = &MemoryCache{
-					Level:             uint8(level),
-					Type:              cacheType,
-					SizeBytes:         uint64(size) * uint64(KB),
-					LogicalProcessors: make([]ProcessorId, 0),
-				}
-				caches[cacheKey] = cache
-			}
-			cache := caches[cacheKey]
-			cache.LogicalProcessors = append(
-				cache.LogicalProcessors,
-				ProcessorId(lpId),
-			)
-		}
-	}
-
-	cacheVals := make([]*MemoryCache, len(caches))
-	x := 0
-	for _, c := range caches {
-		cacheVals[x] = c
-		x++
-	}
-
-	return cacheVals, nil
 }

--- a/topology_linux.go
+++ b/topology_linux.go
@@ -50,7 +50,7 @@ func Nodes() ([]*Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		node.Id = NodeId(nodeId)
+		node.Id = uint32(nodeId)
 		cores, err := coresForNode(node.Id)
 		if err != nil {
 			return nil, err
@@ -66,7 +66,7 @@ func Nodes() ([]*Node, error) {
 	return nodes, nil
 }
 
-func coresForNode(nodeId NodeId) ([]*ProcessorCore, error) {
+func coresForNode(nodeId uint32) ([]*ProcessorCore, error) {
 	// The /sys/devices/system/node/nodeX directory contains a subdirectory
 	// called 'cpuX' for each logical processor assigned to the node. Each of
 	// those subdirectories contains a topology subdirectory which has a
@@ -137,7 +137,7 @@ func coresForNode(nodeId NodeId) ([]*ProcessorCore, error) {
 	return cores, nil
 }
 
-func cachesForNode(nodeId NodeId) ([]*MemoryCache, error) {
+func cachesForNode(nodeId uint32) ([]*MemoryCache, error) {
 	// The /sys/devices/node/nodeX directory contains a subdirectory called
 	// 'cpuX' for each logical processor assigned to the node. Each of those
 	// subdirectories containers a 'cache' subdirectory which contains a number

--- a/topology_linux.go
+++ b/topology_linux.go
@@ -18,7 +18,7 @@ const (
 )
 
 func topologyFillInfo(info *TopologyInfo) error {
-	nodes, err := Nodes()
+	nodes, err := TopologyNodes()
 	if err != nil {
 		return err
 	}
@@ -31,8 +31,8 @@ func topologyFillInfo(info *TopologyInfo) error {
 	return nil
 }
 
-func Nodes() ([]*Node, error) {
-	nodes := make([]*Node, 0)
+func TopologyNodes() ([]*TopologyNode, error) {
+	nodes := make([]*TopologyNode, 0)
 
 	files, err := ioutil.ReadDir(PATH_DEVICES_SYSTEM_NODE)
 	if err != nil {
@@ -43,7 +43,7 @@ func Nodes() ([]*Node, error) {
 		if !strings.HasPrefix(filename, "node") {
 			continue
 		}
-		node := &Node{}
+		node := &TopologyNode{}
 		nodeId, err := strconv.Atoi(filename[4:])
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
* Removes unnecessary typedefs for uint32 on node and processor
* Renames Node -> TopologyNode (Fix Issue #33)
* Makes memory cache sorting deterministic by breaking ties by looking at the cache's first logical processor (Fix Issue #35)