### PR TITLE
add NIC capabilities to NIC struct

### DIFF
--- a/ghwc/cmd/net.go
+++ b/ghwc/cmd/net.go
@@ -26,6 +26,19 @@ func showNetwork(cmd *cobra.Command, args []string) error {
 
 	for _, nic := range net.NICs {
 		fmt.Printf(" %v\n", nic)
+
+		enabledCaps := make([]int, 0)
+		for x, cap := range nic.Capabilities {
+			if cap.IsEnabled {
+				enabledCaps = append(enabledCaps, x)
+			}
+		}
+		if len(enabledCaps) > 0 {
+			fmt.Printf("  enabled capabilities:\n")
+			for _, x := range enabledCaps {
+				fmt.Printf("   - %s\n", nic.Capabilities[x].Name)
+			}
+		}
 	}
 	return nil
 }

--- a/net.go
+++ b/net.go
@@ -8,38 +8,29 @@ package ghw
 
 import (
 	"fmt"
-	"strings"
 )
 
+type NICCapability struct {
+	Name      string
+	IsEnabled bool
+	CanChange bool
+}
+
 type NIC struct {
-	Name            string
-	BusType         string
-	Driver          string
-	MacAddress      string
-	Model           string
-	Vendor          string
-	IsVirtual       bool
-	EnabledFeatures []string
+	Name         string
+	MacAddress   string
+	IsVirtual    bool
+	Capabilities []*NICCapability
 }
 
 func (n *NIC) String() string {
-	vendorStr := ""
-	if n.Vendor != "" {
-		vendorStr = " [" + strings.TrimSpace(n.Vendor) + "]"
-	}
-	modelStr := ""
-	if n.Model != "" {
-		modelStr = " - " + strings.TrimSpace(n.Model)
-	}
 	isVirtualStr := ""
 	if n.IsVirtual {
 		isVirtualStr = " (virtual)"
 	}
 	return fmt.Sprintf(
-		"%s%s%s%s",
+		"%s%s",
 		n.Name,
-		vendorStr,
-		modelStr,
 		isVirtualStr,
 	)
 }


### PR DESCRIPTION
Adds the ability to query for a NIC's capabilities (as reported via
`ethtool -k <DEVICE>`). The new `ghw.NICCapability` struct can be used
to determine the name of the capability/feature, whether a NIC has the
feature enabled and whether the feature can be turned on/off.

Note that this patch removes the unused and undocumented attributes from the `ghw.NIC` struct:

- Model
- Vendor
- Driver
- BusType
- EnabledFeatures

We may add one or more of the above *back* into the `ghw.NIC` struct at some point in the future if there is demand for them.

Issue #7