### PR TITLE
testing Windows and OSX build environments

### DIFF
--- a/.get-go-packages.sh
+++ b/.get-go-packages.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+export GO_PACKAGES=$(go list ./... | grep -v /vendor/)

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,15 @@ language: go
 # Using sudo triggers a real virtual machine as opposed to a container, which
 # allows ghw to actually determine things like host memory or block storage...
 sudo: required
-env:
-  - GHW_TESTING_SKIP_GPU=1
+os:
+  - windows
+  - linux
+  - osx
+install:
+  - go get -u github.com/golang/dep/cmd/dep
+before_script:
+  - dep ensure -v
+  - source ./.get-go-packages.sh
 script:
   - make test
   - go run cmd/ghwc/main.go


### PR DESCRIPTION
Adds Windows and OSX build environments to the TravisCI configuration.
These platforms are not supported but should be stubbed out at the very
least so ghw doesn't blow up like a minefield for users...

Issue #8
Issue #39