### PR TITLE
ghwc: Gather only the info required in each subcommand

### DIFF
--- a/cmd/ghwc/commands/block.go
+++ b/cmd/ghwc/commands/block.go
@@ -9,6 +9,8 @@ package commands
 import (
 	"fmt"
 
+	"github.com/jaypipes/ghw"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +23,11 @@ var blockCmd = &cobra.Command{
 
 // showBlock show block storage information for the host system.
 func showBlock(cmd *cobra.Command, args []string) error {
-	block := info.Block
+	block, err := ghw.Block()
+	if err != nil {
+		return errors.Wrap(err, "error getting block device info")
+	}
+
 	fmt.Printf("%v\n", block)
 
 	for _, disk := range block.Disks {

--- a/cmd/ghwc/commands/cpu.go
+++ b/cmd/ghwc/commands/cpu.go
@@ -11,6 +11,8 @@ import (
 	"math"
 	"strings"
 
+	"github.com/jaypipes/ghw"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +25,11 @@ var cpuCmd = &cobra.Command{
 
 // showCPU show CPU information for the host system.
 func showCPU(cmd *cobra.Command, args []string) error {
-	cpu := info.CPU
+	cpu, err := ghw.CPU()
+	if err != nil {
+		return errors.Wrap(err, "error getting CPU info")
+	}
+
 	fmt.Printf("%v\n", cpu)
 
 	for _, proc := range cpu.Processors {

--- a/cmd/ghwc/commands/gpu.go
+++ b/cmd/ghwc/commands/gpu.go
@@ -9,6 +9,8 @@ package commands
 import (
 	"fmt"
 
+	"github.com/jaypipes/ghw"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +23,11 @@ var gpuCmd = &cobra.Command{
 
 // showGPU show graphics/GPU information for the host system.
 func showGPU(cmd *cobra.Command, args []string) error {
-	gpu := info.GPU
+	gpu, err := ghw.GPU()
+	if err != nil {
+		return errors.Wrap(err, "error getting GPU info")
+	}
+
 	fmt.Printf("%v\n", gpu)
 
 	for _, card := range gpu.GraphicsCards {

--- a/cmd/ghwc/commands/memory.go
+++ b/cmd/ghwc/commands/memory.go
@@ -9,6 +9,8 @@ package commands
 import (
 	"fmt"
 
+	"github.com/jaypipes/ghw"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +23,11 @@ var memoryCmd = &cobra.Command{
 
 // showMemory show memory information for the host system.
 func showMemory(cmd *cobra.Command, args []string) error {
-	mem := info.Memory
+	mem, err := ghw.Memory()
+	if err != nil {
+		return errors.Wrap(err, "error getting memory info")
+	}
+
 	fmt.Printf("%v\n", mem)
 	return nil
 }

--- a/cmd/ghwc/commands/net.go
+++ b/cmd/ghwc/commands/net.go
@@ -9,6 +9,8 @@ package commands
 import (
 	"fmt"
 
+	"github.com/jaypipes/ghw"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +23,11 @@ var netCmd = &cobra.Command{
 
 // showNetwork show network information for the host system.
 func showNetwork(cmd *cobra.Command, args []string) error {
-	net := info.Network
+	net, err := ghw.Network()
+	if err != nil {
+		return errors.Wrap(err, "error getting network info")
+	}
+
 	fmt.Printf("%v\n", net)
 
 	for _, nic := range net.NICs {

--- a/cmd/ghwc/commands/root.go
+++ b/cmd/ghwc/commands/root.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jaypipes/ghw"
 	"github.com/spf13/cobra"
 )
 
@@ -19,7 +18,6 @@ var (
 	buildHash string
 	buildDate string
 	debug     bool
-	info      *ghw.HostInfo
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -71,13 +69,6 @@ func Execute(v string, bh string, bd string) {
 	version = v
 	buildHash = bh
 	buildDate = bd
-
-	i, err := ghw.Host()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-	info = i
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/cmd/ghwc/commands/topology.go
+++ b/cmd/ghwc/commands/topology.go
@@ -9,6 +9,8 @@ package commands
 import (
 	"fmt"
 
+	"github.com/jaypipes/ghw"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +23,11 @@ var topologyCmd = &cobra.Command{
 
 // showTopology show topology information for the host system.
 func showTopology(cmd *cobra.Command, args []string) error {
-	topology := info.Topology
+	topology, err := ghw.Topology()
+	if err != nil {
+		return errors.Wrap(err, "error getting topology info")
+	}
+
 	fmt.Printf("%v\n", topology)
 
 	for _, node := range topology.Nodes {


### PR DESCRIPTION
This makes it possible to actually produce useful output from ghwc on platforms which only implement a subset of ghw's functionality. Right now this is the case for macOS, which so far only supports querying block devices.