### PR TITLE
lint-fixes: deadcode and megacheck

### DIFF
--- a/block_linux.go
+++ b/block_linux.go
@@ -21,7 +21,7 @@ const (
 )
 
 var regexNVMeDev = regexp.MustCompile(`^nvme\d+n\d+$`)
-var regexNVMePart = regexp.MustCompile(`^(nvme\d+n\d+)p\d+$`)
+var _REGEX_NVME_PART = regexp.MustCompile(`^(nvme\d+n\d+)p\d+$`)
 
 func blockFillInfo(info *BlockInfo) error {
 	info.Disks = Disks()
@@ -259,11 +259,9 @@ func Disks() []*Disk {
 func PartitionSizeBytes(part string) uint64 {
 	// Allow calling PartitionSize with either the full partition name
 	// "/dev/sda1" or just "sda1"
-	if strings.HasPrefix(part, "/dev") {
-		part = part[4:len(part)]
-	}
+	part = strings.TrimPrefix(part, "/dev")
 	disk := part[0:3]
-	if m := regexNVMePart.FindStringSubmatch(part); len(m) > 0 {
+	if m := _REGEX_NVME_PART.FindStringSubmatch(part); len(m) > 0 {
 		disk = m[1]
 	}
 	path := filepath.Join(pathSysBlock(), disk, part, "size")

--- a/cpu_linux.go
+++ b/cpu_linux.go
@@ -39,7 +39,7 @@ func Processors() []*Processor {
 
 	// An array of maps of attributes describing the logical processor
 	procAttrs := make([]map[string]string, 0)
-	curProcAttrs := make(map[string]string, 0)
+	curProcAttrs := make(map[string]string)
 
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
@@ -50,7 +50,7 @@ func Processors() []*Processor {
 			// collected for this logical processor block
 			procAttrs = append(procAttrs, curProcAttrs)
 			// Reset the current set of processor attributes...
-			curProcAttrs = make(map[string]string, 0)
+			curProcAttrs = make(map[string]string)
 			continue
 		}
 		parts := strings.Split(line, ":")
@@ -61,7 +61,7 @@ func Processors() []*Processor {
 
 	// Build a set of physical processor IDs which represent the physical
 	// package of the CPU
-	setPhysicalIds := make(map[uint32]bool, 0)
+	setPhysicalIds := make(map[uint32]bool)
 	for _, attrs := range procAttrs {
 		pid, err := strconv.Atoi(attrs["physical id"])
 		if err != nil {

--- a/ghwc/cmd/root.go
+++ b/ghwc/cmd/root.go
@@ -62,10 +62,7 @@ func showAll(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	err = showGPU(cmd, args)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/memory_cache_linux.go
+++ b/memory_cache_linux.go
@@ -27,7 +27,7 @@ func cachesForNode(nodeID int) ([]*MemoryCache, error) {
 		pathSysDevicesSystemNode(),
 		fmt.Sprintf("node%d", nodeID),
 	)
-	caches := make(map[string]*MemoryCache, 0)
+	caches := make(map[string]*MemoryCache)
 
 	files, err := ioutil.ReadDir(path)
 	if err != nil {

--- a/memory_linux.go
+++ b/memory_linux.go
@@ -28,6 +28,12 @@ total physical amount of memory to the total usable amount of memory
 `
 )
 
+var (
+	// System log lines will look similar to the following:
+	// ... kernel: [0.000000] Memory: 24633272K/25155024K ...
+	_REGEX_SYSLOG_MEMLINE = regexp.MustCompile(`Memory:\s+\d+K\/(\d+)K`)
+)
+
 func memFillInfo(info *MemoryInfo) error {
 	tub := memTotalUsableBytes()
 	if tub < 1 {
@@ -44,19 +50,13 @@ func memFillInfo(info *MemoryInfo) error {
 	return nil
 }
 
-// System log lines will look similar to the following:
-// ... kernel: [0.000000] Memory: 24633272K/25155024K ...
-var (
-	syslogMemLineRe = regexp.MustCompile("Memory:\\s+\\d+K\\/(\\d+)K")
-)
-
 func memTotalPhysicalBytes() int64 {
 	// In Linux, the total physical memory can be determined by looking at the
 	// output of dmidecode, however dmidecode requires root privileges to run,
 	// so instead we examine the system logs for startup information containing
 	// total physical memory and cache the results of this.
 	findPhysicalKb := func(line string) int64 {
-		matches := syslogMemLineRe.FindStringSubmatch(line)
+		matches := _REGEX_SYSLOG_MEMLINE.FindStringSubmatch(line)
 		if len(matches) == 2 {
 			i, err := strconv.Atoi(matches[1])
 			if err != nil {

--- a/net_linux.go
+++ b/net_linux.go
@@ -34,6 +34,9 @@ func NICs() []*NIC {
 	}
 
 	etInstalled := ethtoolInstalled()
+	if !etInstalled {
+		warn(_WARN_ETHTOOL_NOT_INSTALLED)
+	}
 	for _, file := range files {
 		filename := file.Name()
 		// Ignore loopback...

--- a/path_linux.go
+++ b/path_linux.go
@@ -45,10 +45,6 @@ func pathSysDevicesSystemNode() string {
 	return filepath.Join(pathRoot(), "sys", "devices", "system", "node")
 }
 
-func pathDevDiskById() string {
-	return filepath.Join(pathRoot(), "dev", "disk", "by-id")
-}
-
 func pathSysBusPciDevices() string {
 	return filepath.Join(pathRoot(), "sys", "bus", "pci", "devices")
 }

--- a/pci.go
+++ b/pci.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	RE_PCI_ADDRESS *regexp.Regexp = regexp.MustCompile(
-		"^(([0-9a-f]{0,4}):)?([0-9a-f]{2}):([0-9a-f]{2})\\.([0-9a-f]{1})$",
+	_RE_PCI_ADDRESS *regexp.Regexp = regexp.MustCompile(
+		`^(([0-9a-f]{0,4}):)?([0-9a-f]{2}):([0-9a-f]{2})\.([0-9a-f]{1})$`,
 	)
 )
 
@@ -77,7 +77,7 @@ type PCIAddress struct {
 // Returns "" if the address string wasn't a valid PCI address.
 func PCIAddressFromString(address string) *PCIAddress {
 	addrLowered := strings.ToLower(address)
-	matches := RE_PCI_ADDRESS.FindStringSubmatch(addrLowered)
+	matches := _RE_PCI_ADDRESS.FindStringSubmatch(addrLowered)
 	if len(matches) == 6 {
 		dom := "0000"
 		if matches[1] != "" {


### PR DESCRIPTION
Fixes a variety of linter warnings for the `deadcode` and `megacheck` linters.

Issue #51