### PR TITLE
clean up errcheck linter output

### DIFF
--- a/block_linux.go
+++ b/block_linux.go
@@ -294,7 +294,7 @@ func PartitionInfo(part string) (string, string, bool) {
 	if err != nil {
 		return "", "", true
 	}
-	defer r.Close()
+	defer safeClose(r)
 
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {

--- a/cpu_linux.go
+++ b/cpu_linux.go
@@ -35,7 +35,7 @@ func Processors() []*Processor {
 	if err != nil {
 		return nil
 	}
-	defer r.Close()
+	defer safeClose(r)
 
 	// An array of maps of attributes describing the logical processor
 	procAttrs := make([]map[string]string, 0)

--- a/memory_cache_linux.go
+++ b/memory_cache_linux.go
@@ -138,14 +138,14 @@ func memoryCacheLevel(nodeID int, lpID int, cacheIndex int) int {
 	)
 	levelContents, err := ioutil.ReadFile(levelPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
 		return -1
 	}
 	// levelContents is now a []byte with the last byte being a newline
 	// character. Trim that off and convert the contents to an integer.
 	level, err := strconv.Atoi(string(levelContents[:len(levelContents)-1]))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to parse int from %s\n", levelContents)
+		_, _ = fmt.Fprintf(os.Stderr, "Unable to parse int from %s\n", levelContents)
 		return -1
 	}
 	return level
@@ -158,13 +158,13 @@ func memoryCacheSize(nodeID int, lpID int, cacheIndex int) int {
 	)
 	sizeContents, err := ioutil.ReadFile(sizePath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
 		return -1
 	}
 	// size comes as XK\n, so we trim off the K and the newline.
 	size, err := strconv.Atoi(string(sizeContents[:len(sizeContents)-2]))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to parse int from %s\n", sizeContents)
+		_, _ = fmt.Fprintf(os.Stderr, "Unable to parse int from %s\n", sizeContents)
 		return -1
 	}
 	return size
@@ -177,7 +177,7 @@ func memoryCacheType(nodeID int, lpID int, cacheIndex int) MemoryCacheType {
 	)
 	cacheTypeContents, err := ioutil.ReadFile(typePath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
 		return UNIFIED
 	}
 	switch string(cacheTypeContents[:len(cacheTypeContents)-1]) {
@@ -197,7 +197,7 @@ func memoryCacheSharedCPUMap(nodeID int, lpID int, cacheIndex int) string {
 	)
 	sharedCpuMap, err := ioutil.ReadFile(scpuPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
 		return ""
 	}
 	return string(sharedCpuMap[:len(sharedCpuMap)-1])

--- a/pci_linux.go
+++ b/pci_linux.go
@@ -273,7 +273,7 @@ func (info *PCIInfo) ListDevices() []*PCIDevice {
 	// address and append to the returned array.
 	links, err := ioutil.ReadDir(pathSysBusPciDevices())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: failed to read /sys/bus/pci/devices")
+		_, _ = fmt.Fprintf(os.Stderr, "error: failed to read /sys/bus/pci/devices")
 		return nil
 	}
 	var dev *PCIDevice
@@ -281,7 +281,7 @@ func (info *PCIInfo) ListDevices() []*PCIDevice {
 		addr := link.Name()
 		dev = info.GetDevice(addr)
 		if dev == nil {
-			fmt.Fprintf(os.Stderr, "error: failed to get device information for PCI address %s\n", addr)
+			_, _ = fmt.Fprintf(os.Stderr, "error: failed to get device information for PCI address %s\n", addr)
 		} else {
 			devs = append(devs, dev)
 		}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,28 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ghw
+
+import (
+	"fmt"
+	"os"
+)
+
+type closer interface {
+	Close() error
+}
+
+func safeClose(c closer) {
+	err := c.Close()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "failed to close: %s", err)
+	}
+}
+
+func warn(msg string, args ...interface{}) {
+	_, _ = fmt.Fprint(os.Stderr, "WARNING: ")
+	_, _ = fmt.Fprintf(os.Stderr, msg, args...)
+}


### PR DESCRIPTION
Two primary things are addressed:

1) All places where we were doing defer r.Close() is changed to instead
call defer safeClose(r), with a new safeClose() function providing
stderr output of any errors that occur while calling Close()

2) Clean up the calls to fmt.Fprintf() in cases where were were printing
warning or error messages to stderr. Fprintf() returns (int, error) and
we silence errcheck by doing _, _ = fmt.Fprintf()

Issue #51