### PR TITLE
convert ghw.Disk.BusType to enum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ sudo: required
 env:
   - GHW_TESTING_SKIP_GPU=1
 script:
+  - make dep
   - make test
   - go run cmd/ghwc/main.go

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DEP := $(BIN_DIR)/dep
 GOMETALINTER := $(BIN_DIR)/gometalinter
 
 .PHONY: test
-test: dep fmtcheck vet
+test: fmtcheck vet
 	go test $(PKGS)
 
 $(DEP):

--- a/README.md
+++ b/README.md
@@ -228,7 +228,10 @@ Each `ghw.Disk` struct contains the following fields:
 * `ghw.Disk.SizeBytes` contains the amount of storage the disk provides
 * `ghw.Disk.PhysicalBlockSizeBytes` contains the size of the physical blocks
   used on the disk, in bytes
-* `ghw.Disk.BusType` will be "SCSI", "IDE", "Virtio", or "NVMe"
+* `ghw.Disk.BusType` is the type of bus used for the disk. It is of type
+  `ghw.BusType` which has a `ghw.BusType.String()` method that can be called to
+  return a string representation of the bus. This string will be "SCSI", "IDE",
+  "Virtio", or "NVMe"
 * `ghw.Disk.NUMANodeID` is the numeric index of the NUMA node this disk is
   local to, or -1
 * `ghw.Disk.Vendor` contains a string with the name of the hardware vendor for

--- a/block.go
+++ b/block.go
@@ -17,7 +17,7 @@ type Disk struct {
 	Name                   string
 	SizeBytes              uint64
 	PhysicalBlockSizeBytes uint64
-	BusType                string
+	BusType                BusType
 	BusPath                string
 	NUMANodeID             int
 	Vendor                 string
@@ -107,7 +107,7 @@ func (d *Disk) String() string {
 		"/dev/%s (%s) [%s @ %s%s]%s%s%s%s",
 		d.Name,
 		sizeStr,
-		d.BusType,
+		d.BusType.String(),
 		d.BusPath,
 		atNode,
 		vendor,

--- a/block_linux.go
+++ b/block_linux.go
@@ -333,17 +333,17 @@ func (ctx *context) disks() []*Disk {
 	for _, file := range files {
 		dname := file.Name()
 
-		var busType string
+		busType := BUS_TYPE_UNKNOWN
 		if strings.HasPrefix(dname, "sd") {
-			busType = "SCSI"
+			busType = BUS_TYPE_SCSI
 		} else if strings.HasPrefix(dname, "hd") {
-			busType = "IDE"
+			busType = BUS_TYPE_IDE
 		} else if strings.HasPrefix(dname, "vd") {
-			busType = "Virtio"
+			busType = BUS_TYPE_VIRTIO
 		} else if regexNVMeDev.MatchString(dname) {
-			busType = "NVMe"
+			busType = BUS_TYPE_NVME
 		}
-		if busType == "" {
+		if busType == BUS_TYPE_UNKNOWN {
 			continue
 		}
 

--- a/bus_type.go
+++ b/bus_type.go
@@ -1,0 +1,33 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ghw
+
+type BusType int
+
+const (
+	BUS_TYPE_UNKNOWN BusType = iota
+	BUS_TYPE_IDE
+	BUS_TYPE_PCI
+	BUS_TYPE_SCSI
+	BUS_TYPE_NVME
+	BUS_TYPE_VIRTIO
+)
+
+var (
+	BusTypeString = map[BusType]string{
+		BUS_TYPE_UNKNOWN: "Unknown",
+		BUS_TYPE_IDE:     "IDE",
+		BUS_TYPE_PCI:     "PCI",
+		BUS_TYPE_SCSI:    "SCSI",
+		BUS_TYPE_NVME:    "NVMe",
+		BUS_TYPE_VIRTIO:  "Virtio",
+	}
+)
+
+func (bt BusType) String() string {
+	return BusTypeString[bt]
+}


### PR DESCRIPTION
Modifies the `ghw.Disk` struct's `BusType` attribute to be of type `ghw.BusType` instead of `string`. Creates an "enum" of bus types, including a new PCI bus type which will be useful in future patches for auxiliary devices.
    
Issue #106
