### PR TITLE
Make GraphicsCard.Node a pointer not array

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,9 +732,9 @@ Each `ghw.GraphicsCard` struct contains the following fields:
 * `ghw.GraphicsCard.DeviceInfo` is a pointer to a `ghw.PCIDevice` struct
   describing the graphics card. This may be `nil` if no PCI device information
   could be determined for the card.
-* `ghw.GraphicsCard.Nodes` is an array of pointers to `ghw.TopologyNode`
-  structs, one for each NUMA node that the GPU/graphics card is affined to. On
-  non-NUMA systems, this will always be an empty array.
+* `ghw.GraphicsCard.Node` is an pointer to a `ghw.TopologyNode` struct that the
+  GPU/graphics card is affined to. On non-NUMA systems, this will always be
+  `nil`.
 
 ```go
 package main

--- a/gpu.go
+++ b/gpu.go
@@ -8,7 +8,6 @@ package ghw
 
 import (
 	"fmt"
-	"strconv"
 )
 
 type GraphicsCard struct {
@@ -20,9 +19,9 @@ type GraphicsCard struct {
 	// pointer to a PCIDevice struct that describes the vendor and product
 	// model, etc
 	DeviceInfo *PCIDevice
-	// Array of topology nodes that the graphics card is affined to. Will be empty
-	// if the architecture is not NUMA.
-	Nodes []*TopologyNode
+	// Topology nodes that the graphics card is affined to. Will be nil if the
+	// architecture is not NUMA.
+	Node *TopologyNode
 }
 
 func (card *GraphicsCard) String() string {
@@ -31,17 +30,8 @@ func (card *GraphicsCard) String() string {
 		deviceStr = card.DeviceInfo.String()
 	}
 	nodeStr := ""
-	if len(card.Nodes) > 0 {
-		x := 0
-		nodeStr = " NUMA nodes ["
-		for _, node := range card.Nodes {
-			if x > 0 {
-				nodeStr += ","
-			}
-			nodeStr += strconv.Itoa(int(node.Id))
-			x++
-		}
-		nodeStr += "] "
+	if card.Node != nil {
+		nodeStr = fmt.Sprintf(" [affined to NUMA node %d]", card.Node.Id)
 	}
 	return fmt.Sprintf(
 		"card #%d %s@%s",

--- a/gpu_linux.go
+++ b/gpu_linux.go
@@ -14,11 +14,12 @@ import (
 )
 
 const (
-	_WARN_CANNOT_READ_NUMA_NODES = `
-Unable to read numa_nodes descriptor file on this system.
-Setting graphics card's Nodes attribute to empty array.
+	_WARN_CANNOT_READ_NUMA_NODE = `
+Unable to read numa_node descriptor file on this system.
+Setting graphics card's Node attribute to nil.
 `
-	_WARN_NO_SYS_CLASS_DRM = `
+	_WARN_NUMA_NODE_NOT_INTEGER = `device numa_node not an integer`
+	_WARN_NO_SYS_CLASS_DRM      = `
 /sys/class/drm does not exist on this system (likely the host system is a
 virtual machine or container with no graphics). Therefore,
 GPUInfo.GraphicsCards will be an empty array.
@@ -109,29 +110,23 @@ func gpuFillPCIDevice(cards []*GraphicsCard) {
 	}
 }
 
-// Loops through each GraphicsCard struct and find which NUMA nodes the card is
-// affined to, setting the GraphicsCard.Nodes field accordingly. If the host
-// system is not a NUMA system, the Nodes field will be set to an empty array
-// of Node pointers.
+// Loops through each GraphicsCard struct and find which NUMA node the card is
+// affined to, setting the GraphicsCard.Node field accordingly. If the host
+// system is not a NUMA system, the Node field will be set to nil.
 func gpuFillNUMANodes(cards []*GraphicsCard) {
 	topo, err := Topology()
 	if err != nil {
 		for _, card := range cards {
 			if topo.Architecture != NUMA {
-				card.Nodes = make([]*TopologyNode, 0)
+				card.Node = nil
 			}
 		}
 		return
 	}
 	for _, card := range cards {
-		if topo.Architecture != NUMA {
-			card.Nodes = make([]*TopologyNode, 0)
-			continue
-		}
 		// Each graphics card on a NUMA system will have a pseudo-file
 		// called /sys/class/drm/card$CARD_INDEX/device/numa_node which
-		// contains a comma-separated list of NUMA nodes that the card is
-		// affined to
+		// contains the NUMA node that the card is affined to
 		cardIndexStr := strconv.Itoa(card.Index)
 		fpath := filepath.Join(
 			pathSysClassDrm(),
@@ -141,20 +136,19 @@ func gpuFillNUMANodes(cards []*GraphicsCard) {
 		)
 		numaContents, err := ioutil.ReadFile(fpath)
 		if err != nil {
-			warn(_WARN_CANNOT_READ_NUMA_NODES)
-			card.Nodes = make([]*TopologyNode, 0)
+			warn(_WARN_CANNOT_READ_NUMA_NODE)
+			card.Node = nil
 			continue
 		}
-		cardNodes := make([]*TopologyNode, 0)
-		nodeIndexes := strings.Split(string(numaContents), ",")
-		for _, nodeIndex := range nodeIndexes {
-			for _, node := range topo.Nodes {
-				nodeIndexInt, _ := strconv.Atoi(nodeIndex)
-				if nodeIndexInt == int(node.Id) {
-					cardNodes = append(cardNodes, node)
-				}
+		nodeIdx, err := strconv.Atoi(string(numaContents))
+		if err != nil {
+			warn(_WARN_NUMA_NODE_NOT_INTEGER)
+			continue
+		}
+		for _, node := range topo.Nodes {
+			if nodeIdx == int(node.Id) {
+				card.Node = node
 			}
 		}
-		card.Nodes = cardNodes
 	}
 }

--- a/gpu_test.go
+++ b/gpu_test.go
@@ -34,10 +34,6 @@ func TestGPU(t *testing.T) {
 				t.Fatalf("Expected card with address %s to have non-nil DeviceInfo.", card.Address)
 			}
 		}
-		// The Nodes attribute should at least be filled with empty arrays of
-		// Node pointers
-		if card.Nodes == nil {
-			t.Fatalf("Expected card with address %s to have non-nil Nodes.", card.Address)
-		}
+		// TODO(jaypipes): Add Card.Node test when using injected sysfs for testing
 	}
 }


### PR DESCRIPTION
A PCI device, which graphics cards predominantly are, may only be
affined to a single NUMA node, so this changes the GraphicsCard.Nodes
field to GraphicsCard.Node.

Issue #65