### PR TITLE
cpu: linter fixes and deprecation warnings

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -10,8 +10,13 @@ import (
 	"fmt"
 )
 
+// ProcessorCore describes a physical host processor core. A processor core is
+// a separate processing unit within some types of central processing units
+// (CPU).
 type ProcessorCore struct {
+	// TODO(jaypipes): Deprecated in 0.2, remove in 1.0
 	Id                uint32
+	ID                uint32
 	Index             int
 	NumThreads        uint32
 	LogicalProcessors []uint32
@@ -26,8 +31,11 @@ func (c *ProcessorCore) String() string {
 	)
 }
 
+// Processor describes a physical host central processing unit (CPU).
 type Processor struct {
+	// TODO(jaypipes): Deprecated in 0.2, remove in 1.0
 	Id           uint32
+	ID           uint32
 	NumCores     uint32
 	NumThreads   uint32
 	Vendor       string
@@ -36,6 +44,12 @@ type Processor struct {
 	Cores        []*ProcessorCore
 }
 
+// HasCapability returns true if the `ghw.Processor` has the supplied cpuid
+// capability, false otherwise. Example of cpuid capabilities would be 'vmx' or
+// 'sse4_2'. To see a list of potential cpuid capabilitiies, see the section on
+// CPUID feature bits in the following article:
+//
+// https://en.wikipedia.org/wiki/CPUID
 func (p *Processor) HasCapability(find string) bool {
 	for _, c := range p.Capabilities {
 		if c == find {
@@ -56,7 +70,7 @@ func (p *Processor) String() string {
 	}
 	return fmt.Sprintf(
 		"physical package #%d (%d %s, %d hardware %s)",
-		p.Id,
+		p.ID,
 		p.NumCores,
 		ncs,
 		p.NumThreads,
@@ -64,12 +78,15 @@ func (p *Processor) String() string {
 	)
 }
 
+// CPUInfo describes all central processing unit (CPU) functionality on a host.
+// Returned by the `ghw.CPU()` function.
 type CPUInfo struct {
 	TotalCores   uint32
 	TotalThreads uint32
 	Processors   []*Processor
 }
 
+// CPU returns a struct containing information about the host's CPU resources.
 func CPU() (*CPUInfo, error) {
 	info := &CPUInfo{}
 	err := cpuFillInfo(info)

--- a/cpu.go
+++ b/cpu.go
@@ -15,11 +15,11 @@ import (
 // (CPU).
 type ProcessorCore struct {
 	// TODO(jaypipes): Deprecated in 0.2, remove in 1.0
-	Id                uint32
-	ID                uint32
+	Id                int
+	ID                int
 	Index             int
 	NumThreads        uint32
-	LogicalProcessors []uint32
+	LogicalProcessors []int
 }
 
 func (c *ProcessorCore) String() string {
@@ -34,8 +34,8 @@ func (c *ProcessorCore) String() string {
 // Processor describes a physical host central processing unit (CPU).
 type Processor struct {
 	// TODO(jaypipes): Deprecated in 0.2, remove in 1.0
-	Id           uint32
-	ID           uint32
+	Id           int
+	ID           int
 	NumCores     uint32
 	NumThreads   uint32
 	Vendor       string

--- a/topology_linux.go
+++ b/topology_linux.go
@@ -43,7 +43,7 @@ func TopologyNodes() ([]*TopologyNode, error) {
 			return nil, err
 		}
 		node.Id = uint32(nodeId)
-		cores, err := coresForNode(node.Id)
+		cores, err := coresForNode(int(node.Id))
 		if err != nil {
 			return nil, err
 		}

--- a/utils.go
+++ b/utils.go
@@ -8,7 +8,10 @@ package ghw
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"strconv"
+	"strings"
 )
 
 type closer interface {
@@ -25,4 +28,23 @@ func safeClose(c closer) {
 func warn(msg string, args ...interface{}) {
 	_, _ = fmt.Fprint(os.Stderr, "WARNING: ")
 	_, _ = fmt.Fprintf(os.Stderr, msg, args...)
+}
+
+// Reads a supplied filepath and converts the contents to an integer. Returns
+// -1 if there were file permissions or existence errors or if the contents
+// could not be successfully converted to an integer. In any error, a message
+// is printed to STDERR, but -1 is returned.
+func safeIntFromFile(path string) int {
+	buf, err := ioutil.ReadFile(path)
+	if err != nil {
+		fmt.Fprint(os.Stderr, err)
+		return -1
+	}
+	contents := strings.TrimSpace(string(buf))
+	res, err := strconv.Atoi(contents)
+	if err != nil {
+		fmt.Fprint(os.Stderr, err)
+		return -1
+	}
+	return res
 }


### PR DESCRIPTION
* Deprecates the `ProcessorCore.Id` and `Processor.Id` fields, adding new `ID` fields. The old fields will be removed in 1.0 release
* Deprecates the undocumented `Processors()` function, since the only interface that `ghw` should provide to get processor information should be the `ghw.CPU()` function that returns a `ghw.CPUInfo` struct

Issue #51 