### PR TITLE
Moves ghwc client code into cmd/ghwc/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,7 +804,7 @@ You can run unit tests easily using the `make test` command, like so:
 
 ```
 [jaypipes@uberbox ghw]$ make test
-go test github.com/jaypipes/ghw github.com/jaypipes/ghw/ghwc
+go test github.com/jaypipes/ghw github.com/jaypipes/ghw/cmd/ghwc
 ok      github.com/jaypipes/ghw 0.084s
-?       github.com/jaypipes/ghw/ghwc    [no test files]
+?       github.com/jaypipes/ghw/cmd/ghwc    [no test files]
 ```

--- a/cmd/ghwc/commands/block.go
+++ b/cmd/ghwc/commands/block.go
@@ -4,7 +4,7 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package cmd
+package commands
 
 import (
 	"fmt"

--- a/cmd/ghwc/commands/cpu.go
+++ b/cmd/ghwc/commands/cpu.go
@@ -4,7 +4,7 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package cmd
+package commands
 
 import (
 	"fmt"

--- a/cmd/ghwc/commands/gpu.go
+++ b/cmd/ghwc/commands/gpu.go
@@ -4,7 +4,7 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package cmd
+package commands
 
 import (
 	"fmt"

--- a/cmd/ghwc/commands/memory.go
+++ b/cmd/ghwc/commands/memory.go
@@ -4,7 +4,7 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package cmd
+package commands
 
 import (
 	"fmt"

--- a/cmd/ghwc/commands/net.go
+++ b/cmd/ghwc/commands/net.go
@@ -4,7 +4,7 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package cmd
+package commands
 
 import (
 	"fmt"

--- a/cmd/ghwc/commands/root.go
+++ b/cmd/ghwc/commands/root.go
@@ -4,7 +4,7 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package cmd
+package commands
 
 import (
 	"fmt"

--- a/cmd/ghwc/commands/topology.go
+++ b/cmd/ghwc/commands/topology.go
@@ -4,7 +4,7 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package cmd
+package commands
 
 import (
 	"fmt"

--- a/cmd/ghwc/commands/version.go
+++ b/cmd/ghwc/commands/version.go
@@ -4,7 +4,7 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package cmd
+package commands
 
 import (
 	"fmt"

--- a/cmd/ghwc/main.go
+++ b/cmd/ghwc/main.go
@@ -7,7 +7,7 @@
 package main
 
 import (
-	"github.com/jaypipes/ghw/ghwc/cmd"
+	"github.com/jaypipes/ghw/cmd/ghwc/commands"
 )
 
 var (
@@ -20,5 +20,5 @@ var (
 )
 
 func main() {
-	cmd.Execute(version, buildHash, buildDate)
+	commands.Execute(version, buildHash, buildDate)
 }


### PR DESCRIPTION
`ghw` was started before the Golang community standardized best
practices of having a `cmd/` directory contain all CLI tools for a
project. This patch simply moves the location of the sample `ghwc` CLI
tool to this best practice `cmd/ghwc/` directory.

You can install ghwc using `go get github.com/jaypipes/ghw/cmd/ghwc`

Issue #90