### PR TITLE
update to pcidb 0.3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,8 +10,8 @@
 [[projects]]
   name = "github.com/jaypipes/pcidb"
   packages = ["."]
-  revision = "a366ef0d1cd2ab000beb0a21a73793455c3b693f"
-  version = "0.2"
+  revision = "141a53e65d4ad43fdbd2760c714344da88f24adb"
+  version = "0.3"
 
 [[projects]]
   name = "github.com/mitchellh/go-homedir"
@@ -40,6 +40,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ed869e2dd2448260e7cb8fa3eddcf9488d2c5724902ac5649ed09747e91b7006"
+  inputs-digest = "d4e1adb583f0a5bc5d521064063b34804ec61cfd9446eacc2230804f38108142"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,7 +3,7 @@
 
 [[constraint]]
   name = "github.com/jaypipes/pcidb"
-  version = "0.2"
+  version = "0.3"
 
 [[constraint]]
   name = "github.com/spf13/cobra"

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ information about the CPUs on the host system.
 
 Each `ghw.Processor` struct contains a number of fields:
 
-* `ghw.Processor.Id` is the physical processor `uint32` ID according to the
+* `ghw.Processor.ID` is the physical processor `uint32` ID according to the
   system
 * `ghw.Processor.NumCores` is the number of physical cores in the processor
   package
@@ -128,7 +128,7 @@ Each `ghw.Processor` struct contains a number of fields:
 
 A `ghw.ProcessorCore` has the following fields:
 
-* `ghw.ProcessorCore.Id` is the `uint32` identifier that the host gave this
+* `ghw.ProcessorCore.ID` is the `uint32` identifier that the host gave this
   core. Note that this does *not* necessarily equate to a zero-based index of
   the core within a physical package. For example, the core IDs for an Intel Core
   i7 are 0, 1, 2, 8, 9, and 10
@@ -310,7 +310,7 @@ The `ghw.TopologyInfo` struct contains two fields:
 
 Each `ghw.TopologyNode` struct contains the following fields:
 
-* `ghw.TopologyNode.Id` is the system's `uint32` identifier for the node
+* `ghw.TopologyNode.ID` is the system's `uint32` identifier for the node
 * `ghw.TopologyNode.Cores` is an array of pointers to `ghw.ProcessorCore` structs that
   are contained in this node
 * `ghw.TopologyNode.Caches` is an array of pointers to `ghw.MemoryCache` structs that
@@ -518,13 +518,13 @@ The `ghw.PCI()` function returns a `ghw.PCIInfo` struct. The `ghw.PCIInfo`
 struct contains a number of fields that may be queried for PCI information:
 
 * `ghw.PCIInfo.Classes` is a map, keyed by the PCI class ID (a hex-encoded
-  string) of pointers to `pcidb.PCIClass` structs, one for each class of PCI
+  string) of pointers to `pcidb.Class` structs, one for each class of PCI
   device known to `ghw`
 * `ghw.PCIInfo.Vendors` is a map, keyed by the PCI vendor ID (a hex-encoded
-  string) of pointers to `pcidb.PCIVendor` structs, one for each PCI vendor
+  string) of pointers to `pcidb.Vendor` structs, one for each PCI vendor
   known to `ghw`
 * `ghw.PCIInfo.Products` is a map, keyed by the PCI product ID* (a hex-encoded
-  string) of pointers to `pcidb.PCIProduct` structs, one for each PCI product
+  string) of pointers to `pcidb.Product` structs, one for each PCI product
   known to `ghw`
 
 **NOTE**: PCI products are often referred to by their "device ID". We use
@@ -543,18 +543,18 @@ This methods return either an array of or a single pointer to a `ghw.PCIDevice`
 struct, which has the following fields:
 
 
-* `ghw.PCIDevice.Vendor` is a pointer to a `pcidb.PCIVendor` struct that
+* `ghw.PCIDevice.Vendor` is a pointer to a `pcidb.Vendor` struct that
   describes the device's primary vendor. This will always be non-nil.
-* `ghw.PCIDevice.Product` is a pointer to a `pcidb.PCIProduct` struct that
+* `ghw.PCIDevice.Product` is a pointer to a `pcidb.Product` struct that
   describes the device's primary product. This will always be non-nil.
-* `ghw.PCIDevice.Subsystem` is a pointer to a `pcidb.PCIProduct` struct that
+* `ghw.PCIDevice.Subsystem` is a pointer to a `pcidb.Product` struct that
   describes the device's secondary/sub-product. This will always be non-nil.
-* `ghw.PCIDevice.Class` is a pointer to a `pcidb.PCIClass` struct that
+* `ghw.PCIDevice.Class` is a pointer to a `pcidb.Class` struct that
   describes the device's class. This will always be non-nil.
-* `ghw.PCIDevice.Subclass` is a pointer to a `pcidb.PCISubclass` struct
+* `ghw.PCIDevice.Subclass` is a pointer to a `pcidb.Subclass` struct
   that describes the device's subclass. This will always be non-nil.
 * `ghw.PCIDevice.ProgrammingInterface` is a pointer to a
-  `pcidb.PCIProgrammingInterface` struct that describes the device subclass'
+  `pcidb.ProgrammingInterface` struct that describes the device subclass'
   programming interface. This will always be non-nil.
 
 The following code snippet shows how to call the `ghw.PCIInfo.ListDevices()`
@@ -694,22 +694,22 @@ func main() {
 	}
 
 	vendor := deviceInfo.Vendor
-	fmt.Printf("Vendor: %s [%s]\n", vendor.Name, vendor.Id)
+	fmt.Printf("Vendor: %s [%s]\n", vendor.Name, vendor.ID)
 	product := deviceInfo.Product
-	fmt.Printf("Product: %s [%s]\n", product.Name, product.Id)
+	fmt.Printf("Product: %s [%s]\n", product.Name, product.ID)
 	subsystem := deviceInfo.Subsystem
-	subvendor := pci.Vendors[subsystem.VendorId]
+	subvendor := pci.Vendors[subsystem.VendorID]
 	subvendorName := "UNKNOWN"
 	if subvendor != nil {
 		subvendorName = subvendor.Name
 	}
-	fmt.Printf("Subsystem: %s [%s] (Subvendor: %s)\n", subsystem.Name, subsystem.Id, subvendorName)
+	fmt.Printf("Subsystem: %s [%s] (Subvendor: %s)\n", subsystem.Name, subsystem.ID, subvendorName)
 	class := deviceInfo.Class
-	fmt.Printf("Class: %s [%s]\n", class.Name, class.Id)
+	fmt.Printf("Class: %s [%s]\n", class.Name, class.ID)
 	subclass := deviceInfo.Subclass
-	fmt.Printf("Subclass: %s [%s]\n", subclass.Name, subclass.Id)
+	fmt.Printf("Subclass: %s [%s]\n", subclass.Name, subclass.ID)
 	progIface := deviceInfo.ProgrammingInterface
-	fmt.Printf("Programming Interface: %s [%s]\n", progIface.Name, progIface.Id)
+	fmt.Printf("Programming Interface: %s [%s]\n", progIface.Name, progIface.ID)
 }
 ```
 

--- a/pci.go
+++ b/pci.go
@@ -22,12 +22,12 @@ var (
 
 type PCIDevice struct {
 	Address              string // The PCI address of the device
-	Vendor               *pcidb.PCIVendor
-	Product              *pcidb.PCIProduct
-	Subsystem            *pcidb.PCIProduct // optional subvendor/sub-device information
-	Class                *pcidb.PCIClass
-	Subclass             *pcidb.PCISubclass             // optional sub-class for the device
-	ProgrammingInterface *pcidb.PCIProgrammingInterface // optional programming interface
+	Vendor               *pcidb.Vendor
+	Product              *pcidb.Product
+	Subsystem            *pcidb.Product // optional subvendor/sub-device information
+	Class                *pcidb.Class
+	Subclass             *pcidb.Subclass             // optional sub-class for the device
+	ProgrammingInterface *pcidb.ProgrammingInterface // optional programming interface
 }
 
 func (di *PCIDevice) String() string {
@@ -55,11 +55,11 @@ func (di *PCIDevice) String() string {
 type PCIInfo struct {
 	ctx *context
 	// hash of class ID -> class information
-	Classes map[string]*pcidb.PCIClass
+	Classes map[string]*pcidb.Class
 	// hash of vendor ID -> vendor information
-	Vendors map[string]*pcidb.PCIVendor
+	Vendors map[string]*pcidb.Vendor
 	// hash of vendor ID + product/device ID -> product information
-	Products map[string]*pcidb.PCIProduct
+	Products map[string]*pcidb.Product
 }
 
 type PCIAddress struct {

--- a/pci_linux.go
+++ b/pci_linux.go
@@ -96,7 +96,7 @@ func parseModaliasFile(fp string) *deviceModaliasInfo {
 // ID string. If no such vendor ID string could be found, returns the
 // pcidb.Vendor struct populated with "unknown" vendor Name attribute and
 // empty Products attribute.
-func findVendor(info *PCIInfo, vendorID string) *pcidb.Vendor {
+func findPCIVendor(info *PCIInfo, vendorID string) *pcidb.Vendor {
 	vendor := info.Vendors[vendorID]
 	if vendor == nil {
 		return &pcidb.Vendor{
@@ -112,7 +112,7 @@ func findVendor(info *PCIInfo, vendorID string) *pcidb.Vendor {
 // and product ID strings. If no such product could be found, returns the
 // pcidb.Product struct populated with "unknown" product Name attribute and
 // empty Subsystems attribute.
-func findProduct(
+func findPCIProduct(
 	info *PCIInfo,
 	vendorID string,
 	productID string,
@@ -159,7 +159,7 @@ func findPCISubsystem(
 // string. If no such class ID string could be found, returns the
 // pcidb.Class struct populated with "unknown" class Name attribute and
 // empty Subclasses attribute.
-func findClass(info *PCIInfo, classID string) *pcidb.Class {
+func findPCIClass(info *PCIInfo, classID string) *pcidb.Class {
 	class := info.Classes[classID]
 	if class == nil {
 		return &pcidb.Class{
@@ -175,7 +175,7 @@ func findClass(info *PCIInfo, classID string) *pcidb.Class {
 // and subclass ID strings.  If no such subclass could be found, returns the
 // pcidb.Subclass struct populated with "unknown" subclass Name attribute
 // and empty ProgrammingInterfaces attribute.
-func findSubclass(
+func findPCISubclass(
 	info *PCIInfo,
 	classID string,
 	subclassID string,
@@ -199,13 +199,13 @@ func findSubclass(
 // supplied class, subclass and programming interface ID strings.  If no such
 // programming interface could be found, returns the
 // pcidb.ProgrammingInterface struct populated with "unknown" Name attribute
-func findProgrammingInterface(
+func findPCIProgrammingInterface(
 	info *PCIInfo,
 	classID string,
 	subclassID string,
 	progIfaceID string,
 ) *pcidb.ProgrammingInterface {
-	subclass := findSubclass(info, classID, subclassID)
+	subclass := findPCISubclass(info, classID, subclassID)
 	for _, pi := range subclass.ProgrammingInterfaces {
 		if pi.ID == progIfaceID {
 			return pi
@@ -231,8 +231,8 @@ func (info *PCIInfo) GetDevice(address string) *PCIDevice {
 		return nil
 	}
 
-	vendor := findVendor(info, modaliasInfo.vendorID)
-	product := findProduct(
+	vendor := findPCIVendor(info, modaliasInfo.vendorID)
+	product := findPCIProduct(
 		info,
 		modaliasInfo.vendorID,
 		modaliasInfo.productID,
@@ -244,13 +244,13 @@ func (info *PCIInfo) GetDevice(address string) *PCIDevice {
 		modaliasInfo.subvendorID,
 		modaliasInfo.subproductID,
 	)
-	class := findClass(info, modaliasInfo.classID)
-	subclass := findSubclass(
+	class := findPCIClass(info, modaliasInfo.classID)
+	subclass := findPCISubclass(
 		info,
 		modaliasInfo.classID,
 		modaliasInfo.subclassID,
 	)
-	progIface := findProgrammingInterface(
+	progIface := findPCIProgrammingInterface(
 		info,
 		modaliasInfo.classID,
 		modaliasInfo.subclassID,

--- a/pci_linux.go
+++ b/pci_linux.go
@@ -92,45 +92,45 @@ func parseModaliasFile(fp string) *deviceModaliasInfo {
 	}
 }
 
-// Returns a pointer to a pcidb.PCIVendor struct matching the supplied vendor
+// Returns a pointer to a pcidb.Vendor struct matching the supplied vendor
 // ID string. If no such vendor ID string could be found, returns the
-// pcidb.PCIVendor struct populated with "unknown" vendor Name attribute and
+// pcidb.Vendor struct populated with "unknown" vendor Name attribute and
 // empty Products attribute.
-func findPCIVendor(info *PCIInfo, vendorID string) *pcidb.PCIVendor {
+func findVendor(info *PCIInfo, vendorID string) *pcidb.Vendor {
 	vendor := info.Vendors[vendorID]
 	if vendor == nil {
-		return &pcidb.PCIVendor{
+		return &pcidb.Vendor{
 			ID:       vendorID,
 			Name:     UNKNOWN,
-			Products: []*pcidb.PCIProduct{},
+			Products: []*pcidb.Product{},
 		}
 	}
 	return vendor
 }
 
-// Returns a pointer to a pcidb.PCIProduct struct matching the supplied vendor
+// Returns a pointer to a pcidb.Product struct matching the supplied vendor
 // and product ID strings. If no such product could be found, returns the
-// pcidb.PCIProduct struct populated with "unknown" product Name attribute and
+// pcidb.Product struct populated with "unknown" product Name attribute and
 // empty Subsystems attribute.
-func findPCIProduct(
+func findProduct(
 	info *PCIInfo,
 	vendorID string,
 	productID string,
-) *pcidb.PCIProduct {
+) *pcidb.Product {
 	product := info.Products[vendorID+productID]
 	if product == nil {
-		return &pcidb.PCIProduct{
+		return &pcidb.Product{
 			ID:         productID,
 			Name:       UNKNOWN,
-			Subsystems: []*pcidb.PCIProduct{},
+			Subsystems: []*pcidb.Product{},
 		}
 	}
 	return product
 }
 
-// Returns a pointer to a pcidb.PCIProduct struct matching the supplied vendor,
+// Returns a pointer to a pcidb.Product struct matching the supplied vendor,
 // product, subvendor and subproduct ID strings. If no such product could be
-// found, returns the pcidb.PCIProduct struct populated with "unknown" product
+// found, returns the pcidb.Product struct populated with "unknown" product
 // Name attribute and empty Subsystems attribute.
 func findPCISubsystem(
 	info *PCIInfo,
@@ -138,7 +138,7 @@ func findPCISubsystem(
 	productID string,
 	subvendorID string,
 	subproductID string,
-) *pcidb.PCIProduct {
+) *pcidb.Product {
 	product := info.Products[vendorID+productID]
 	subvendor := info.Vendors[subvendorID]
 	if subvendor != nil && product != nil {
@@ -148,38 +148,38 @@ func findPCISubsystem(
 			}
 		}
 	}
-	return &pcidb.PCIProduct{
+	return &pcidb.Product{
 		VendorID: subvendorID,
 		ID:       subproductID,
 		Name:     UNKNOWN,
 	}
 }
 
-// Returns a pointer to a pcidb.PCIClass struct matching the supplied class ID
+// Returns a pointer to a pcidb.Class struct matching the supplied class ID
 // string. If no such class ID string could be found, returns the
-// pcidb.PCIClass struct populated with "unknown" class Name attribute and
+// pcidb.Class struct populated with "unknown" class Name attribute and
 // empty Subclasses attribute.
-func findPCIClass(info *PCIInfo, classID string) *pcidb.PCIClass {
+func findClass(info *PCIInfo, classID string) *pcidb.Class {
 	class := info.Classes[classID]
 	if class == nil {
-		return &pcidb.PCIClass{
+		return &pcidb.Class{
 			ID:         classID,
 			Name:       UNKNOWN,
-			Subclasses: []*pcidb.PCISubclass{},
+			Subclasses: []*pcidb.Subclass{},
 		}
 	}
 	return class
 }
 
-// Returns a pointer to a pcidb.PCISubclass struct matching the supplied class
+// Returns a pointer to a pcidb.Subclass struct matching the supplied class
 // and subclass ID strings.  If no such subclass could be found, returns the
-// pcidb.PCISubclass struct populated with "unknown" subclass Name attribute
+// pcidb.Subclass struct populated with "unknown" subclass Name attribute
 // and empty ProgrammingInterfaces attribute.
-func findPCISubclass(
+func findSubclass(
 	info *PCIInfo,
 	classID string,
 	subclassID string,
-) *pcidb.PCISubclass {
+) *pcidb.Subclass {
 	class := info.Classes[classID]
 	if class != nil {
 		for _, sc := range class.Subclasses {
@@ -188,30 +188,30 @@ func findPCISubclass(
 			}
 		}
 	}
-	return &pcidb.PCISubclass{
+	return &pcidb.Subclass{
 		ID:   subclassID,
 		Name: UNKNOWN,
-		ProgrammingInterfaces: []*pcidb.PCIProgrammingInterface{},
+		ProgrammingInterfaces: []*pcidb.ProgrammingInterface{},
 	}
 }
 
-// Returns a pointer to a pcidb.PCIProgrammingInterface struct matching the
+// Returns a pointer to a pcidb.ProgrammingInterface struct matching the
 // supplied class, subclass and programming interface ID strings.  If no such
 // programming interface could be found, returns the
-// pcidb.PCIProgrammingInterface struct populated with "unknown" Name attribute
-func findPCIProgrammingInterface(
+// pcidb.ProgrammingInterface struct populated with "unknown" Name attribute
+func findProgrammingInterface(
 	info *PCIInfo,
 	classID string,
 	subclassID string,
 	progIfaceID string,
-) *pcidb.PCIProgrammingInterface {
-	subclass := findPCISubclass(info, classID, subclassID)
+) *pcidb.ProgrammingInterface {
+	subclass := findSubclass(info, classID, subclassID)
 	for _, pi := range subclass.ProgrammingInterfaces {
 		if pi.ID == progIfaceID {
 			return pi
 		}
 	}
-	return &pcidb.PCIProgrammingInterface{
+	return &pcidb.ProgrammingInterface{
 		ID:   progIfaceID,
 		Name: UNKNOWN,
 	}
@@ -231,8 +231,8 @@ func (info *PCIInfo) GetDevice(address string) *PCIDevice {
 		return nil
 	}
 
-	vendor := findPCIVendor(info, modaliasInfo.vendorID)
-	product := findPCIProduct(
+	vendor := findVendor(info, modaliasInfo.vendorID)
+	product := findProduct(
 		info,
 		modaliasInfo.vendorID,
 		modaliasInfo.productID,
@@ -244,13 +244,13 @@ func (info *PCIInfo) GetDevice(address string) *PCIDevice {
 		modaliasInfo.subvendorID,
 		modaliasInfo.subproductID,
 	)
-	class := findPCIClass(info, modaliasInfo.classID)
-	subclass := findPCISubclass(
+	class := findClass(info, modaliasInfo.classID)
+	subclass := findSubclass(
 		info,
 		modaliasInfo.classID,
 		modaliasInfo.subclassID,
 	)
-	progIface := findPCIProgrammingInterface(
+	progIface := findProgrammingInterface(
 		info,
 		modaliasInfo.classID,
 		modaliasInfo.subclassID,


### PR DESCRIPTION
Brings in support for the pcidb 0.3 library, which is a
backwards-incompatible release of pcidb. This is why you always pin
dependencies on specific tags/releases!

Issue #87