### PR TITLE
Allow overriding root path/bindmount

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ information about the host computer:
 * [PCI](#pci)
 * [GPU](#gpu)
 
+**NOTE**: The default root mountpoint that `ghw` uses when looking for
+information about the host system is `/`. So, for example, when looking up CPU
+information on Linux, `ghw` will attempt to parse the `/proc/cpuinfo` file. If
+you are calling `ghw` from a system that has an alternate root mountpoint, you
+can set the `GHW_CHROOT` environment variable to that alternate path. for
+example, if you are executing from within an application container that has
+bind-mounted the root host filesystem to the mount point `/host`, you would set
+`GHW_CHROOT` to `/host` so that `ghw` can find files like `/proc/cpuinfo` at
+`/host/proc/cpuinfo`.
+
 ### Memory
 
 Information about the host computer's memory can be retrieved using the

--- a/cpu_linux.go
+++ b/cpu_linux.go
@@ -15,10 +15,6 @@ import (
 	"strings"
 )
 
-const (
-	PathProcCpuinfo = "/proc/cpuinfo"
-)
-
 func cpuFillInfo(info *CPUInfo) error {
 	info.Processors = Processors()
 	var totCores uint32
@@ -35,7 +31,7 @@ func cpuFillInfo(info *CPUInfo) error {
 func Processors() []*Processor {
 	procs := make([]*Processor, 0)
 
-	r, err := os.Open(PathProcCpuinfo)
+	r, err := os.Open(pathProcCpuinfo())
 	if err != nil {
 		return nil
 	}
@@ -153,7 +149,7 @@ func coresForNode(nodeId uint32) ([]*ProcessorCore, error) {
 	// core_id file that indicates the 0-based identifier of the physical core
 	// the logical processor (hardware thread) is on.
 	path := filepath.Join(
-		PATH_DEVICES_SYSTEM_NODE,
+		pathSysDevicesSystemNode(),
 		fmt.Sprintf("node%d", nodeId),
 	)
 	cores := make([]*ProcessorCore, 0)

--- a/memory_cache_linux.go
+++ b/memory_cache_linux.go
@@ -23,7 +23,7 @@ func cachesForNode(nodeId uint32) ([]*MemoryCache, error) {
 	// files, including 'shared_cpu_list', 'size', and 'type' which we use to
 	// determine cache characteristics.
 	path := filepath.Join(
-		PATH_DEVICES_SYSTEM_NODE,
+		pathSysDevicesSystemNode(),
 		fmt.Sprintf("node%d", nodeId),
 	)
 	caches := make(map[string]*MemoryCache, 0)

--- a/path_linux.go
+++ b/path_linux.go
@@ -1,0 +1,50 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ghw
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const (
+	DEFAULT_ROOT_PATH = "/"
+)
+
+// To facilitate querying of sysfs filesystems that are bind-mounted to a
+// non-default root mountpoint, we allow users to set the GHW_CHROOT environ
+// vairable to an alternate mountpoint. For instance, assume that the user of
+// ghw is a Golang binary being executed from an application container that has
+// certain host filesystems bind-mounted into the container at /host. The user
+// would ensure the GHW_CHROOT environ variable is set to "/host" and ghw will
+// build its paths from that location instead of /
+func pathRoot() string {
+	path := DEFAULT_ROOT_PATH
+	if override, exists := os.LookupEnv("GHW_CHROOT"); exists {
+		path = override
+	}
+	return path
+}
+
+func pathProcCpuinfo() string {
+	return filepath.Join(pathRoot(), "proc", "cpuinfo")
+}
+
+func pathEtcMtab() string {
+	return filepath.Join(pathRoot(), "etc", "mtab")
+}
+
+func pathSysBlock() string {
+	return filepath.Join(pathRoot(), "sys", "block")
+}
+
+func pathSysDevicesSystemNode() string {
+	return filepath.Join(pathRoot(), "sys", "devices", "system", "node")
+}
+
+func pathDevDiskById() string {
+	return filepath.Join(pathRoot(), "dev", "disk", "by-id")
+}

--- a/path_linux_test.go
+++ b/path_linux_test.go
@@ -1,0 +1,39 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+// +build linux
+
+package ghw
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPathRoot(t *testing.T) {
+	orig, origExists := os.LookupEnv("GHW_CHROOT")
+	if origExists {
+		// For tests, save the original, test an override and then at the end
+		// of the test, reset to the original
+		defer os.Setenv("GHW_CHROOT", orig)
+		os.Unsetenv("GHW_CHROOT")
+	}
+
+	// No environment variable is set for GHW_CHROOT, so pathRoot() should
+	// return the default "/"
+	path := pathRoot()
+	if path != DEFAULT_ROOT_PATH {
+		t.Fatalf("Expected pathRoot() to return '/' but got %s", path)
+	}
+
+	// Now set the GHW_CHROOT environ variable and verify that pathRoot()
+	// returns that value
+	os.Setenv("GHW_CHROOT", "/host")
+	path = pathRoot()
+	if path != "/host" {
+		t.Fatalf("Expected pathRoot() to return '/host' but got %s", path)
+	}
+}

--- a/path_linux_test.go
+++ b/path_linux_test.go
@@ -20,6 +20,8 @@ func TestPathRoot(t *testing.T) {
 		// of the test, reset to the original
 		defer os.Setenv("GHW_CHROOT", orig)
 		os.Unsetenv("GHW_CHROOT")
+	} else {
+		defer os.Unsetenv("GHW_CHROOT")
 	}
 
 	// No environment variable is set for GHW_CHROOT, so pathRoot() should

--- a/topology_linux.go
+++ b/topology_linux.go
@@ -11,10 +11,6 @@ import (
 	"strings"
 )
 
-const (
-	PATH_DEVICES_SYSTEM_NODE = "/sys/devices/system/node/"
-)
-
 func topologyFillInfo(info *TopologyInfo) error {
 	nodes, err := TopologyNodes()
 	if err != nil {
@@ -32,7 +28,7 @@ func topologyFillInfo(info *TopologyInfo) error {
 func TopologyNodes() ([]*TopologyNode, error) {
 	nodes := make([]*TopologyNode, 0)
 
-	files, err := ioutil.ReadDir(PATH_DEVICES_SYSTEM_NODE)
+	files, err := ioutil.ReadDir(pathSysDevicesSystemNode())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If a host filesystem has been bind-mounted to a particular directory
within an application container (say, '/host'), we want to inform `ghw`
to use that bind-mount as its root directory when constructing paths to
certain files like /proc/cpuinfo or /etc/mtab.

This patch adds the ability for the user to set the GHW_CHROOT environ
variable to the value of this alternate root mountpoint, allowing `ghw`
to find important files from within an application container that has
bind-mounted a host filesystem.

Issue #56