### PR TITLE
Support specifying options in module constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,28 @@ information about the host computer:
 * [PCI](#pci)
 * [GPU](#gpu)
 
-**NOTE**: The default root mountpoint that `ghw` uses when looking for
-information about the host system is `/`. So, for example, when looking up CPU
-information on Linux, `ghw` will attempt to parse the `/proc/cpuinfo` file. If
-you are calling `ghw` from a system that has an alternate root mountpoint, you
-can set the `GHW_CHROOT` environment variable to that alternate path. for
-example, if you are executing from within an application container that has
+
+### Overriding the root mountpoint `ghw` uses
+
+The default root mountpoint that `ghw` uses when looking for information about
+the host system is `/`. So, for example, when looking up CPU information on a
+Linux system, `ghw.CPU()` will use the path `/proc/cpuinfo`.
+
+If you are calling `ghw` from a system that has an alternate root mountpoint,
+you can either set the `GHW_CHROOT` environment variable to that alternate
+path, or call the module constructor function with the `ghw.WithChroot()`
+modifier.
+
+For example, if you are executing from within an application container that has
 bind-mounted the root host filesystem to the mount point `/host`, you would set
-`GHW_CHROOT` to `/host` so that `ghw` can find files like `/proc/cpuinfo` at
+`GHW_CHROOT` to `/host` so that `ghw` can find `/proc/cpuinfo` at
 `/host/proc/cpuinfo`.
+
+Alternately, you can use the `ghw.WithChroot()` function like so:
+
+```go
+cpu, err := ghw.CPU(ghw.WithChroot("/host"))
+```
 
 ### Memory
 

--- a/block.go
+++ b/block.go
@@ -47,10 +47,13 @@ type BlockInfo struct {
 
 // Block returns a BlockInfo struct that describes the block storage resources
 // of the host system.
-func Block() (*BlockInfo, error) {
+func Block(opts ...*WithOption) (*BlockInfo, error) {
+	mergeOpts := mergeOptions(opts...)
+	ctx := &context{
+		chroot: *mergeOpts.Chroot,
+	}
 	info := &BlockInfo{}
-	err := blockFillInfo(info)
-	if err != nil {
+	if err := ctx.blockFillInfo(info); err != nil {
 		return nil, err
 	}
 	return info, nil

--- a/block_test.go
+++ b/block_test.go
@@ -17,8 +17,12 @@ func TestBlock(t *testing.T) {
 	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_BLOCK"); ok {
 		t.Skip("Skipping block tests.")
 	}
-	info, err := Block()
-	if err != nil {
+
+	ctx := contextFromEnv()
+
+	info := &BlockInfo{}
+
+	if err := ctx.blockFillInfo(info); err != nil {
 		t.Fatalf("Expected no error creating BlockInfo, but got %v", err)
 	}
 	tpb := info.TotalPhysicalBytes
@@ -63,22 +67,22 @@ func TestBlock(t *testing.T) {
 	for _, p := range d0.Partitions {
 		// Check that all the singular functions return the same information as
 		// the information constructed by ghw.Block()
-		ps := partitionSizeBytes(p.Name)
+		ps := ctx.partitionSizeBytes(p.Name)
 		if ps != p.SizeBytes {
 			t.Fatalf("Expected matching size, but got %d != %d",
 				ps, p.SizeBytes)
 		}
-		pmp := partitionMountPoint(p.Name)
+		pmp := ctx.partitionMountPoint(p.Name)
 		if pmp != p.MountPoint {
 			t.Fatalf("Expected matching mountpoints, but got %s != %s",
 				pmp, p.MountPoint)
 		}
-		pt := partitionType(p.Name)
+		pt := ctx.partitionType(p.Name)
 		if pt != p.Type {
 			t.Fatalf("Expected matching types, but got %s != %s",
 				pt, p.Type)
 		}
-		pro := partitionIsReadOnly(p.Name)
+		pro := ctx.partitionIsReadOnly(p.Name)
 		if pro != p.IsReadOnly {
 			t.Fatalf("Expected matching readonly, but got %v != %v",
 				pro, p.IsReadOnly)

--- a/cpu.go
+++ b/cpu.go
@@ -87,10 +87,13 @@ type CPUInfo struct {
 }
 
 // CPU returns a struct containing information about the host's CPU resources.
-func CPU() (*CPUInfo, error) {
+func CPU(opts ...*WithOption) (*CPUInfo, error) {
+	mergeOpts := mergeOptions(opts...)
+	ctx := &context{
+		chroot: *mergeOpts.Chroot,
+	}
 	info := &CPUInfo{}
-	err := cpuFillInfo(info)
-	if err != nil {
+	if err := ctx.cpuFillInfo(info); err != nil {
 		return nil, err
 	}
 	return info, nil

--- a/cpu_linux.go
+++ b/cpu_linux.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 )
 
-func cpuFillInfo(info *CPUInfo) error {
-	info.Processors = processorsGet()
+func (ctx *context) cpuFillInfo(info *CPUInfo) error {
+	info.Processors = ctx.processorsGet()
 	var totCores uint32
 	var totThreads uint32
 	for _, p := range info.Processors {
@@ -32,13 +32,14 @@ func cpuFillInfo(info *CPUInfo) error {
 // the CPUInfo.Processors attribute.
 // TODO(jaypipes): Remove in 1.0
 func Processors() []*Processor {
-	return processorsGet()
+	ctx := contextFromEnv()
+	return ctx.processorsGet()
 }
 
-func processorsGet() []*Processor {
+func (ctx *context) processorsGet() []*Processor {
 	procs := make([]*Processor, 0)
 
-	r, err := os.Open(pathProcCpuinfo())
+	r, err := os.Open(ctx.pathProcCpuinfo())
 	if err != nil {
 		return nil
 	}
@@ -149,14 +150,14 @@ func processorsGet() []*Processor {
 	return procs
 }
 
-func coresForNode(nodeID int) ([]*ProcessorCore, error) {
+func (ctx *context) coresForNode(nodeID int) ([]*ProcessorCore, error) {
 	// The /sys/devices/system/node/nodeX directory contains a subdirectory
 	// called 'cpuX' for each logical processor assigned to the node. Each of
 	// those subdirectories contains a topology subdirectory which has a
 	// core_id file that indicates the 0-based identifier of the physical core
 	// the logical processor (hardware thread) is on.
 	path := filepath.Join(
-		pathSysDevicesSystemNode(),
+		ctx.pathSysDevicesSystemNode(),
 		fmt.Sprintf("node%d", nodeID),
 	)
 	cores := make([]*ProcessorCore, 0)

--- a/gpu.go
+++ b/gpu.go
@@ -45,10 +45,13 @@ type GPUInfo struct {
 	GraphicsCards []*GraphicsCard
 }
 
-func GPU() (*GPUInfo, error) {
+func GPU(opts ...*WithOption) (*GPUInfo, error) {
+	mergeOpts := mergeOptions(opts...)
+	ctx := &context{
+		chroot: *mergeOpts.Chroot,
+	}
 	info := &GPUInfo{}
-	err := gpuFillInfo(info)
-	if err != nil {
+	if err := ctx.gpuFillInfo(info); err != nil {
 		return nil, err
 	}
 	return info, nil

--- a/main.go
+++ b/main.go
@@ -19,37 +19,39 @@ type HostInfo struct {
 	GPU      *GPUInfo
 }
 
+// Host returns a pointer to a HostInfo struct that contains fields with
+// information about the host system's CPU, memory, network devices, etc
 func Host() (*HostInfo, error) {
-	info := &HostInfo{}
 	mem, err := Memory()
 	if err != nil {
 		return nil, err
 	}
-	info.Memory = mem
 	block, err := Block()
 	if err != nil {
 		return nil, err
 	}
-	info.Block = block
 	cpu, err := CPU()
 	if err != nil {
 		return nil, err
 	}
-	info.CPU = cpu
 	topology, err := Topology()
 	if err != nil {
 		return nil, err
 	}
-	info.Topology = topology
 	net, err := Network()
 	if err != nil {
 		return nil, err
 	}
-	info.Network = net
 	gpu, err := GPU()
 	if err != nil {
 		return nil, err
 	}
-	info.GPU = gpu
-	return info, nil
+	return &HostInfo{
+		CPU:      cpu,
+		Memory:   mem,
+		Block:    block,
+		Topology: topology,
+		Network:  net,
+		GPU:      gpu,
+	}, nil
 }

--- a/memory.go
+++ b/memory.go
@@ -18,10 +18,13 @@ type MemoryInfo struct {
 	SupportedPageSizes []uint64
 }
 
-func Memory() (*MemoryInfo, error) {
+func Memory(opts ...*WithOption) (*MemoryInfo, error) {
+	mergeOpts := mergeOptions(opts...)
+	ctx := &context{
+		chroot: *mergeOpts.Chroot,
+	}
 	info := &MemoryInfo{}
-	err := memFillInfo(info)
-	if err != nil {
+	if err := ctx.memFillInfo(info); err != nil {
 		return nil, err
 	}
 	return info, nil

--- a/memory_linux.go
+++ b/memory_linux.go
@@ -71,7 +71,7 @@ func memTotalPhysicalBytes() int64 {
 	// syslog.$NUMBER or syslog.$NUMBER.gz containing system log records. We
 	// search each, stopping when we match a system log record line that
 	// contains physical memory information.
-	logDir := "/var/log"
+	logDir := pathVarLog()
 	logFiles, err := ioutil.ReadDir(logDir)
 	if err != nil {
 		return -1
@@ -129,7 +129,7 @@ func memTotalUsableBytes() int64 {
 	// information, see:
 	//
 	//  https://www.kernel.org/doc/Documentation/filesystems/proc.txt
-	filePath := "/proc/meminfo"
+	filePath := pathProcMeminfo()
 	r, err := os.Open(filePath)
 	if err != nil {
 		return -1
@@ -161,7 +161,7 @@ func memSupportedPageSizes() []uint64 {
 	// In Linux, /sys/kernel/mm/hugepages contains a directory per page size
 	// supported by the kernel. The directory name corresponds to the pattern
 	// 'hugepages-{pagesize}kb'
-	dir := "/sys/kernel/mm/hugepages"
+	dir := pathSysKernelMMHugepages()
 	out := make([]uint64, 0)
 
 	files, err := ioutil.ReadDir(dir)

--- a/memory_linux.go
+++ b/memory_linux.go
@@ -34,23 +34,23 @@ var (
 	_REGEX_SYSLOG_MEMLINE = regexp.MustCompile(`Memory:\s+\d+K\/(\d+)K`)
 )
 
-func memFillInfo(info *MemoryInfo) error {
-	tub := memTotalUsableBytes()
+func (ctx *context) memFillInfo(info *MemoryInfo) error {
+	tub := ctx.memTotalUsableBytes()
 	if tub < 1 {
 		return fmt.Errorf("Could not determine total usable bytes of memory")
 	}
 	info.TotalUsableBytes = tub
-	tpb := memTotalPhysicalBytes()
+	tpb := ctx.memTotalPhysicalBytes()
 	info.TotalPhysicalBytes = tpb
 	if tpb < 1 {
 		warn(_WARN_CANNOT_DETERMINE_PHYSICAL_MEMORY)
 		info.TotalPhysicalBytes = tub
 	}
-	info.SupportedPageSizes = memSupportedPageSizes()
+	info.SupportedPageSizes = ctx.memSupportedPageSizes()
 	return nil
 }
 
-func memTotalPhysicalBytes() int64 {
+func (ctx *context) memTotalPhysicalBytes() int64 {
 	// In Linux, the total physical memory can be determined by looking at the
 	// output of dmidecode, however dmidecode requires root privileges to run,
 	// so instead we examine the system logs for startup information containing
@@ -71,7 +71,7 @@ func memTotalPhysicalBytes() int64 {
 	// syslog.$NUMBER or syslog.$NUMBER.gz containing system log records. We
 	// search each, stopping when we match a system log record line that
 	// contains physical memory information.
-	logDir := pathVarLog()
+	logDir := ctx.pathVarLog()
 	logFiles, err := ioutil.ReadDir(logDir)
 	if err != nil {
 		return -1
@@ -106,7 +106,7 @@ func memTotalPhysicalBytes() int64 {
 	return -1
 }
 
-func memTotalUsableBytes() int64 {
+func (ctx *context) memTotalUsableBytes() int64 {
 	// In Linux, /proc/meminfo contains a set of memory-related amounts, with
 	// lines looking like the following:
 	//
@@ -129,7 +129,7 @@ func memTotalUsableBytes() int64 {
 	// information, see:
 	//
 	//  https://www.kernel.org/doc/Documentation/filesystems/proc.txt
-	filePath := pathProcMeminfo()
+	filePath := ctx.pathProcMeminfo()
 	r, err := os.Open(filePath)
 	if err != nil {
 		return -1
@@ -157,11 +157,11 @@ func memTotalUsableBytes() int64 {
 	return -1
 }
 
-func memSupportedPageSizes() []uint64 {
+func (ctx *context) memSupportedPageSizes() []uint64 {
 	// In Linux, /sys/kernel/mm/hugepages contains a directory per page size
 	// supported by the kernel. The directory name corresponds to the pattern
 	// 'hugepages-{pagesize}kb'
-	dir := pathSysKernelMMHugepages()
+	dir := ctx.pathSysKernelMMHugepages()
 	out := make([]uint64, 0)
 
 	files, err := ioutil.ReadDir(dir)

--- a/net.go
+++ b/net.go
@@ -39,10 +39,13 @@ type NetworkInfo struct {
 	NICs []*NIC
 }
 
-func Network() (*NetworkInfo, error) {
+func Network(opts ...*WithOption) (*NetworkInfo, error) {
+	mergeOpts := mergeOptions(opts...)
+	ctx := &context{
+		chroot: *mergeOpts.Chroot,
+	}
 	info := &NetworkInfo{}
-	err := netFillInfo(info)
-	if err != nil {
+	if err := ctx.netFillInfo(info); err != nil {
 		return nil, err
 	}
 	return info, nil

--- a/options.go
+++ b/options.go
@@ -1,0 +1,59 @@
+package ghw
+
+import "os"
+
+const (
+	defaultChroot = "/"
+	envKeyChroot  = "GHW_CHROOT"
+)
+
+// optDefaultChroot returns the value of the GHW_CHROOT environs variable or
+// the default value of "/" if not set
+func envOrDefaultChroot() string {
+	// Grab options from the environs by default
+	if val, exists := os.LookupEnv(envKeyChroot); exists {
+		return val
+	}
+	return defaultChroot
+}
+
+// WithOption is used to represent optionally-configured settings. Each field
+// is a pointer to some concrete value so that we can tell when something has
+// been set or left unset.
+type WithOption struct {
+	// To facilitate querying of sysfs filesystems that are bind-mounted to a
+	// non-default root mountpoint, we allow users to set the GHW_CHROOT environ
+	// vairable to an alternate mountpoint. For instance, assume that the user of
+	// ghw is a Golang binary being executed from an application container that has
+	// certain host filesystems bind-mounted into the container at /host. The user
+	// would ensure the GHW_CHROOT environ variable is set to "/host" and ghw will
+	// build its paths from that location instead of /
+	Chroot *string
+}
+
+func WithChroot(dir string) *WithOption {
+	return &WithOption{Chroot: &dir}
+}
+
+func mergeOptions(opts ...*WithOption) *WithOption {
+	merged := &WithOption{}
+	for _, opt := range opts {
+		if opt.Chroot != nil {
+			merged.Chroot = opt.Chroot
+		}
+	}
+	// Set the default value if missing from mergeOpts
+	if merged.Chroot == nil {
+		chroot := envOrDefaultChroot()
+		merged.Chroot = &chroot
+	}
+	return merged
+}
+
+// contextFromEnv returns a pointer to a context struct that has been populated
+// from the environs or default options values
+func contextFromEnv() *context {
+	return &context{
+		chroot: envOrDefaultChroot(),
+	}
+}

--- a/path_linux.go
+++ b/path_linux.go
@@ -6,69 +6,49 @@
 package ghw
 
 import (
-	"os"
 	"path/filepath"
 )
 
-const (
-	DEFAULT_ROOT_PATH = "/"
-)
-
-// To facilitate querying of sysfs filesystems that are bind-mounted to a
-// non-default root mountpoint, we allow users to set the GHW_CHROOT environ
-// vairable to an alternate mountpoint. For instance, assume that the user of
-// ghw is a Golang binary being executed from an application container that has
-// certain host filesystems bind-mounted into the container at /host. The user
-// would ensure the GHW_CHROOT environ variable is set to "/host" and ghw will
-// build its paths from that location instead of /
-func pathRoot() string {
-	path := DEFAULT_ROOT_PATH
-	if override, exists := os.LookupEnv("GHW_CHROOT"); exists {
-		path = override
-	}
-	return path
+func (ctx *context) pathVarLog() string {
+	return filepath.Join(ctx.chroot, "var", "log")
 }
 
-func pathVarLog() string {
-	return filepath.Join(pathRoot(), "var", "log")
+func (ctx *context) pathProcMeminfo() string {
+	return filepath.Join(ctx.chroot, "proc", "meminfo")
 }
 
-func pathProcMeminfo() string {
-	return filepath.Join(pathRoot(), "proc", "meminfo")
+func (ctx *context) pathSysKernelMMHugepages() string {
+	return filepath.Join(ctx.chroot, "sys", "kernel", "mm", "hugepages")
 }
 
-func pathSysKernelMMHugepages() string {
-	return filepath.Join(pathRoot(), "sys", "kernel", "mm", "hugepages")
+func (ctx *context) pathProcCpuinfo() string {
+	return filepath.Join(ctx.chroot, "proc", "cpuinfo")
 }
 
-func pathProcCpuinfo() string {
-	return filepath.Join(pathRoot(), "proc", "cpuinfo")
+func (ctx *context) pathEtcMtab() string {
+	return filepath.Join(ctx.chroot, "etc", "mtab")
 }
 
-func pathEtcMtab() string {
-	return filepath.Join(pathRoot(), "etc", "mtab")
+func (ctx *context) pathSysBlock() string {
+	return filepath.Join(ctx.chroot, "sys", "block")
 }
 
-func pathSysBlock() string {
-	return filepath.Join(pathRoot(), "sys", "block")
+func (ctx *context) pathSysDevicesSystemNode() string {
+	return filepath.Join(ctx.chroot, "sys", "devices", "system", "node")
 }
 
-func pathSysDevicesSystemNode() string {
-	return filepath.Join(pathRoot(), "sys", "devices", "system", "node")
+func (ctx *context) pathSysBusPciDevices() string {
+	return filepath.Join(ctx.chroot, "sys", "bus", "pci", "devices")
 }
 
-func pathSysBusPciDevices() string {
-	return filepath.Join(pathRoot(), "sys", "bus", "pci", "devices")
+func (ctx *context) pathSysClassDrm() string {
+	return filepath.Join(ctx.chroot, "sys", "class", "drm")
 }
 
-func pathSysClassDrm() string {
-	return filepath.Join(pathRoot(), "sys", "class", "drm")
+func (ctx *context) pathSysClassNet() string {
+	return filepath.Join(ctx.chroot, "sys", "class", "net")
 }
 
-func pathSysClassNet() string {
-	return filepath.Join(pathRoot(), "sys", "class", "net")
-}
-
-func pathRunUdevData() string {
-	return filepath.Join(pathRoot(), "run", "udev", "data")
+func (ctx *context) pathRunUdevData() string {
+	return filepath.Join(ctx.chroot, "run", "udev", "data")
 }

--- a/path_linux.go
+++ b/path_linux.go
@@ -29,6 +29,18 @@ func pathRoot() string {
 	return path
 }
 
+func pathVarLog() string {
+	return filepath.Join(pathRoot(), "var", "log")
+}
+
+func pathProcMeminfo() string {
+	return filepath.Join(pathRoot(), "proc", "meminfo")
+}
+
+func pathSysKernelMMHugepages() string {
+	return filepath.Join(pathRoot(), "sys", "kernel", "mm", "hugepages")
+}
+
 func pathProcCpuinfo() string {
 	return filepath.Join(pathRoot(), "proc", "cpuinfo")
 }

--- a/path_linux_test.go
+++ b/path_linux_test.go
@@ -24,18 +24,23 @@ func TestPathRoot(t *testing.T) {
 		defer os.Unsetenv("GHW_CHROOT")
 	}
 
-	// No environment variable is set for GHW_CHROOT, so pathRoot() should
-	// return the default "/"
-	path := pathRoot()
-	if path != DEFAULT_ROOT_PATH {
-		t.Fatalf("Expected pathRoot() to return '/' but got %s", path)
+	ctx := contextFromEnv()
+
+	// No environment variable is set for GHW_CHROOT, so pathProcCpuinfo() should
+	// return the default "/proc/cpuinfo"
+	path := ctx.pathProcCpuinfo()
+	if path != "/proc/cpuinfo" {
+		t.Fatalf("Expected pathProcCpuInfo() to return '/proc/cpuinfo' but got %s", path)
 	}
 
 	// Now set the GHW_CHROOT environ variable and verify that pathRoot()
 	// returns that value
 	os.Setenv("GHW_CHROOT", "/host")
-	path = pathRoot()
-	if path != "/host" {
-		t.Fatalf("Expected pathRoot() to return '/host' but got %s", path)
+
+	ctx = contextFromEnv()
+
+	path = ctx.pathProcCpuinfo()
+	if path != "/host/proc/cpuinfo" {
+		t.Fatalf("Expected pathProcCpuinfo() to return '/host/proc/cpuinfo' but got %s", path)
 	}
 }

--- a/pci.go
+++ b/pci.go
@@ -53,6 +53,7 @@ func (di *PCIDevice) String() string {
 }
 
 type PCIInfo struct {
+	ctx *context
 	// hash of class ID -> class information
 	Classes map[string]*pcidb.PCIClass
 	// hash of vendor ID -> vendor information
@@ -93,10 +94,13 @@ func PCIAddressFromString(address string) *PCIAddress {
 	return nil
 }
 
-func PCI() (*PCIInfo, error) {
+func PCI(opts ...*WithOption) (*PCIInfo, error) {
+	mergeOpts := mergeOptions(opts...)
+	ctx := &context{
+		chroot: *mergeOpts.Chroot,
+	}
 	info := &PCIInfo{}
-	err := pciFillInfo(info)
-	if err != nil {
+	if err := ctx.pciFillInfo(info); err != nil {
 		return nil, err
 	}
 	return info, nil

--- a/topology.go
+++ b/topology.go
@@ -53,14 +53,17 @@ type TopologyInfo struct {
 
 // Topology returns a TopologyInfo struct that describes the system topology of
 // the host hardware
-func Topology() (*TopologyInfo, error) {
+func Topology(opts ...*WithOption) (*TopologyInfo, error) {
+	mergeOpts := mergeOptions(opts...)
+	ctx := &context{
+		chroot: *mergeOpts.Chroot,
+	}
 	info := &TopologyInfo{}
-	err := topologyFillInfo(info)
+	if err := ctx.topologyFillInfo(info); err != nil {
+		return nil, err
+	}
 	for _, node := range info.Nodes {
 		sort.Sort(SortByMemoryCacheLevelTypeFirstProcessor(node.Caches))
-	}
-	if err != nil {
-		return nil, err
 	}
 	return info, nil
 }

--- a/topology_linux.go
+++ b/topology_linux.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 )
 
-func topologyFillInfo(info *TopologyInfo) error {
-	nodes, err := topologyNodes()
+func (ctx *context) topologyFillInfo(info *TopologyInfo) error {
+	nodes, err := ctx.topologyNodes()
 	if err != nil {
 		return err
 	}
@@ -34,13 +34,14 @@ The TopologyNodes() function has been DEPRECATED and will be removed in the 1.0
 release of ghw. Please use the TopologyInfo.Nodes attribute.
 `
 	warn(msg)
-	return topologyNodes()
+	ctx := contextFromEnv()
+	return ctx.topologyNodes()
 }
 
-func topologyNodes() ([]*TopologyNode, error) {
+func (ctx *context) topologyNodes() ([]*TopologyNode, error) {
 	nodes := make([]*TopologyNode, 0)
 
-	files, err := ioutil.ReadDir(pathSysDevicesSystemNode())
+	files, err := ioutil.ReadDir(ctx.pathSysDevicesSystemNode())
 	if err != nil {
 		return nil, err
 	}
@@ -55,12 +56,12 @@ func topologyNodes() ([]*TopologyNode, error) {
 			return nil, err
 		}
 		node.ID = nodeID
-		cores, err := coresForNode(nodeID)
+		cores, err := ctx.coresForNode(nodeID)
 		if err != nil {
 			return nil, err
 		}
 		node.Cores = cores
-		caches, err := cachesForNode(nodeID)
+		caches, err := ctx.cachesForNode(nodeID)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Each module (CPU(), Memory(), Network(), etc...) now supports calling
the main module constructor with zero or more pointers to WithOption
structs. There is only a single option (the CHROOT value for path
construction) but I've designed it so the system is flexible for future
additional options without needing to change the calling interface.

To specify a chroot override for a particular module, use the
WithChroot() function, like so:

```go
mem, err := ghw.Memory(WithChroot("/host"));
```

Issue #86