### PR TITLE
Removed build tags

### DIFF
--- a/block_linux.go
+++ b/block_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-//
 // Use and distribution licensed under the Apache license version 2.
 //
 // See the COPYING file in the root project directory for full text.

--- a/cpu_linux.go
+++ b/cpu_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-//
 // Use and distribution licensed under the Apache license version 2.
 //
 // See the COPYING file in the root project directory for full text.

--- a/gpu_linux.go
+++ b/gpu_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-//
 // Use and distribution licensed under the Apache license version 2.
 //
 // See the COPYING file in the root project directory for full text.

--- a/memory_cache_linux.go
+++ b/memory_cache_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-//
 // Use and distribution licensed under the Apache license version 2.
 //
 // See the COPYING file in the root project directory for full text.

--- a/memory_linux.go
+++ b/memory_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-//
 // Use and distribution licensed under the Apache license version 2.
 //
 // See the COPYING file in the root project directory for full text.

--- a/net_linux.go
+++ b/net_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-//
 // Use and distribution licensed under the Apache license version 2.
 //
 // See the COPYING file in the root project directory for full text.

--- a/pci_linux.go
+++ b/pci_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-//
 // Use and distribution licensed under the Apache license version 2.
 //
 // See the COPYING file in the root project directory for full text.

--- a/topology_linux.go
+++ b/topology_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-//
 // Use and distribution licensed under the Apache license version 2.
 //
 // See the COPYING file in the root project directory for full text.


### PR DESCRIPTION
> Build tags and file suffixes overlap in fuctionality. For example, a
  file called mypkg_linux.go that contained the build tag // +build linux
  is redundant.

> In general, when choosing between a build tag or a file suffix, you
  should choose a file suffix when there is an exact match between the
  platform or architecture and the file you want to include.

  [1] https://dave.cheney.net/2013/10/12/how-to-use-conditional-compilation-with-the-go-build-tool