### PR TITLE
Adjust *_stub.go to new internal context API

### DIFF
--- a/block_stub.go
+++ b/block_stub.go
@@ -12,70 +12,256 @@ import (
 	"github.com/pkg/errors"
 )
 
-func blockFillInfo(info *BlockInfo) error {
+func (ctx *context) blockFillInfo(info *BlockInfo) error {
 	return errors.New("blockFillInfo not implemented on " + runtime.GOOS)
 }
 
+// DiskPhysicalBlockSizeBytes has been deprecated in 0.2. Please use the
+// Disk.PhysicalBlockSizeBytes attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskPhysicalBlockSizeBytes(disk string) uint64 {
+	msg := `
+The DiskPhysicalBlockSizeBytes() function has been DEPRECATED and will be
+removed in the 1.0 release of ghw. Please use the Disk.PhysicalBlockSizeBytes
+attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.diskPhysicalBlockSizeBytes(disk)
+}
+
+func (ctx *context) diskPhysicalBlockSizeBytes(disk string) uint64 {
 	return 0
 }
 
+// DiskSizeBytes has been deprecated in 0.2. Please use the Disk.SizeBytes
+// attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskSizeBytes(disk string) uint64 {
+	msg := `
+The DiskSizeBytes() function has been DEPRECATED and will be
+removed in the 1.0 release of ghw. Please use the Disk.SizeBytes attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.diskSizeBytes(disk)
+}
+
+func (ctx *context) diskSizeBytes(disk string) uint64 {
 	return 0
 }
 
+// DiskNUMANodeID has been deprecated in 0.2. Please use the Disk.NUMANodeID
+// attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskNUMANodeID(disk string) int {
+	msg := `
+The DiskNUMANodeID() function has been DEPRECATED and will be
+removed in the 1.0 release of ghw. Please use the Disk.NUMANodeID attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.diskNUMANodeID(disk)
+}
+
+func (ctx *context) diskNUMANodeID(disk string) int {
 	return -1
 }
 
+// DiskVendor has been deprecated in 0.2. Please use the Disk.Vendor attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskVendor(disk string) string {
+	msg := `
+The DiskVendor() function has been DEPRECATED and will be
+removed in the 1.0 release of ghw. Please use the Disk.Vendor attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.diskVendor(disk)
+}
+
+func (ctx *context) diskVendor(disk string) string {
 	return UNKNOWN
 }
 
+// DiskModel has been deprecated in 0.2. Please use the Disk.Model attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskModel(disk string) string {
+	msg := `
+The DiskModel() function has been DEPRECATED and will be removed in the 1.0
+release of ghw. Please use the Disk.Model attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.diskModel(disk)
+}
+
+func (ctx *context) diskModel(disk string) string {
 	return UNKNOWN
 }
 
+// DiskSerialNumber has been deprecated in 0.2. Please use the Disk.SerialNumber attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskSerialNumber(disk string) string {
+	msg := `
+The DiskSerialNumber() function has been DEPRECATED and will be removed in the
+1.0 release of ghw. Please use the Disk.SerialNumber attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.diskSerialNumber(disk)
+}
+
+func (ctx *context) diskSerialNumber(disk string) string {
 	return UNKNOWN
 }
 
+// DiskBusPath has been deprecated in 0.2. Please use the Disk.BusPath attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskBusPath(disk string) string {
+	msg := `
+The DiskBusPath() function has been DEPRECATED and will be removed in the 1.0
+release of ghw. Please use the Disk.BusPath attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.diskBusPath(disk)
+}
+
+func (ctx *context) diskBusPath(disk string) string {
 	return UNKNOWN
 }
 
+// DiskWWN has been deprecated in 0.2. Please use the Disk.WWN attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskWWN(disk string) string {
+	msg := `
+The DiskWWN() function has been DEPRECATED and will be removed in the 1.0
+release of ghw. Please use the Disk.WWN attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.diskWWN(disk)
+}
+
+func (ctx *context) diskWWN(disk string) string {
 	return UNKNOWN
 }
 
+// DiskPartitions has been deprecated in 0.2. Please use the Disk.Partitions attribute.
+// TODO(jaypipes): Remove in 1.0.
 func DiskPartitions(disk string) []*Partition {
+	msg := `
+The DiskPartitions() function has been DEPRECATED and will be removed in the
+1.0 release of ghw. Please use the Disk.Partitions attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.diskPartitions(disk)
+}
+
+func (ctx *context) diskPartitions(disk string) []*Partition {
 	return nil
 }
 
+// Disks has been deprecated in 0.2. Please use the BlockInfo.Disks attribute.
+// TODO(jaypipes): Remove in 1.0.
 func Disks() []*Disk {
+	msg := `
+The Disks() function has been DEPRECATED and will be removed in the
+1.0 release of ghw. Please use the BlockInfo.Disks attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.disks()
+}
+
+func (ctx *context) disks() []*Disk {
 	return nil
 }
 
+// PartitionSizeBytes has been deprecated in 0.2. Please use the
+// Partition.SizeBytes attribute.  TODO(jaypipes): Remove in 1.0.
 func PartitionSizeBytes(part string) uint64 {
+	msg := `
+The PartitionSizeBytes() function has been DEPRECATED and will be removed in
+the 1.0 release of ghw. Please use the Partition.SizeBytes attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.partitionSizeBytes(part)
+}
+
+func (ctx *context) partitionSizeBytes(part string) uint64 {
 	return 0
 }
 
+// PartitionInfo has been deprecated in 0.2. Please use the Partition struct.
+// TODO(jaypipes): Remove in 1.0.
 func PartitionInfo(part string) (string, string, bool) {
+	msg := `
+The PartitionInfo() function has been DEPRECATED and will be removed in
+the 1.0 release of ghw. Please use the Partition struct.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.partitionInfo(part)
+}
+
+// Given a full or short partition name, returns the mount point, the type of
+// the partition and whether it's readonly
+func (ctx *context) partitionInfo(part string) (string, string, bool) {
 	// full name, short name, read-only
 	return "", "", true
 }
 
+// PartitionMountPoint has been deprecated in 0.2. Please use the
+// Partition.MountPoint attribute.  TODO(jaypipes): Remove in 1.0.
 func PartitionMountPoint(part string) string {
-	mp, _, _ := PartitionInfo(part)
+	msg := `
+The PartitionMountPoint() function has been DEPRECATED and will be removed in
+the 1.0 release of ghw. Please use the Partition.MountPoint attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.partitionMountPoint(part)
+}
+
+func (ctx *context) partitionMountPoint(part string) string {
+	mp, _, _ := ctx.partitionInfo(part)
 	return mp
 }
 
+// PartitionType has been deprecated in 0.2. Please use the
+// Partition.Type attribute.  TODO(jaypipes): Remove in 1.0.
 func PartitionType(part string) string {
-	_, pt, _ := PartitionInfo(part)
+	msg := `
+The PartitionType() function has been DEPRECATED and will be removed in
+the 1.0 release of ghw. Please use the Partition.Type attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.partitionType(part)
+}
+
+func (ctx *context) partitionType(part string) string {
+	_, pt, _ := ctx.partitionInfo(part)
 	return pt
 }
 
+// PartitionIsReadOnly has been deprecated in 0.2. Please use the
+// Partition.IsReadOnly attribute.  TODO(jaypipes): Remove in 1.0.
 func PartitionIsReadOnly(part string) bool {
-	_, _, ro := PartitionInfo(part)
+	msg := `
+The PartitionIsReadOnly() function has been DEPRECATED and will be removed in
+the 1.0 release of ghw. Please use the Partition.IsReadOnly attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.partitionIsReadOnly(part)
+}
+
+func (ctx *context) partitionIsReadOnly(part string) bool {
+	_, _, ro := ctx.partitionInfo(part)
 	return ro
 }

--- a/cpu_stub.go
+++ b/cpu_stub.go
@@ -12,10 +12,18 @@ import (
 	"github.com/pkg/errors"
 )
 
-func cpuFillInfo(info *CPUInfo) error {
+func (ctx *context) cpuFillInfo(info *CPUInfo) error {
 	return errors.New("cpuFillInfo not implemented on " + runtime.GOOS)
 }
 
+// Processors has been DEPRECATED in 0.2 and will be REMOVED in 1.0. Please use
+// the CPUInfo.Processors attribute.
+// TODO(jaypipes): Remove in 1.0
 func Processors() []*Processor {
 	return nil
+}
+
+// TODO: remove
+func (ctx *context) coresForNode(nodeID int) ([]*ProcessorCore, error) {
+	return nil, errors.New("coresForNode not implemented on " + runtime.GOOS)
 }

--- a/gpu_stub.go
+++ b/gpu_stub.go
@@ -12,6 +12,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func gpuFillInfo(info *GPUInfo) error {
+func (ctx *context) gpuFillInfo(info *GPUInfo) error {
 	return errors.New("gpuFillInfo not implemented on " + runtime.GOOS)
 }

--- a/memory_stub.go
+++ b/memory_stub.go
@@ -12,6 +12,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func memFillInfo(info *MemoryInfo) error {
+func (ctx *context) memFillInfo(info *MemoryInfo) error {
 	return errors.New("memFillInfo not implemented on " + runtime.GOOS)
 }

--- a/net_stub.go
+++ b/net_stub.go
@@ -12,10 +12,22 @@ import (
 	"github.com/pkg/errors"
 )
 
-func netFillInfo(info *NetworkInfo) error {
+func (ctx *context) netFillInfo(info *NetworkInfo) error {
 	return errors.New("netFillInfo not implemented on " + runtime.GOOS)
 }
 
+// NICS has been deprecated in 0.2. Please use the NetworkInfo.NICs attribute.
+// TODO(jaypipes): Remove in 1.0.
 func NICs() []*NIC {
+	msg := `
+The NICs() function has been DEPRECATED and will be removed in the 1.0 release
+of ghw. Please use the NetworkInfo.NICs attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.nics()
+}
+
+func (ctx *context) nics() []*NIC {
 	return nil
 }

--- a/pci_stub.go
+++ b/pci_stub.go
@@ -12,14 +12,19 @@ import (
 	"github.com/pkg/errors"
 )
 
-func pciFillInfo(info *PCIInfo) error {
+func (ctx *context) pciFillInfo(info *PCIInfo) error {
 	return errors.New("pciFillInfo not implemented on " + runtime.GOOS)
 }
 
+// GetDevice returns a pointer to a PCIDevice struct that describes the PCI
+// device at the requested address. If no such device could be found, returns
+// nil
 func (info *PCIInfo) GetDevice(address string) *PCIDevice {
 	return nil
 }
 
+// ListDevices returns a list of pointers to PCIDevice structs present on the
+// host system
 func (info *PCIInfo) ListDevices() []*PCIDevice {
 	return nil
 }

--- a/topology_stub.go
+++ b/topology_stub.go
@@ -12,10 +12,23 @@ import (
 	"github.com/pkg/errors"
 )
 
-func topologyFillInfo(info *TopologyInfo) error {
+func (ctx *context) topologyFillInfo(info *TopologyInfo) error {
 	return errors.New("topologyFillInfo not implemented on " + runtime.GOOS)
 }
 
+// TopologyNodes has been deprecated in 0.2. Please use the TopologyInfo.Nodes
+// attribute.
+// TODO(jaypipes): Remove in 1.0.
 func TopologyNodes() ([]*TopologyNode, error) {
+	msg := `
+The TopologyNodes() function has been DEPRECATED and will be removed in the 1.0
+release of ghw. Please use the TopologyInfo.Nodes attribute.
+`
+	warn(msg)
+	ctx := contextFromEnv()
+	return ctx.topologyNodes()
+}
+
+func (ctx *context) topologyNodes() ([]*TopologyNode, error) {
 	return nil, errors.New("Don't know how to get topology on " + runtime.GOOS)
 }


### PR DESCRIPTION
This fixes the build on !linux again (tested on macOS), although still doesn't report anything useful there.