### PR TITLE
Stop exporting linux-specific paths

### DIFF
--- a/block_linux.go
+++ b/block_linux.go
@@ -17,11 +17,11 @@ import (
 )
 
 const (
-	LINUX_SECTOR_SIZE = 512
+	linuxSectorSize = 512
 )
 
-var RegexNVMeDev = regexp.MustCompile(`^nvme\d+n\d+$`)
-var RegexNVMePart = regexp.MustCompile(`^(nvme\d+n\d+)p\d+$`)
+var regexNVMeDev = regexp.MustCompile(`^nvme\d+n\d+$`)
+var regexNVMePart = regexp.MustCompile(`^(nvme\d+n\d+)p\d+$`)
 
 func blockFillInfo(info *BlockInfo) error {
 	info.Disks = Disks()
@@ -60,7 +60,7 @@ func DiskSizeBytes(disk string) uint64 {
 	if err != nil {
 		return 0
 	}
-	return uint64(i) * LINUX_SECTOR_SIZE
+	return uint64(i) * linuxSectorSize
 }
 
 func DiskNUMANodeID(disk string) int {
@@ -214,7 +214,7 @@ func Disks() []*Disk {
 			busType = "SCSI"
 		} else if strings.HasPrefix(dname, "hd") {
 			busType = "IDE"
-		} else if RegexNVMeDev.MatchString(dname) {
+		} else if regexNVMeDev.MatchString(dname) {
 			busType = "NVMe"
 		}
 		if busType == "" {
@@ -263,7 +263,7 @@ func PartitionSizeBytes(part string) uint64 {
 		part = part[4:len(part)]
 	}
 	disk := part[0:3]
-	if m := RegexNVMePart.FindStringSubmatch(part); len(m) > 0 {
+	if m := regexNVMePart.FindStringSubmatch(part); len(m) > 0 {
 		disk = m[1]
 	}
 	path := filepath.Join(pathSysBlock(), disk, part, "size")
@@ -275,7 +275,7 @@ func PartitionSizeBytes(part string) uint64 {
 	if err != nil {
 		return 0
 	}
-	return uint64(i) * LINUX_SECTOR_SIZE
+	return uint64(i) * linuxSectorSize
 }
 
 // Given a full or short partition name, returns the mount point, the type of

--- a/gpu_linux.go
+++ b/gpu_linux.go
@@ -14,10 +14,6 @@ import (
 	"strings"
 )
 
-const (
-	PATH_SYSFS_CLASS_DRM = "/sys/class/drm"
-)
-
 func gpuFillInfo(info *GPUInfo) error {
 	// In Linux, each graphics card is listed under the /sys/class/drm
 	// directory as a symbolic link named "cardN", where N is a zero-based
@@ -45,7 +41,7 @@ func gpuFillInfo(info *GPUInfo) error {
 	// we follow to gather information about the actual device from the PCI
 	// subsystem (we query the modalias file of the PCI device's sysfs
 	// directory using the `ghw.PCIInfo.GetDevice()` function.
-	links, err := ioutil.ReadDir(PATH_SYSFS_CLASS_DRM)
+	links, err := ioutil.ReadDir(pathSysClassDrm())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, `************************ WARNING ***********************************
 /sys/class/drm does not exist on this system (likely the host system is a
@@ -74,7 +70,7 @@ GPUInfo.GraphicsCards will be an empty array.
 
 		// Calculate the card's PCI address by looking at the symbolic link's
 		// target
-		lpath := filepath.Join(PATH_SYSFS_CLASS_DRM, lname)
+		lpath := filepath.Join(pathSysClassDrm(), lname)
 		dest, err := os.Readlink(lpath)
 		if err != nil {
 			continue
@@ -133,7 +129,7 @@ func gpuFillNUMANodes(cards []*GraphicsCard) {
 		// affined to
 		cardIndexStr := strconv.Itoa(card.Index)
 		fpath := filepath.Join(
-			PATH_SYSFS_CLASS_DRM,
+			pathSysClassDrm(),
 			"card"+cardIndexStr,
 			"device",
 			"numa_node",

--- a/net_linux.go
+++ b/net_linux.go
@@ -12,10 +12,6 @@ import (
 	"strings"
 )
 
-const (
-	PathSysClassNet = "/sys/class/net"
-)
-
 func netFillInfo(info *NetworkInfo) error {
 	info.NICs = NICs()
 	return nil
@@ -24,7 +20,7 @@ func netFillInfo(info *NetworkInfo) error {
 func NICs() []*NIC {
 	nics := make([]*NIC, 0)
 
-	files, err := ioutil.ReadDir(PathSysClassNet)
+	files, err := ioutil.ReadDir(pathSysClassNet())
 	if err != nil {
 		return nics
 	}
@@ -36,7 +32,7 @@ func NICs() []*NIC {
 			continue
 		}
 
-		netPath := filepath.Join(PathSysClassNet, filename)
+		netPath := filepath.Join(pathSysClassNet(), filename)
 		dest, _ := os.Readlink(netPath)
 		isVirtual := false
 		if strings.Contains(dest, "virtio") {
@@ -61,7 +57,7 @@ func netDeviceMacAddress(dev string) string {
 	// the /sys/class/net/$DEVICE/address file in sysfs. However, for devices
 	// that have addr_assign_type != 0, return None since the MAC address is
 	// random.
-	aatPath := filepath.Join(PathSysClassNet, dev, "addr_assign_type")
+	aatPath := filepath.Join(pathSysClassNet(), dev, "addr_assign_type")
 	contents, err := ioutil.ReadFile(aatPath)
 	if err != nil {
 		return ""
@@ -69,7 +65,7 @@ func netDeviceMacAddress(dev string) string {
 	if strings.TrimSpace(string(contents)) != "0" {
 		return ""
 	}
-	addrPath := filepath.Join(PathSysClassNet, dev, "address")
+	addrPath := filepath.Join(pathSysClassNet(), dev, "address")
 	contents, err = ioutil.ReadFile(addrPath)
 	if err != nil {
 		return ""

--- a/path_linux.go
+++ b/path_linux.go
@@ -53,6 +53,14 @@ func pathSysBusPciDevices() string {
 	return filepath.Join(pathRoot(), "sys", "bus", "pci", "devices")
 }
 
+func pathSysClassDrm() string {
+	return filepath.Join(pathRoot(), "sys", "class", "drm")
+}
+
+func pathSysClassNet() string {
+	return filepath.Join(pathRoot(), "sys", "class", "net")
+}
+
 func pathRunUdevData() string {
 	return filepath.Join(pathRoot(), "run", "udev", "data")
 }


### PR DESCRIPTION
These make no sense on non-linux platforms and wouldn't exist in `*_otherOS.go` files, so remove them now before anybody starts accidentally using them to avoid breaking backwards compat when adding support for other OSes.