### PR TITLE
Add Virtio as BusType

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Each `ghw.Disk` struct contains the following fields:
 * `ghw.Disk.SizeBytes` contains the amount of storage the disk provides
 * `ghw.Disk.PhysicalBlockSizeBytes` contains the size of the physical blocks
   used on the disk, in bytes
-* `ghw.Disk.BusType` will be either "scsi" or "ide"
+* `ghw.Disk.BusType` will be "SCSI", "IDE", "Virtio", or "NVMe"
 * `ghw.Disk.NUMANodeID` is the numeric index of the NUMA node this disk is
   local to, or -1
 * `ghw.Disk.Vendor` contains a string with the name of the hardware vendor for

--- a/block_linux.go
+++ b/block_linux.go
@@ -338,6 +338,8 @@ func (ctx *context) disks() []*Disk {
 			busType = "SCSI"
 		} else if strings.HasPrefix(dname, "hd") {
 			busType = "IDE"
+		} else if strings.HasPrefix(dname, "vd") {
+			busType = "Virtio"
 		} else if regexNVMeDev.MatchString(dname) {
 			busType = "NVMe"
 		}


### PR DESCRIPTION
I add the Virtio BusType for KVM users.

https://www.linux-kvm.org/page/Virtio
> Disk will show up as /dev/vd[a-z][1-9]
