### PR TITLE
Correct improper Linux block device size calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ Each `ghw.Disk` struct contains the following fields:
 
 * `ghw.Disk.Name` contains a string with the short name of the disk, e.g. "sda"
 * `ghw.Disk.SizeBytes` contains the amount of storage the disk provides
-* `ghw.Disk.SectorSizeBytes` contains the size of the sector used on the disk,
-  in bytes
+* `ghw.Disk.PhysicalBlockSizeBytes` contains the size of the physical blocks
+  used on the disk, in bytes
 * `ghw.Disk.BusType` will be either "scsi" or "ide"
 * `ghw.Disk.Vendor` contains a string with the name of the hardware vendor for
   the disk drive

--- a/block.go
+++ b/block.go
@@ -12,13 +12,13 @@ import (
 )
 
 type Disk struct {
-	Name            string
-	SizeBytes       uint64
-	SectorSizeBytes uint64
-	BusType         string
-	Vendor          string
-	SerialNumber    string
-	Partitions      []*Partition
+	Name                   string
+	SizeBytes              uint64
+	PhysicalBlockSizeBytes uint64
+	BusType                string
+	Vendor                 string
+	SerialNumber           string
+	Partitions             []*Partition
 }
 
 type Partition struct {

--- a/block_test.go
+++ b/block_test.go
@@ -44,8 +44,8 @@ func TestBlock(t *testing.T) {
 	if d0.Partitions == nil {
 		t.Fatalf("Expected non-nil partitions, but got nil.")
 	}
-	if d0.SectorSizeBytes <= 0 {
-		t.Fatalf("Expected >0 sector size, but got %d", d0.SectorSizeBytes)
+	if d0.PhysicalBlockSizeBytes <= 0 {
+		t.Fatalf("Expected >0 sector size, but got %d", d0.PhysicalBlockSizeBytes)
 	}
 
 	if len(d0.Partitions) > 0 {


### PR DESCRIPTION
Linux hard-codes the block device sector size to 512, and when
determining the total size of a disk, we multiply this 512 hard-coded
number by the value in /sys/block/$device/size.

We were erroneously calculating the block device's size by multiplying
the physical block size returned from
/sys/block/$device/queue/physical_block_size with the value in
/sys/block/$device/size.

Issue #57