### PR TITLE
Collect more disk information

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,14 @@ Each `ghw.Disk` struct contains the following fields:
 * `ghw.Disk.PhysicalBlockSizeBytes` contains the size of the physical blocks
   used on the disk, in bytes
 * `ghw.Disk.BusType` will be either "scsi" or "ide"
+* `ghw.Disk.NumaNodeId` is the numeric index of the NUMA node this disk is
+  local to, or -1
 * `ghw.Disk.Vendor` contains a string with the name of the hardware vendor for
   the disk drive
+* `ghw.Disk.Model` contains a string with the vendor-assigned disk model name
 * `ghw.Disk.SerialNumber` contains a string with the disk's serial number
+* `ghw.Disk.WorldWideName` contains a string with the disk's
+  [World Wide Name](https://en.wikipedia.org/wiki/World_Wide_Name)
 * `ghw.Disk.Partitions` contains an array of pointers to `ghw.Partition`
   structs, one for each partition on the disk
 

--- a/README.md
+++ b/README.md
@@ -216,13 +216,13 @@ Each `ghw.Disk` struct contains the following fields:
 * `ghw.Disk.PhysicalBlockSizeBytes` contains the size of the physical blocks
   used on the disk, in bytes
 * `ghw.Disk.BusType` will be either "scsi" or "ide"
-* `ghw.Disk.NumaNodeId` is the numeric index of the NUMA node this disk is
+* `ghw.Disk.NUMANodeID` is the numeric index of the NUMA node this disk is
   local to, or -1
 * `ghw.Disk.Vendor` contains a string with the name of the hardware vendor for
   the disk drive
 * `ghw.Disk.Model` contains a string with the vendor-assigned disk model name
 * `ghw.Disk.SerialNumber` contains a string with the disk's serial number
-* `ghw.Disk.WorldWideName` contains a string with the disk's
+* `ghw.Disk.WWN` contains a string with the disk's
   [World Wide Name](https://en.wikipedia.org/wiki/World_Wide_Name)
 * `ghw.Disk.Partitions` contains an array of pointers to `ghw.Partition`
   structs, one for each partition on the disk

--- a/block.go
+++ b/block.go
@@ -16,6 +16,7 @@ type Disk struct {
 	SizeBytes              uint64
 	PhysicalBlockSizeBytes uint64
 	BusType                string
+	BusPath                string
 	Vendor                 string
 	SerialNumber           string
 	Partitions             []*Partition
@@ -79,10 +80,11 @@ func (d *Disk) String() string {
 		sizeStr = fmt.Sprintf("%d%s", size, unitStr)
 	}
 	return fmt.Sprintf(
-		"/dev/%s (%s) [%s]%s%s",
+		"/dev/%s (%s) [%s @ %s]%s%s",
 		d.Name,
 		sizeStr,
 		d.BusType,
+		d.BusPath,
 		vendor,
 		serial,
 	)

--- a/block.go
+++ b/block.go
@@ -20,6 +20,7 @@ type Disk struct {
 	Vendor                 string
 	SerialNumber           string
 	Partitions             []*Partition
+	NumaNodeId             int
 }
 
 type Partition struct {
@@ -79,12 +80,17 @@ func (d *Disk) String() string {
 		size = uint64(math.Ceil(float64(size) / float64(unit)))
 		sizeStr = fmt.Sprintf("%d%s", size, unitStr)
 	}
+	atNode := ""
+	if d.NumaNodeId >= 0 {
+		atNode = fmt.Sprintf(" (node #%d)", d.NumaNodeId)
+	}
 	return fmt.Sprintf(
-		"/dev/%s (%s) [%s @ %s]%s%s",
+		"/dev/%s (%s) [%s @ %s%s]%s%s",
 		d.Name,
 		sizeStr,
 		d.BusType,
 		d.BusPath,
+		atNode,
 		vendor,
 		serial,
 	)

--- a/block.go
+++ b/block.go
@@ -17,10 +17,12 @@ type Disk struct {
 	PhysicalBlockSizeBytes uint64
 	BusType                string
 	BusPath                string
-	Vendor                 string
-	SerialNumber           string
-	Partitions             []*Partition
 	NumaNodeId             int
+	Vendor                 string
+	Model                  string
+	SerialNumber           string
+	WorldWideName          string
+	Partitions             []*Partition
 }
 
 type Partition struct {
@@ -65,14 +67,6 @@ func (i *BlockInfo) String() string {
 }
 
 func (d *Disk) String() string {
-	vendor := ""
-	if d.Vendor != "" {
-		vendor = "  " + d.Vendor
-	}
-	serial := ""
-	if d.SerialNumber != "" {
-		serial = " - SN #" + d.SerialNumber
-	}
 	sizeStr := UNKNOWN
 	if d.SizeBytes > 0 {
 		size := d.SizeBytes
@@ -84,15 +78,33 @@ func (d *Disk) String() string {
 	if d.NumaNodeId >= 0 {
 		atNode = fmt.Sprintf(" (node #%d)", d.NumaNodeId)
 	}
+	vendor := ""
+	if d.Vendor != "" {
+		vendor = " vendor=" + d.Vendor
+	}
+	model := ""
+	if d.Model != UNKNOWN {
+		model = " model=" + d.Model
+	}
+	serial := ""
+	if d.SerialNumber != UNKNOWN {
+		serial = " serial=" + d.SerialNumber
+	}
+	wwn := ""
+	if d.WorldWideName != UNKNOWN {
+		wwn = " WWN=" + d.WorldWideName
+	}
 	return fmt.Sprintf(
-		"/dev/%s (%s) [%s @ %s%s]%s%s",
+		"/dev/%s (%s) [%s @ %s%s]%s%s%s%s",
 		d.Name,
 		sizeStr,
 		d.BusType,
 		d.BusPath,
 		atNode,
 		vendor,
+		model,
 		serial,
+		wwn,
 	)
 }
 

--- a/block.go
+++ b/block.go
@@ -17,11 +17,11 @@ type Disk struct {
 	PhysicalBlockSizeBytes uint64
 	BusType                string
 	BusPath                string
-	NumaNodeId             int
+	NUMANodeID             int
 	Vendor                 string
 	Model                  string
 	SerialNumber           string
-	WorldWideName          string
+	WWN                    string
 	Partitions             []*Partition
 }
 
@@ -75,8 +75,8 @@ func (d *Disk) String() string {
 		sizeStr = fmt.Sprintf("%d%s", size, unitStr)
 	}
 	atNode := ""
-	if d.NumaNodeId >= 0 {
-		atNode = fmt.Sprintf(" (node #%d)", d.NumaNodeId)
+	if d.NUMANodeID >= 0 {
+		atNode = fmt.Sprintf(" (node #%d)", d.NUMANodeID)
 	}
 	vendor := ""
 	if d.Vendor != "" {
@@ -91,8 +91,8 @@ func (d *Disk) String() string {
 		serial = " serial=" + d.SerialNumber
 	}
 	wwn := ""
-	if d.WorldWideName != UNKNOWN {
-		wwn = " WWN=" + d.WorldWideName
+	if d.WWN != UNKNOWN {
+		wwn = " WWN=" + d.WWN
 	}
 	return fmt.Sprintf(
 		"/dev/%s (%s) [%s @ %s%s]%s%s%s%s",

--- a/block_linux.go
+++ b/block_linux.go
@@ -113,6 +113,20 @@ func DiskSerialNumber(disk string) string {
 	return UNKNOWN
 }
 
+func DiskBusPath(disk string) string {
+	info, err := udevInfo(disk)
+	if err != nil {
+		return UNKNOWN
+	}
+
+	// There are two path keys, ID_PATH and ID_PATH_TAG.
+	// The difference seems to be _TAG has funky characters converted to underscores.
+	if path, ok := info["ID_PATH"]; ok {
+		return path
+	}
+	return UNKNOWN
+}
+
 func DiskPartitions(disk string) []*Partition {
 	out := make([]*Partition, 0)
 	path := filepath.Join(pathSysBlock(), disk)
@@ -166,6 +180,7 @@ func Disks() []*Disk {
 
 		size := DiskSizeBytes(dname)
 		pbs := DiskPhysicalBlockSizeBytes(dname)
+		busPath := DiskBusPath(dname)
 		vendor := DiskVendor(dname)
 		serialNo := DiskSerialNumber(dname)
 
@@ -174,6 +189,7 @@ func Disks() []*Disk {
 			SizeBytes:              size,
 			PhysicalBlockSizeBytes: pbs,
 			BusType:                busType,
+			BusPath:                busPath,
 			Vendor:                 vendor,
 			SerialNumber:           serialNo,
 		}

--- a/block_linux.go
+++ b/block_linux.go
@@ -63,7 +63,7 @@ func DiskSizeBytes(disk string) uint64 {
 	return uint64(i) * LINUX_SECTOR_SIZE
 }
 
-func DiskNumaNodeId(disk string) int {
+func DiskNUMANodeID(disk string) int {
 	link, err := os.Readlink(filepath.Join(pathSysBlock(), disk))
 	if err != nil {
 		return -1
@@ -154,7 +154,7 @@ func DiskBusPath(disk string) string {
 	return UNKNOWN
 }
 
-func DiskWorldWideName(disk string) string {
+func DiskWWN(disk string) string {
 	info, err := udevInfo(disk)
 	if err != nil {
 		return UNKNOWN
@@ -224,11 +224,11 @@ func Disks() []*Disk {
 		size := DiskSizeBytes(dname)
 		pbs := DiskPhysicalBlockSizeBytes(dname)
 		busPath := DiskBusPath(dname)
-		node := DiskNumaNodeId(dname)
+		node := DiskNUMANodeID(dname)
 		vendor := DiskVendor(dname)
 		model := DiskModel(dname)
 		serialNo := DiskSerialNumber(dname)
-		wwn := DiskWorldWideName(dname)
+		wwn := DiskWWN(dname)
 
 		d := &Disk{
 			Name:                   dname,
@@ -236,11 +236,11 @@ func Disks() []*Disk {
 			PhysicalBlockSizeBytes: pbs,
 			BusType:                busType,
 			BusPath:                busPath,
-			NumaNodeId:             node,
+			NUMANodeID:             node,
 			Vendor:                 vendor,
 			Model:                  model,
 			SerialNumber:           serialNo,
-			WorldWideName:          wwn,
+			WWN:                    wwn,
 		}
 
 		parts := DiskPartitions(dname)


### PR DESCRIPTION
This PR adds code to also collect:
- which NUMA node a disk is local to (useful when trying to balance IO)
- the disk's bus path (useful when trying to know where to unplug the thing from)
- the disk's model (useful in conjunction with the serial number)

Also fixes a bug where serial numbers would be listed as #unknown instead of being omitted

One downside is we re-read and re-parse the udev db (a small flat file) for each property lookup. I could cache it, but it would make the code uglier. Let me know if you'd like me to.

If you need me to break these out into separate PRs, just let me know.