### PR TITLE
Handle newline, tab and space in mtab entry

### DIFF
--- a/block_linux.go
+++ b/block_linux.go
@@ -281,9 +281,24 @@ func parseMtabEntry(line string) *mtabEntry {
 		return nil
 	}
 	fields := strings.Fields(line)
+
+	// We do some special parsing of the mountpoint, which may contain space,
+	// tab and newline characters, encoded into the mtab entry line using their
+	// octal-to-string representations. From the GNU mtab man pages:
+	//
+	//   "Therefore these characters are encoded in the files and the getmntent
+	//   function takes care of the decoding while reading the entries back in.
+	//   '\040' is used to encode a space character, '\011' to encode a tab
+	//   character, '\012' to encode a newline character, and '\\' to encode a
+	//   backslash."
+	mp := fields[1]
+	mp = strings.Replace(mp, "\\011", "\t", -1)
+	mp = strings.Replace(mp, "\\012", "\n", -1)
+	mp = strings.Replace(mp, "\\040", " ", -1)
+
 	res := &mtabEntry{
 		Partition:      fields[0],
-		Mountpoint:     fields[1],
+		Mountpoint:     mp,
 		FilesystemType: fields[2],
 	}
 	opts := strings.Split(fields[3], ",")

--- a/block_linux_test.go
+++ b/block_linux_test.go
@@ -1,0 +1,59 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+// +build linux
+
+package ghw
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestParseMtabEntry(t *testing.T) {
+	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_BLOCK"); ok {
+		t.Skip("Skipping block tests.")
+	}
+
+	tests := []struct {
+		line     string
+		expected *mtabEntry
+	}{
+		{
+			line: "/dev/sda6 / ext4 rw,relatime,errors=remount-ro,data=ordered 0 0",
+			expected: &mtabEntry{
+				Partition:      "/dev/sda6",
+				Mountpoint:     "/",
+				FilesystemType: "ext4",
+				Options: []string{
+					"rw",
+					"relatime",
+					"errors=remount-ro",
+					"data=ordered",
+				},
+			},
+		},
+		{
+			line: "/dev/sda8 /home/Name\040with\040spaces ext4 ro 0 0",
+			expected: &mtabEntry{
+				Partition:      "/dev/sda6",
+				Mountpoint:     "/Name with spaces",
+				FilesystemType: "ext4",
+				Options: []string{
+					"ro",
+				},
+			},
+		},
+	}
+
+	for x, test := range tests {
+		actual := parseMtabEntry(test.line)
+		if !reflect.DeepEqual(test.expected, actual) {
+			t.Fatalf("In test %d, expected %v == %v", x, test.expected, actual)
+		}
+	}
+}

--- a/block_linux_test.go
+++ b/block_linux_test.go
@@ -38,10 +38,23 @@ func TestParseMtabEntry(t *testing.T) {
 			},
 		},
 		{
-			line: "/dev/sda8 /home/Name\040with\040spaces ext4 ro 0 0",
+			line: "/dev/sda8 /home/Name\\040with\\040spaces ext4 ro 0 0",
 			expected: &mtabEntry{
-				Partition:      "/dev/sda6",
-				Mountpoint:     "/Name with spaces",
+				Partition:      "/dev/sda8",
+				Mountpoint:     "/home/Name with spaces",
+				FilesystemType: "ext4",
+				Options: []string{
+					"ro",
+				},
+			},
+		},
+		{
+			// Whoever might do this in real life should be quarantined and
+			// placed in administrative segregation
+			line: "/dev/sda8 /home/Name\\011with\\012tab&newline ext4 ro 0 0",
+			expected: &mtabEntry{
+				Partition:      "/dev/sda8",
+				Mountpoint:     "/home/Name\twith\ntab&newline",
 				FilesystemType: "ext4",
 				Options: []string{
 					"ro",


### PR DESCRIPTION
Adds specialized parsing for mountpoints in mtab entries that contain
spaces, tabs and newlines. These characters will be encoded as their
octal-to-string representations by the glibc, and we need to decode
these values accordingly.

Issue #45 