### PR TITLE
correct detection of virtual interfaces on linux

### DIFF
--- a/net_linux.go
+++ b/net_linux.go
@@ -59,7 +59,7 @@ func (ctx *context) nics() []*NIC {
 		netPath := filepath.Join(ctx.pathSysClassNet(), filename)
 		dest, _ := os.Readlink(netPath)
 		isVirtual := false
-		if strings.Contains(dest, "virtio") {
+		if strings.Contains(dest, "devices/virtual/net") {
 			isVirtual = true
 		}
 


### PR DESCRIPTION
To detect interfaces like :
- veth
- tun
- bridge
- and, Virtio
- etc;

I suggest to capture sys network interface class path contain
'devices/virtual/net' on symlink target.