### PR TITLE
lint-fixes: block, pci, and topology modules

### DIFF
--- a/block.go
+++ b/block.go
@@ -11,6 +11,8 @@ import (
 	"math"
 )
 
+// Disk describes a single disk drive on the host system. Disk drives provide
+// raw block storage resources.
 type Disk struct {
 	Name                   string
 	SizeBytes              uint64
@@ -25,6 +27,7 @@ type Disk struct {
 	Partitions             []*Partition
 }
 
+// Partition describes a logical division of a Disk.
 type Partition struct {
 	Disk       *Disk
 	Name       string
@@ -35,12 +38,15 @@ type Partition struct {
 	IsReadOnly bool
 }
 
+// BlockInfo describes all disk drives and partitions in the host system.
 type BlockInfo struct {
 	TotalPhysicalBytes uint64
 	Disks              []*Disk
 	Partitions         []*Partition
 }
 
+// Block returns a BlockInfo struct that describes the block storage resources
+// of the host system.
 func Block() (*BlockInfo, error) {
 	info := &BlockInfo{}
 	err := blockFillInfo(info)

--- a/block_linux.go
+++ b/block_linux.go
@@ -17,14 +17,14 @@ import (
 )
 
 const (
-	linuxSectorSize = 512
+	sectorSize = 512
 )
 
 var regexNVMeDev = regexp.MustCompile(`^nvme\d+n\d+$`)
-var _REGEX_NVME_PART = regexp.MustCompile(`^(nvme\d+n\d+)p\d+$`)
+var regexNVMePart = regexp.MustCompile(`^(nvme\d+n\d+)p\d+$`)
 
 func blockFillInfo(info *BlockInfo) error {
-	info.Disks = Disks()
+	info.Disks = disks()
 	var tpb uint64
 	for _, d := range info.Disks {
 		tpb += d.SizeBytes
@@ -33,7 +33,20 @@ func blockFillInfo(info *BlockInfo) error {
 	return nil
 }
 
+// DiskPhysicalBlockSizeBytes has been deprecated in 0.2. Please use the
+// Disk.PhysicalBlockSizeBytes attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskPhysicalBlockSizeBytes(disk string) uint64 {
+	msg := `
+The DiskPhysicalBlockSizeBytes() function has been DEPRECATED and will be
+removed in the 1.0 release of ghw. Please use the Disk.PhysicalBlockSizeBytes
+attribute.
+`
+	warn(msg)
+	return diskPhysicalBlockSizeBytes(disk)
+}
+
+func diskPhysicalBlockSizeBytes(disk string) uint64 {
 	// We can find the sector size in Linux by looking at the
 	// /sys/block/$DEVICE/queue/physical_block_size file in sysfs
 	path := filepath.Join(pathSysBlock(), disk, "queue", "physical_block_size")
@@ -48,7 +61,19 @@ func DiskPhysicalBlockSizeBytes(disk string) uint64 {
 	return uint64(i)
 }
 
+// DiskSizeBytes has been deprecated in 0.2. Please use the Disk.SizeBytes
+// attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskSizeBytes(disk string) uint64 {
+	msg := `
+The DiskSizeBytes() function has been DEPRECATED and will be
+removed in the 1.0 release of ghw. Please use the Disk.SizeBytes attribute.
+`
+	warn(msg)
+	return diskSizeBytes(disk)
+}
+
+func diskSizeBytes(disk string) uint64 {
 	// We can find the number of 512-byte sectors by examining the contents of
 	// /sys/block/$DEVICE/size and calculate the physical bytes accordingly.
 	path := filepath.Join(pathSysBlock(), disk, "size")
@@ -60,10 +85,22 @@ func DiskSizeBytes(disk string) uint64 {
 	if err != nil {
 		return 0
 	}
-	return uint64(i) * linuxSectorSize
+	return uint64(i) * sectorSize
 }
 
+// DiskNUMANodeID has been deprecated in 0.2. Please use the Disk.NUMANodeID
+// attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskNUMANodeID(disk string) int {
+	msg := `
+The DiskNUMANodeID() function has been DEPRECATED and will be
+removed in the 1.0 release of ghw. Please use the Disk.NUMANodeID attribute.
+`
+	warn(msg)
+	return diskNUMANodeID(disk)
+}
+
+func diskNUMANodeID(disk string) int {
 	link, err := os.Readlink(filepath.Join(pathSysBlock(), disk))
 	if err != nil {
 		return -1
@@ -78,7 +115,18 @@ func DiskNUMANodeID(disk string) int {
 	return -1
 }
 
+// DiskVendor has been deprecated in 0.2. Please use the Disk.Vendor attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskVendor(disk string) string {
+	msg := `
+The DiskVendor() function has been DEPRECATED and will be
+removed in the 1.0 release of ghw. Please use the Disk.Vendor attribute.
+`
+	warn(msg)
+	return diskVendor(disk)
+}
+
+func diskVendor(disk string) string {
 	// In Linux, the vendor for a disk device is found in the
 	// /sys/block/$DEVICE/device/vendor file in sysfs
 	path := filepath.Join(pathSysBlock(), disk, "device", "vendor")
@@ -97,8 +145,8 @@ func udevInfo(disk string) (map[string]string, error) {
 	}
 
 	// Look up block device in udev runtime database
-	udevId := "b" + strings.TrimSpace(string(devNo))
-	udevBytes, err := ioutil.ReadFile(filepath.Join(pathRunUdevData(), udevId))
+	udevID := "b" + strings.TrimSpace(string(devNo))
+	udevBytes, err := ioutil.ReadFile(filepath.Join(pathRunUdevData(), udevID))
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +162,18 @@ func udevInfo(disk string) (map[string]string, error) {
 	return udevInfo, nil
 }
 
+// DiskModel has been deprecated in 0.2. Please use the Disk.Model attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskModel(disk string) string {
+	msg := `
+The DiskModel() function has been DEPRECATED and will be removed in the 1.0
+release of ghw. Please use the Disk.Model attribute.
+`
+	warn(msg)
+	return diskModel(disk)
+}
+
+func diskModel(disk string) string {
 	info, err := udevInfo(disk)
 	if err != nil {
 		return UNKNOWN
@@ -126,7 +185,18 @@ func DiskModel(disk string) string {
 	return UNKNOWN
 }
 
+// DiskSerialNumber has been deprecated in 0.2. Please use the Disk.SerialNumber attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskSerialNumber(disk string) string {
+	msg := `
+The DiskSerialNumber() function has been DEPRECATED and will be removed in the
+1.0 release of ghw. Please use the Disk.SerialNumber attribute.
+`
+	warn(msg)
+	return diskSerialNumber(disk)
+}
+
+func diskSerialNumber(disk string) string {
 	info, err := udevInfo(disk)
 	if err != nil {
 		return UNKNOWN
@@ -140,7 +210,18 @@ func DiskSerialNumber(disk string) string {
 	return UNKNOWN
 }
 
+// DiskBusPath has been deprecated in 0.2. Please use the Disk.BusPath attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskBusPath(disk string) string {
+	msg := `
+The DiskBusPath() function has been DEPRECATED and will be removed in the 1.0
+release of ghw. Please use the Disk.BusPath attribute.
+`
+	warn(msg)
+	return diskBusPath(disk)
+}
+
+func diskBusPath(disk string) string {
 	info, err := udevInfo(disk)
 	if err != nil {
 		return UNKNOWN
@@ -154,7 +235,18 @@ func DiskBusPath(disk string) string {
 	return UNKNOWN
 }
 
+// DiskWWN has been deprecated in 0.2. Please use the Disk.WWN attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskWWN(disk string) string {
+	msg := `
+The DiskWWN() function has been DEPRECATED and will be removed in the 1.0
+release of ghw. Please use the Disk.WWN attribute.
+`
+	warn(msg)
+	return diskWWN(disk)
+}
+
+func diskWWN(disk string) string {
 	info, err := udevInfo(disk)
 	if err != nil {
 		return UNKNOWN
@@ -170,7 +262,18 @@ func DiskWWN(disk string) string {
 	return UNKNOWN
 }
 
+// DiskPartitions has been deprecated in 0.2. Please use the Disk.Partitions attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskPartitions(disk string) []*Partition {
+	msg := `
+The DiskPartitions() function has been DEPRECATED and will be removed in the
+1.0 release of ghw. Please use the Disk.Partitions attribute.
+`
+	warn(msg)
+	return diskPartitions(disk)
+}
+
+func diskPartitions(disk string) []*Partition {
 	out := make([]*Partition, 0)
 	path := filepath.Join(pathSysBlock(), disk)
 	files, err := ioutil.ReadDir(path)
@@ -182,8 +285,8 @@ func DiskPartitions(disk string) []*Partition {
 		if !strings.HasPrefix(fname, disk) {
 			continue
 		}
-		size := PartitionSizeBytes(fname)
-		mp, pt, ro := PartitionInfo(fname)
+		size := partitionSizeBytes(fname)
+		mp, pt, ro := partitionInfo(fname)
 		p := &Partition{
 			Name:       fname,
 			SizeBytes:  size,
@@ -196,7 +299,18 @@ func DiskPartitions(disk string) []*Partition {
 	return out
 }
 
-func Disks() []*Disk {
+// Disks has been deprecated in 0.2. Please use the BlockInfo.Disks attribute.
+// TODO(jaypipes): Remove in 1.0.
+func Disks(disk string) []*Disk {
+	msg := `
+The Disks() function has been DEPRECATED and will be removed in the
+1.0 release of ghw. Please use the BlockInfo.Disks attribute.
+`
+	warn(msg)
+	return disks()
+}
+
+func disks() []*Disk {
 	// In Linux, we could use the fdisk, lshw or blockdev commands to list disk
 	// information, however all of these utilities require root privileges to
 	// run. We can get all of this information by examining the /sys/block
@@ -221,14 +335,14 @@ func Disks() []*Disk {
 			continue
 		}
 
-		size := DiskSizeBytes(dname)
-		pbs := DiskPhysicalBlockSizeBytes(dname)
-		busPath := DiskBusPath(dname)
-		node := DiskNUMANodeID(dname)
-		vendor := DiskVendor(dname)
-		model := DiskModel(dname)
-		serialNo := DiskSerialNumber(dname)
-		wwn := DiskWWN(dname)
+		size := diskSizeBytes(dname)
+		pbs := diskPhysicalBlockSizeBytes(dname)
+		busPath := diskBusPath(dname)
+		node := diskNUMANodeID(dname)
+		vendor := diskVendor(dname)
+		model := diskModel(dname)
+		serialNo := diskSerialNumber(dname)
+		wwn := diskWWN(dname)
 
 		d := &Disk{
 			Name:                   dname,
@@ -243,7 +357,7 @@ func Disks() []*Disk {
 			WWN:                    wwn,
 		}
 
-		parts := DiskPartitions(dname)
+		parts := diskPartitions(dname)
 		// Map this Disk object into the Partition...
 		for _, part := range parts {
 			part.Disk = d
@@ -256,12 +370,23 @@ func Disks() []*Disk {
 	return disks
 }
 
+// PartitionSizeBytes has been deprecated in 0.2. Please use the
+// Partition.SizeBytes attribute.  TODO(jaypipes): Remove in 1.0.
 func PartitionSizeBytes(part string) uint64 {
+	msg := `
+The PartitionSizeBytes() function has been DEPRECATED and will be removed in
+the 1.0 release of ghw. Please use the Partition.SizeBytes attribute.
+`
+	warn(msg)
+	return partitionSizeBytes(part)
+}
+
+func partitionSizeBytes(part string) uint64 {
 	// Allow calling PartitionSize with either the full partition name
 	// "/dev/sda1" or just "sda1"
 	part = strings.TrimPrefix(part, "/dev")
 	disk := part[0:3]
-	if m := _REGEX_NVME_PART.FindStringSubmatch(part); len(m) > 0 {
+	if m := regexNVMePart.FindStringSubmatch(part); len(m) > 0 {
 		disk = m[1]
 	}
 	path := filepath.Join(pathSysBlock(), disk, part, "size")
@@ -273,12 +398,23 @@ func PartitionSizeBytes(part string) uint64 {
 	if err != nil {
 		return 0
 	}
-	return uint64(i) * linuxSectorSize
+	return uint64(i) * sectorSize
+}
+
+// PartitionInfo has been deprecated in 0.2. Please use the Partition struct.
+// TODO(jaypipes): Remove in 1.0.
+func PartitionInfo(part string) (string, string, bool) {
+	msg := `
+The PartitionInfo() function has been DEPRECATED and will be removed in
+the 1.0 release of ghw. Please use the Partition struct.
+`
+	warn(msg)
+	return partitionInfo(part)
 }
 
 // Given a full or short partition name, returns the mount point, the type of
 // the partition and whether it's readonly
-func PartitionInfo(part string) (string, string, bool) {
+func partitionInfo(part string) (string, string, bool) {
 	// Allow calling PartitionInfo with either the full partition name
 	// "/dev/sda1" or just "sda1"
 	if !strings.HasPrefix(part, "/dev") {
@@ -358,17 +494,50 @@ func parseMtabEntry(line string) *mtabEntry {
 	return res
 }
 
+// PartitionMountPoint has been deprecated in 0.2. Please use the
+// Partition.MountPoint attribute.  TODO(jaypipes): Remove in 1.0.
 func PartitionMountPoint(part string) string {
-	mp, _, _ := PartitionInfo(part)
+	msg := `
+The PartitionMountPoint() function has been DEPRECATED and will be removed in
+the 1.0 release of ghw. Please use the Partition.MountPoint attribute.
+`
+	warn(msg)
+	return partitionMountPoint(part)
+}
+
+func partitionMountPoint(part string) string {
+	mp, _, _ := partitionInfo(part)
 	return mp
 }
 
+// PartitionType has been deprecated in 0.2. Please use the
+// Partition.Type attribute.  TODO(jaypipes): Remove in 1.0.
 func PartitionType(part string) string {
-	_, pt, _ := PartitionInfo(part)
+	msg := `
+The PartitionType() function has been DEPRECATED and will be removed in
+the 1.0 release of ghw. Please use the Partition.Type attribute.
+`
+	warn(msg)
+	return partitionType(part)
+}
+
+func partitionType(part string) string {
+	_, pt, _ := partitionInfo(part)
 	return pt
 }
 
+// PartitionIsReadOnly has been deprecated in 0.2. Please use the
+// Partition.IsReadOnly attribute.  TODO(jaypipes): Remove in 1.0.
 func PartitionIsReadOnly(part string) bool {
-	_, _, ro := PartitionInfo(part)
+	msg := `
+The PartitionIsReadOnly() function has been DEPRECATED and will be removed in
+the 1.0 release of ghw. Please use the Partition.IsReadOnly attribute.
+`
+	warn(msg)
+	return partitionIsReadOnly(part)
+}
+
+func partitionIsReadOnly(part string) bool {
+	_, _, ro := partitionInfo(part)
 	return ro
 }

--- a/block_test.go
+++ b/block_test.go
@@ -63,22 +63,22 @@ func TestBlock(t *testing.T) {
 	for _, p := range d0.Partitions {
 		// Check that all the singular functions return the same information as
 		// the information constructed by ghw.Block()
-		ps := PartitionSizeBytes(p.Name)
+		ps := partitionSizeBytes(p.Name)
 		if ps != p.SizeBytes {
 			t.Fatalf("Expected matching size, but got %d != %d",
 				ps, p.SizeBytes)
 		}
-		pmp := PartitionMountPoint(p.Name)
+		pmp := partitionMountPoint(p.Name)
 		if pmp != p.MountPoint {
 			t.Fatalf("Expected matching mountpoints, but got %s != %s",
 				pmp, p.MountPoint)
 		}
-		pt := PartitionType(p.Name)
+		pt := partitionType(p.Name)
 		if pt != p.Type {
 			t.Fatalf("Expected matching types, but got %s != %s",
 				pt, p.Type)
 		}
-		pro := PartitionIsReadOnly(p.Name)
+		pro := partitionIsReadOnly(p.Name)
 		if pro != p.IsReadOnly {
 			t.Fatalf("Expected matching readonly, but got %v != %v",
 				pro, p.IsReadOnly)

--- a/pci_linux.go
+++ b/pci_linux.go
@@ -39,13 +39,13 @@ func getPCIDeviceModaliasPath(address string) string {
 }
 
 type deviceModaliasInfo struct {
-	vendorId     string
-	productId    string
-	subproductId string
-	subvendorId  string
-	classId      string
-	subclassId   string
-	progIfaceId  string
+	vendorID     string
+	productID    string
+	subproductID string
+	subvendorID  string
+	classID      string
+	subclassID   string
+	progIfaceID  string
 }
 
 func parseModaliasFile(fp string) *deviceModaliasInfo {
@@ -71,21 +71,21 @@ func parseModaliasFile(fp string) *deviceModaliasInfo {
 	// bc03 -- PCI base class
 	// sc00 -- PCI subclass
 	// i00 -- programming interface
-	vendorId := strings.ToLower(string(data[9:13]))
-	productId := strings.ToLower(string(data[18:22]))
-	subvendorId := strings.ToLower(string(data[28:32]))
-	subproductId := strings.ToLower(string(data[38:42]))
-	classId := string(data[44:46])
-	subclassId := string(data[48:50])
-	progIfaceId := string(data[51:53])
+	vendorID := strings.ToLower(string(data[9:13]))
+	productID := strings.ToLower(string(data[18:22]))
+	subvendorID := strings.ToLower(string(data[28:32]))
+	subproductID := strings.ToLower(string(data[38:42]))
+	classID := string(data[44:46])
+	subclassID := string(data[48:50])
+	progIfaceID := string(data[51:53])
 	return &deviceModaliasInfo{
-		vendorId:     vendorId,
-		productId:    productId,
-		subproductId: subproductId,
-		subvendorId:  subvendorId,
-		classId:      classId,
-		subclassId:   subclassId,
-		progIfaceId:  progIfaceId,
+		vendorID:     vendorID,
+		productID:    productID,
+		subproductID: subproductID,
+		subvendorID:  subvendorID,
+		classID:      classID,
+		subclassID:   subclassID,
+		progIfaceID:  progIfaceID,
 	}
 }
 
@@ -93,11 +93,11 @@ func parseModaliasFile(fp string) *deviceModaliasInfo {
 // ID string. If no such vendor ID string could be found, returns the
 // pcidb.PCIVendor struct populated with "unknown" vendor Name attribute and
 // empty Products attribute.
-func findPCIVendor(info *PCIInfo, vendorId string) *pcidb.PCIVendor {
-	vendor := info.Vendors[vendorId]
+func findPCIVendor(info *PCIInfo, vendorID string) *pcidb.PCIVendor {
+	vendor := info.Vendors[vendorID]
 	if vendor == nil {
 		return &pcidb.PCIVendor{
-			Id:       vendorId,
+			Id:       vendorID,
 			Name:     UNKNOWN,
 			Products: []*pcidb.PCIProduct{},
 		}
@@ -111,13 +111,13 @@ func findPCIVendor(info *PCIInfo, vendorId string) *pcidb.PCIVendor {
 // empty Subsystems attribute.
 func findPCIProduct(
 	info *PCIInfo,
-	vendorId string,
-	productId string,
+	vendorID string,
+	productID string,
 ) *pcidb.PCIProduct {
-	product := info.Products[vendorId+productId]
+	product := info.Products[vendorID+productID]
 	if product == nil {
 		return &pcidb.PCIProduct{
-			Id:         productId,
+			Id:         productID,
 			Name:       UNKNOWN,
 			Subsystems: []*pcidb.PCIProduct{},
 		}
@@ -131,23 +131,23 @@ func findPCIProduct(
 // Name attribute and empty Subsystems attribute.
 func findPCISubsystem(
 	info *PCIInfo,
-	vendorId string,
-	productId string,
-	subvendorId string,
-	subproductId string,
+	vendorID string,
+	productID string,
+	subvendorID string,
+	subproductID string,
 ) *pcidb.PCIProduct {
-	product := info.Products[vendorId+productId]
-	subvendor := info.Vendors[subvendorId]
+	product := info.Products[vendorID+productID]
+	subvendor := info.Vendors[subvendorID]
 	if subvendor != nil && product != nil {
 		for _, p := range product.Subsystems {
-			if p.Id == subproductId {
+			if p.Id == subproductID {
 				return p
 			}
 		}
 	}
 	return &pcidb.PCIProduct{
-		VendorId: subvendorId,
-		Id:       subproductId,
+		VendorId: subvendorID,
+		Id:       subproductID,
 		Name:     UNKNOWN,
 	}
 }
@@ -156,11 +156,11 @@ func findPCISubsystem(
 // string. If no such class ID string could be found, returns the
 // pcidb.PCIClass struct populated with "unknown" class Name attribute and
 // empty Subclasses attribute.
-func findPCIClass(info *PCIInfo, classId string) *pcidb.PCIClass {
-	class := info.Classes[classId]
+func findPCIClass(info *PCIInfo, classID string) *pcidb.PCIClass {
+	class := info.Classes[classID]
 	if class == nil {
 		return &pcidb.PCIClass{
-			Id:         classId,
+			Id:         classID,
 			Name:       UNKNOWN,
 			Subclasses: []*pcidb.PCISubclass{},
 		}
@@ -174,19 +174,19 @@ func findPCIClass(info *PCIInfo, classId string) *pcidb.PCIClass {
 // and empty ProgrammingInterfaces attribute.
 func findPCISubclass(
 	info *PCIInfo,
-	classId string,
-	subclassId string,
+	classID string,
+	subclassID string,
 ) *pcidb.PCISubclass {
-	class := info.Classes[classId]
+	class := info.Classes[classID]
 	if class != nil {
 		for _, sc := range class.Subclasses {
-			if sc.Id == subclassId {
+			if sc.Id == subclassID {
 				return sc
 			}
 		}
 	}
 	return &pcidb.PCISubclass{
-		Id:   subclassId,
+		Id:   subclassID,
 		Name: UNKNOWN,
 		ProgrammingInterfaces: []*pcidb.PCIProgrammingInterface{},
 	}
@@ -198,24 +198,25 @@ func findPCISubclass(
 // pcidb.PCIProgrammingInterface struct populated with "unknown" Name attribute
 func findPCIProgrammingInterface(
 	info *PCIInfo,
-	classId string,
-	subclassId string,
-	progIfaceId string,
+	classID string,
+	subclassID string,
+	progIfaceID string,
 ) *pcidb.PCIProgrammingInterface {
-	subclass := findPCISubclass(info, classId, subclassId)
+	subclass := findPCISubclass(info, classID, subclassID)
 	for _, pi := range subclass.ProgrammingInterfaces {
-		if pi.Id == progIfaceId {
+		if pi.Id == progIfaceID {
 			return pi
 		}
 	}
 	return &pcidb.PCIProgrammingInterface{
-		Id:   progIfaceId,
+		Id:   progIfaceID,
 		Name: UNKNOWN,
 	}
 }
 
-// Returns a pointer to a PCIDevice struct that describes the PCI device at
-// the requested address. If no such device could be found, returns nil
+// GetDevice returns a pointer to a PCIDevice struct that describes the PCI
+// device at the requested address. If no such device could be found, returns
+// nil
 func (info *PCIInfo) GetDevice(address string) *PCIDevice {
 	fp := getPCIDeviceModaliasPath(address)
 	if fp == "" {
@@ -227,30 +228,30 @@ func (info *PCIInfo) GetDevice(address string) *PCIDevice {
 		return nil
 	}
 
-	vendor := findPCIVendor(info, modaliasInfo.vendorId)
+	vendor := findPCIVendor(info, modaliasInfo.vendorID)
 	product := findPCIProduct(
 		info,
-		modaliasInfo.vendorId,
-		modaliasInfo.productId,
+		modaliasInfo.vendorID,
+		modaliasInfo.productID,
 	)
 	subsystem := findPCISubsystem(
 		info,
-		modaliasInfo.vendorId,
-		modaliasInfo.productId,
-		modaliasInfo.subvendorId,
-		modaliasInfo.subproductId,
+		modaliasInfo.vendorID,
+		modaliasInfo.productID,
+		modaliasInfo.subvendorID,
+		modaliasInfo.subproductID,
 	)
-	class := findPCIClass(info, modaliasInfo.classId)
+	class := findPCIClass(info, modaliasInfo.classID)
 	subclass := findPCISubclass(
 		info,
-		modaliasInfo.classId,
-		modaliasInfo.subclassId,
+		modaliasInfo.classID,
+		modaliasInfo.subclassID,
 	)
 	progIface := findPCIProgrammingInterface(
 		info,
-		modaliasInfo.classId,
-		modaliasInfo.subclassId,
-		modaliasInfo.progIfaceId,
+		modaliasInfo.classID,
+		modaliasInfo.subclassID,
+		modaliasInfo.progIfaceID,
 	)
 
 	return &PCIDevice{
@@ -264,7 +265,8 @@ func (info *PCIInfo) GetDevice(address string) *PCIDevice {
 	}
 }
 
-// Returns a list of pointers to PCIDevice structs present on the host system
+// ListDevices returns a list of pointers to PCIDevice structs present on the
+// host system
 func (info *PCIInfo) ListDevices() []*PCIDevice {
 	devs := make([]*PCIDevice, 0)
 	// We scan the /sys/bus/pci/devices directory which contains a collection

--- a/topology.go
+++ b/topology.go
@@ -11,14 +11,18 @@ import (
 	"sort"
 )
 
+// Architecture describes the overall hardware architecture. It can be either
+// Symmetric Multi-Processor (SMP) or Non-Uniform Memory Access (NUMA)
 type Architecture int
 
 const (
+	// SMP is a Symmetric Multi-Processor system
 	SMP Architecture = iota
+	// NUMA is a Non-Uniform Memory Access system
 	NUMA
 )
 
-// A TopologyNode is an abstract construct representing a collection of
+// TopologyNode is an abstract construct representing a collection of
 // processors and various levels of memory cache that those processors share.
 // In a NUMA architecture, there are multiple NUMA nodes, abstracted here as
 // multiple TopologyNode structs. In an SMP architecture, a single TopologyNode
@@ -26,7 +30,9 @@ const (
 // used to describe the levels of memory caching available to the single
 // physical processor package's physical processor cores
 type TopologyNode struct {
-	Id     uint32
+	// TODO(jaypipes): Deprecated in 0.2, remove in 1.0
+	Id     int
+	ID     int
 	Cores  []*ProcessorCore
 	Caches []*MemoryCache
 }
@@ -34,16 +40,19 @@ type TopologyNode struct {
 func (n *TopologyNode) String() string {
 	return fmt.Sprintf(
 		"node #%d (%d cores)",
-		n.Id,
+		n.ID,
 		len(n.Cores),
 	)
 }
 
+// TopologyInfo describes the system topology for the host hardware
 type TopologyInfo struct {
 	Architecture Architecture
 	Nodes        []*TopologyNode
 }
 
+// Topology returns a TopologyInfo struct that describes the system topology of
+// the host hardware
 func Topology() (*TopologyInfo, error) {
 	info := &TopologyInfo{}
 	err := topologyFillInfo(info)

--- a/topology_linux.go
+++ b/topology_linux.go
@@ -12,7 +12,7 @@ import (
 )
 
 func topologyFillInfo(info *TopologyInfo) error {
-	nodes, err := TopologyNodes()
+	nodes, err := topologyNodes()
 	if err != nil {
 		return err
 	}
@@ -25,7 +25,19 @@ func topologyFillInfo(info *TopologyInfo) error {
 	return nil
 }
 
+// TopologyNodes has been deprecated in 0.2. Please use the TopologyInfo.Nodes
+// attribute.
+// TODO(jaypipes): Remove in 1.0.
 func TopologyNodes() ([]*TopologyNode, error) {
+	msg := `
+The TopologyNodes() function has been DEPRECATED and will be removed in the 1.0
+release of ghw. Please use the TopologyInfo.Nodes attribute.
+`
+	warn(msg)
+	return topologyNodes()
+}
+
+func topologyNodes() ([]*TopologyNode, error) {
 	nodes := make([]*TopologyNode, 0)
 
 	files, err := ioutil.ReadDir(pathSysDevicesSystemNode())
@@ -38,17 +50,17 @@ func TopologyNodes() ([]*TopologyNode, error) {
 			continue
 		}
 		node := &TopologyNode{}
-		nodeId, err := strconv.Atoi(filename[4:])
+		nodeID, err := strconv.Atoi(filename[4:])
 		if err != nil {
 			return nil, err
 		}
-		node.Id = uint32(nodeId)
-		cores, err := coresForNode(int(node.Id))
+		node.ID = nodeID
+		cores, err := coresForNode(nodeID)
 		if err != nil {
 			return nil, err
 		}
 		node.Cores = cores
-		caches, err := cachesForNode(int(node.Id))
+		caches, err := cachesForNode(nodeID)
 		if err != nil {
 			return nil, err
 		}

--- a/units.go
+++ b/units.go
@@ -8,11 +8,11 @@ package ghw
 
 var (
 	KB int64 = 1024
-	MB int64 = KB * 1024
-	GB int64 = MB * 1024
-	TB int64 = GB * 1024
-	PB int64 = TB * 1024
-	EB int64 = PB * 1024
+	MB       = KB * 1024
+	GB       = MB * 1024
+	TB       = GB * 1024
+	PB       = TB * 1024
+	EB       = PB * 1024
 )
 
 func unitWithString(size int64) (int64, string) {


### PR DESCRIPTION
Lots of linter suggestion fixes around variable and function naming, missing doc comments, type redundancies.

Issue #51