### PR TITLE
Move to pcidb 0.2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,16 +8,22 @@
   version = "v1.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/jaypipes/pcidb"
   packages = ["."]
-  revision = "707f051d2e53f280dbcd4673b856a8ebf051eb05"
+  revision = "a366ef0d1cd2ab000beb0a21a73793455c3b693f"
+  version = "0.2"
 
 [[projects]]
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
   revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   name = "github.com/spf13/cobra"
@@ -34,6 +40,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f59c3f1328beb18170f712acf703800f4d85d061cf41eef3e2058ffc4ff4bd5c"
+  inputs-digest = "ed869e2dd2448260e7cb8fa3eddcf9488d2c5724902ac5649ed09747e91b7006"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,7 +3,7 @@
 
 [[constraint]]
   name = "github.com/jaypipes/pcidb"
-  branch = "master"
+  version = "0.2"
 
 [[constraint]]
   name = "github.com/spf13/cobra"

--- a/pci.go
+++ b/pci.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	_RE_PCI_ADDRESS *regexp.Regexp = regexp.MustCompile(
+	regexPCIAddress *regexp.Regexp = regexp.MustCompile(
 		`^(([0-9a-f]{0,4}):)?([0-9a-f]{2}):([0-9a-f]{2})\.([0-9a-f]{1})$`,
 	)
 )
@@ -77,7 +77,7 @@ type PCIAddress struct {
 // Returns "" if the address string wasn't a valid PCI address.
 func PCIAddressFromString(address string) *PCIAddress {
 	addrLowered := strings.ToLower(address)
-	matches := _RE_PCI_ADDRESS.FindStringSubmatch(addrLowered)
+	matches := regexPCIAddress.FindStringSubmatch(addrLowered)
 	if len(matches) == 6 {
 		dom := "0000"
 		if matches[1] != "" {

--- a/pci_linux.go
+++ b/pci_linux.go
@@ -97,7 +97,7 @@ func findPCIVendor(info *PCIInfo, vendorID string) *pcidb.PCIVendor {
 	vendor := info.Vendors[vendorID]
 	if vendor == nil {
 		return &pcidb.PCIVendor{
-			Id:       vendorID,
+			ID:       vendorID,
 			Name:     UNKNOWN,
 			Products: []*pcidb.PCIProduct{},
 		}
@@ -117,7 +117,7 @@ func findPCIProduct(
 	product := info.Products[vendorID+productID]
 	if product == nil {
 		return &pcidb.PCIProduct{
-			Id:         productID,
+			ID:         productID,
 			Name:       UNKNOWN,
 			Subsystems: []*pcidb.PCIProduct{},
 		}
@@ -140,14 +140,14 @@ func findPCISubsystem(
 	subvendor := info.Vendors[subvendorID]
 	if subvendor != nil && product != nil {
 		for _, p := range product.Subsystems {
-			if p.Id == subproductID {
+			if p.ID == subproductID {
 				return p
 			}
 		}
 	}
 	return &pcidb.PCIProduct{
-		VendorId: subvendorID,
-		Id:       subproductID,
+		VendorID: subvendorID,
+		ID:       subproductID,
 		Name:     UNKNOWN,
 	}
 }
@@ -160,7 +160,7 @@ func findPCIClass(info *PCIInfo, classID string) *pcidb.PCIClass {
 	class := info.Classes[classID]
 	if class == nil {
 		return &pcidb.PCIClass{
-			Id:         classID,
+			ID:         classID,
 			Name:       UNKNOWN,
 			Subclasses: []*pcidb.PCISubclass{},
 		}
@@ -180,13 +180,13 @@ func findPCISubclass(
 	class := info.Classes[classID]
 	if class != nil {
 		for _, sc := range class.Subclasses {
-			if sc.Id == subclassID {
+			if sc.ID == subclassID {
 				return sc
 			}
 		}
 	}
 	return &pcidb.PCISubclass{
-		Id:   subclassID,
+		ID:   subclassID,
 		Name: UNKNOWN,
 		ProgrammingInterfaces: []*pcidb.PCIProgrammingInterface{},
 	}
@@ -204,12 +204,12 @@ func findPCIProgrammingInterface(
 ) *pcidb.PCIProgrammingInterface {
 	subclass := findPCISubclass(info, classID, subclassID)
 	for _, pi := range subclass.ProgrammingInterfaces {
-		if pi.Id == progIfaceID {
+		if pi.ID == progIfaceID {
 			return pi
 		}
 	}
 	return &pcidb.PCIProgrammingInterface{
-		Id:   progIfaceID,
+		ID:   progIfaceID,
 		Name: UNKNOWN,
 	}
 }


### PR DESCRIPTION
Lock ourselves in the Gopkg.toml to pcidb 0.2.

0.2 release added ID fields, deprecating the Id fields for PCI structs,
so all this patch does is make use of those new ID fields.

Issue #81