### PR TITLE
support JSON and YAML serialization

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,68 +2,62 @@
 
 
 [[projects]]
-  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
+  name = "github.com/ghodss/yaml"
+  packages = ["."]
+  revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
-  pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
-  digest = "1:04a2745baaf3f123935a565182f40763920c8fea322c141373f8d7bd3ffc6aaa"
   name = "github.com/jaypipes/pcidb"
   packages = ["."]
-  pruneopts = ""
   revision = "141a53e65d4ad43fdbd2760c714344da88f24adb"
   version = "0.3"
 
 [[projects]]
-  digest = "1:096a8a9182648da3d00ff243b88407838902b6703fc12657f76890e08d1899bf"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
-  pruneopts = ""
   revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = ""
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:a1403cc8a94b8d7956ee5e9694badef0e7b051af289caad1cf668331e3ffa4f6"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  pruneopts = ""
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
   version = "v0.0.3"
 
 [[projects]]
-  digest = "1:0a52bcb568386d98f4894575d53ce3e456f56471de6897bb8b9de13c33d9340e"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = ""
   revision = "9a97c102cda95a86cec2345a6f09f55a939babf5"
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:e43acd1190dde7223727f1f8aeac537156d33bf87776d5637e672e1c6b354be4"
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
+
+[[projects]]
   name = "howett.net/plist"
   packages = ["."]
-  pruneopts = ""
   revision = "591f970eefbbeb04d7b37f334a0c4c3256e32876"
+  source = "github.com/DHowett/go-plist"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/jaypipes/pcidb",
-    "github.com/pkg/errors",
-    "github.com/spf13/cobra",
-    "howett.net/plist",
-  ]
+  inputs-digest = "999127581bef10b66e55bd85ad1325e0dc45f5bdab01139994fbd89852160c9e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -18,3 +18,11 @@
 [[constraint]]
   name = "github.com/pkg/errors"
   version = "0.8.0"
+
+[[constraint]]
+  name = "gopkg.in/yaml.v2"
+  version = "2.2.2"
+
+[[constraint]]
+  name = "github.com/ghodss/yaml"
+  version = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ information about the host computer:
 * [Network](#network)
 * [PCI](#pci)
 * [GPU](#gpu)
-
+* [YAML and JSON serialization](#serialization)
 
 ### Overriding the root mountpoint `ghw` uses
 
@@ -789,6 +789,48 @@ information
 **NOTE**: You can [read more](#topology) about the fields of the
 `ghw.TopologyNode` struct if you'd like to dig deeper into the NUMA/topology
 subsystem
+
+## Serialization
+
+All of the `ghw` `XXXInfo` structs -- e.g. `ghw.CPUInfo` -- have two methods
+for producing a serialized JSON or YAML string representation of the contained
+information:
+
+* `JSONString()` returns a string containing the information serialized into
+  JSON. It accepts a single boolean parameter indicating whether to use
+  indentation when outputting the string
+* `YAMLString()` returns a string containing the information serialized into
+  YAML
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/jaypipes/ghw"
+)
+
+func main() {
+	mem, err := ghw.Memory()
+	if err != nil {
+		fmt.Printf("Error getting memory info: %v", err)
+	}
+
+	fmt.Printf("%s", mem.YAMLString())
+}
+```
+
+the above example code prints the following out on my local workstation:
+
+```
+memory:
+  supported_page_sizes:
+  - 1073741824
+  - 2097152
+  total_physical_bytes: 25263415296
+  total_usable_bytes: 25263415296
+```
 
 ## Developers
 

--- a/architecture.go
+++ b/architecture.go
@@ -1,0 +1,38 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ghw
+
+import "strings"
+
+// Architecture describes the overall hardware architecture. It can be either
+// Symmetric Multi-Processor (SMP) or Non-Uniform Memory Access (NUMA)
+type Architecture int
+
+const (
+	// SMP is a Symmetric Multi-Processor system
+	ARCHITECTURE_SMP Architecture = iota
+	// NUMA is a Non-Uniform Memory Access system
+	ARCHITECTURE_NUMA
+)
+
+var (
+	architectureString = map[Architecture]string{
+		ARCHITECTURE_SMP:  "SMP",
+		ARCHITECTURE_NUMA: "NUMA",
+	}
+)
+
+func (a Architecture) String() string {
+	return architectureString[a]
+}
+
+// NOTE(jaypipes): since serialized output is as "official" as we're going to
+// get, let's lowercase the string output when serializing, in order to
+// "normalize" the expected serialized output
+func (a Architecture) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + strings.ToLower(a.String()) + "\""), nil
+}

--- a/bus_type.go
+++ b/bus_type.go
@@ -6,6 +6,8 @@
 
 package ghw
 
+import "strings"
+
 type BusType int
 
 const (
@@ -18,7 +20,7 @@ const (
 )
 
 var (
-	BusTypeString = map[BusType]string{
+	busTypeString = map[BusType]string{
 		BUS_TYPE_UNKNOWN: "Unknown",
 		BUS_TYPE_IDE:     "IDE",
 		BUS_TYPE_PCI:     "PCI",
@@ -29,5 +31,12 @@ var (
 )
 
 func (bt BusType) String() string {
-	return BusTypeString[bt]
+	return busTypeString[bt]
+}
+
+// NOTE(jaypipes): since serialized output is as "official" as we're going to
+// get, let's lowercase the string output when serializing, in order to
+// "normalize" the expected serialized output
+func (bt BusType) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + strings.ToLower(bt.String()) + "\""), nil
 }

--- a/cmd/ghwc/commands/block.go
+++ b/cmd/ghwc/commands/block.go
@@ -28,13 +28,20 @@ func showBlock(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "error getting block device info")
 	}
 
-	fmt.Printf("%v\n", block)
+	switch outputFormat {
+	case outputFormatHuman:
+		fmt.Printf("%v\n", block)
 
-	for _, disk := range block.Disks {
-		fmt.Printf(" %v\n", disk)
-		for _, part := range disk.Partitions {
-			fmt.Printf("  %v\n", part)
+		for _, disk := range block.Disks {
+			fmt.Printf(" %v\n", disk)
+			for _, part := range disk.Partitions {
+				fmt.Printf("  %v\n", part)
+			}
 		}
+	case outputFormatJSON:
+		fmt.Printf("%s\n", block.JSONString(pretty))
+	case outputFormatYAML:
+		fmt.Printf("%s", block.YAMLString())
 	}
 	return nil
 }

--- a/cmd/ghwc/commands/cpu.go
+++ b/cmd/ghwc/commands/cpu.go
@@ -30,31 +30,38 @@ func showCPU(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "error getting CPU info")
 	}
 
-	fmt.Printf("%v\n", cpu)
+	switch outputFormat {
+	case outputFormatHuman:
+		fmt.Printf("%v\n", cpu)
 
-	for _, proc := range cpu.Processors {
-		fmt.Printf(" %v\n", proc)
-		for _, core := range proc.Cores {
-			fmt.Printf("  %v\n", core)
-		}
-		if len(proc.Capabilities) > 0 {
-			// pretty-print the (large) block of capability strings into rows
-			// of 6 capability strings
-			rows := int(math.Ceil(float64(len(proc.Capabilities)) / float64(6)))
-			for row := 1; row < rows; row = row + 1 {
-				rowStart := (row * 6) - 1
-				rowEnd := int(math.Min(float64(rowStart+6), float64(len(proc.Capabilities))))
-				rowElems := proc.Capabilities[rowStart:rowEnd]
-				capStr := strings.Join(rowElems, " ")
-				if row == 1 {
-					fmt.Printf("  capabilities: [%s\n", capStr)
-				} else if rowEnd < len(proc.Capabilities) {
-					fmt.Printf("                 %s\n", capStr)
-				} else {
-					fmt.Printf("                 %s]\n", capStr)
+		for _, proc := range cpu.Processors {
+			fmt.Printf(" %v\n", proc)
+			for _, core := range proc.Cores {
+				fmt.Printf("  %v\n", core)
+			}
+			if len(proc.Capabilities) > 0 {
+				// pretty-print the (large) block of capability strings into rows
+				// of 6 capability strings
+				rows := int(math.Ceil(float64(len(proc.Capabilities)) / float64(6)))
+				for row := 1; row < rows; row = row + 1 {
+					rowStart := (row * 6) - 1
+					rowEnd := int(math.Min(float64(rowStart+6), float64(len(proc.Capabilities))))
+					rowElems := proc.Capabilities[rowStart:rowEnd]
+					capStr := strings.Join(rowElems, " ")
+					if row == 1 {
+						fmt.Printf("  capabilities: [%s\n", capStr)
+					} else if rowEnd < len(proc.Capabilities) {
+						fmt.Printf("                 %s\n", capStr)
+					} else {
+						fmt.Printf("                 %s]\n", capStr)
+					}
 				}
 			}
 		}
+	case outputFormatJSON:
+		fmt.Printf("%s\n", cpu.JSONString(pretty))
+	case outputFormatYAML:
+		fmt.Printf("%s", cpu.YAMLString())
 	}
 	return nil
 }

--- a/cmd/ghwc/commands/gpu.go
+++ b/cmd/ghwc/commands/gpu.go
@@ -28,10 +28,17 @@ func showGPU(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "error getting GPU info")
 	}
 
-	fmt.Printf("%v\n", gpu)
+	switch outputFormat {
+	case outputFormatHuman:
+		fmt.Printf("%v\n", gpu)
 
-	for _, card := range gpu.GraphicsCards {
-		fmt.Printf(" %v\n", card)
+		for _, card := range gpu.GraphicsCards {
+			fmt.Printf(" %v\n", card)
+		}
+	case outputFormatJSON:
+		fmt.Printf("%s\n", gpu.JSONString(pretty))
+	case outputFormatYAML:
+		fmt.Printf("%s", gpu.YAMLString())
 	}
 	return nil
 }

--- a/cmd/ghwc/commands/memory.go
+++ b/cmd/ghwc/commands/memory.go
@@ -7,8 +7,6 @@
 package commands
 
 import (
-	"fmt"
-
 	"github.com/jaypipes/ghw"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -28,7 +26,7 @@ func showMemory(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "error getting memory info")
 	}
 
-	fmt.Printf("%v\n", mem)
+	printInfo(mem)
 	return nil
 }
 

--- a/cmd/ghwc/commands/net.go
+++ b/cmd/ghwc/commands/net.go
@@ -28,23 +28,30 @@ func showNetwork(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "error getting network info")
 	}
 
-	fmt.Printf("%v\n", net)
+	switch outputFormat {
+	case outputFormatHuman:
+		fmt.Printf("%v\n", net)
 
-	for _, nic := range net.NICs {
-		fmt.Printf(" %v\n", nic)
+		for _, nic := range net.NICs {
+			fmt.Printf(" %v\n", nic)
 
-		enabledCaps := make([]int, 0)
-		for x, cap := range nic.Capabilities {
-			if cap.IsEnabled {
-				enabledCaps = append(enabledCaps, x)
+			enabledCaps := make([]int, 0)
+			for x, cap := range nic.Capabilities {
+				if cap.IsEnabled {
+					enabledCaps = append(enabledCaps, x)
+				}
+			}
+			if len(enabledCaps) > 0 {
+				fmt.Printf("  enabled capabilities:\n")
+				for _, x := range enabledCaps {
+					fmt.Printf("   - %s\n", nic.Capabilities[x].Name)
+				}
 			}
 		}
-		if len(enabledCaps) > 0 {
-			fmt.Printf("  enabled capabilities:\n")
-			for _, x := range enabledCaps {
-				fmt.Printf("   - %s\n", nic.Capabilities[x].Name)
-			}
-		}
+	case outputFormatJSON:
+		fmt.Printf("%s\n", net.JSONString(pretty))
+	case outputFormatYAML:
+		fmt.Printf("%s", net.YAMLString())
 	}
 	return nil
 }

--- a/cmd/ghwc/commands/print_util.go
+++ b/cmd/ghwc/commands/print_util.go
@@ -1,0 +1,26 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package commands
+
+import "fmt"
+
+type formattable interface {
+	String() string
+	JSONString(bool) string
+	YAMLString() string
+}
+
+func printInfo(f formattable) {
+	switch outputFormat {
+	case outputFormatHuman:
+		fmt.Printf("%s\n", f)
+	case outputFormatJSON:
+		fmt.Printf("%s\n", f.JSONString(pretty))
+	case outputFormatYAML:
+		fmt.Printf("%s", f.YAMLString())
+	}
+}

--- a/cmd/ghwc/commands/root.go
+++ b/cmd/ghwc/commands/root.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/jaypipes/ghw"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -55,24 +57,12 @@ https://github.com/jaypipes/ghw
 }
 
 func showAll(cmd *cobra.Command, args []string) error {
-	if err := showBlock(cmd, args); err != nil {
-		return err
+	host, err := ghw.Host()
+	if err != nil {
+		return errors.Wrap(err, "error getting host info")
 	}
-	if err := showCPU(cmd, args); err != nil {
-		return err
-	}
-	if err := showGPU(cmd, args); err != nil {
-		return err
-	}
-	if err := showMemory(cmd, args); err != nil {
-		return err
-	}
-	if err := showNetwork(cmd, args); err != nil {
-		return err
-	}
-	if err := showTopology(cmd, args); err != nil {
-		return err
-	}
+
+	printInfo(host)
 	return nil
 }
 

--- a/cmd/ghwc/commands/root.go
+++ b/cmd/ghwc/commands/root.go
@@ -13,17 +13,33 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	outputFormatHuman = "human"
+	outputFormatJSON  = "json"
+	outputFormatYAML  = "yaml"
+	usageOutputFormat = `Output format.
+Choices are 'json','yaml', and 'human'.`
+)
+
 var (
-	version   string
-	buildHash string
-	buildDate string
-	debug     bool
+	version       string
+	buildHash     string
+	buildDate     string
+	debug         bool
+	outputFormat  string
+	outputFormats = []string{
+		outputFormatHuman,
+		outputFormatJSON,
+		outputFormatYAML,
+	}
+	pretty bool
 )
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "ghwc",
 	Short: "ghwc - Discover hardware information.",
+	Args:  validateRootCommand,
 	Long: `
           __
  .-----. |  |--. .--.--.--.
@@ -60,8 +76,9 @@ func showAll(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
+// Execute adds all child commands to the root command and sets flags
+// appropriately. This is called by main.main(). It only needs to happen once
+// to the rootCmd.
 func Execute(v string, bh string, bd string) {
 	version = v
 	buildHash = bh
@@ -73,6 +90,35 @@ func Execute(v string, bh string, bd string) {
 	}
 }
 
+func haveValidOutputFormat() bool {
+	for _, choice := range outputFormats {
+		if choice == outputFormat {
+			return true
+		}
+	}
+	return false
+}
+
+// validateRootCommand ensures any CLI options or arguments are valid,
+// returning an error if not
+func validateRootCommand(rootCmd *cobra.Command, args []string) error {
+	if !haveValidOutputFormat() {
+		return fmt.Errorf("invalid output format %q", outputFormat)
+	}
+	return nil
+}
+
 func init() {
-	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable or disable debug mode")
+	rootCmd.PersistentFlags().BoolVar(
+		&debug, "debug", false, "Enable or disable debug mode",
+	)
+	rootCmd.PersistentFlags().StringVarP(
+		&outputFormat,
+		"format", "f",
+		outputFormatHuman,
+		usageOutputFormat,
+	)
+	rootCmd.PersistentFlags().BoolVar(
+		&pretty, "pretty", false, "When outputting JSON, use indentation",
+	)
 }

--- a/cmd/ghwc/commands/root.go
+++ b/cmd/ghwc/commands/root.go
@@ -57,12 +57,40 @@ https://github.com/jaypipes/ghw
 }
 
 func showAll(cmd *cobra.Command, args []string) error {
-	host, err := ghw.Host()
-	if err != nil {
-		return errors.Wrap(err, "error getting host info")
-	}
 
-	printInfo(host)
+	switch outputFormat {
+	case outputFormatHuman:
+		if err := showBlock(cmd, args); err != nil {
+			return err
+		}
+		if err := showCPU(cmd, args); err != nil {
+			return err
+		}
+		if err := showGPU(cmd, args); err != nil {
+			return err
+		}
+		if err := showMemory(cmd, args); err != nil {
+			return err
+		}
+		if err := showNetwork(cmd, args); err != nil {
+			return err
+		}
+		if err := showTopology(cmd, args); err != nil {
+			return err
+		}
+	case outputFormatJSON:
+		host, err := ghw.Host()
+		if err != nil {
+			return errors.Wrap(err, "error getting host info")
+		}
+		fmt.Printf("%s\n", host.JSONString(pretty))
+	case outputFormatYAML:
+		host, err := ghw.Host()
+		if err != nil {
+			return errors.Wrap(err, "error getting host info")
+		}
+		fmt.Printf("%s", host.YAMLString())
+	}
 	return nil
 }
 

--- a/cmd/ghwc/commands/topology.go
+++ b/cmd/ghwc/commands/topology.go
@@ -28,13 +28,20 @@ func showTopology(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "error getting topology info")
 	}
 
-	fmt.Printf("%v\n", topology)
+	switch outputFormat {
+	case outputFormatHuman:
+		fmt.Printf("%v\n", topology)
 
-	for _, node := range topology.Nodes {
-		fmt.Printf(" %v\n", node)
-		for _, cache := range node.Caches {
-			fmt.Printf("  %v\n", cache)
+		for _, node := range topology.Nodes {
+			fmt.Printf(" %v\n", node)
+			for _, cache := range node.Caches {
+				fmt.Printf("  %v\n", cache)
+			}
 		}
+	case outputFormatJSON:
+		fmt.Printf("%s\n", topology.JSONString(pretty))
+	case outputFormatYAML:
+		fmt.Printf("%s", topology.YAMLString())
 	}
 	return nil
 }

--- a/cpu.go
+++ b/cpu.go
@@ -15,11 +15,11 @@ import (
 // (CPU).
 type ProcessorCore struct {
 	// TODO(jaypipes): Deprecated in 0.2, remove in 1.0
-	Id                int
-	ID                int
-	Index             int
-	NumThreads        uint32
-	LogicalProcessors []int
+	Id                int    `json:"-"`
+	ID                int    `json:"id"`
+	Index             int    `json:"index"`
+	NumThreads        uint32 `json:"total_threads"`
+	LogicalProcessors []int  `json:"logical_processors"`
 }
 
 func (c *ProcessorCore) String() string {
@@ -34,14 +34,14 @@ func (c *ProcessorCore) String() string {
 // Processor describes a physical host central processing unit (CPU).
 type Processor struct {
 	// TODO(jaypipes): Deprecated in 0.2, remove in 1.0
-	Id           int
-	ID           int
-	NumCores     uint32
-	NumThreads   uint32
-	Vendor       string
-	Model        string
-	Capabilities []string
-	Cores        []*ProcessorCore
+	Id           int              `json:"-"`
+	ID           int              `json:"id"`
+	NumCores     uint32           `json:"total_cores"`
+	NumThreads   uint32           `json:"total_threads"`
+	Vendor       string           `json:"vendor"`
+	Model        string           `json:"model"`
+	Capabilities []string         `json:"capabilities"`
+	Cores        []*ProcessorCore `json:"cores"`
 }
 
 // HasCapability returns true if the `ghw.Processor` has the supplied cpuid
@@ -81,9 +81,10 @@ func (p *Processor) String() string {
 // CPUInfo describes all central processing unit (CPU) functionality on a host.
 // Returned by the `ghw.CPU()` function.
 type CPUInfo struct {
-	TotalCores   uint32
-	TotalThreads uint32
-	Processors   []*Processor
+	TotalCores   uint32 `json:"total_cores"`
+	TotalThreads uint32 `json:"total_threads"`
+
+	Processors []*Processor `json:"processors"`
 }
 
 // CPU returns a struct containing information about the host's CPU resources.
@@ -121,4 +122,22 @@ func (i *CPUInfo) String() string {
 		i.TotalThreads,
 		nts,
 	)
+}
+
+// simple private struct used to encapsulate cpu information in a top-level
+// "cpu" YAML/JSON map/object key
+type cpuPrinter struct {
+	Info *CPUInfo `json:"cpu"`
+}
+
+// YAMLString returns a string with the cpu information formatted as YAML
+// under a top-level "cpu:" key
+func (i *CPUInfo) YAMLString() string {
+	return safeYAML(cpuPrinter{i})
+}
+
+// JSONString returns a string with the cpu information formatted as JSON
+// under a top-level "cpu:" key
+func (i *CPUInfo) JSONString(indent bool) string {
+	return safeJSON(cpuPrinter{i}, indent)
 }

--- a/cpu_linux.go
+++ b/cpu_linux.go
@@ -123,7 +123,7 @@ func (ctx *context) processorsGet() []*Processor {
 			}
 			var core *ProcessorCore
 			for _, c := range cores {
-				if c.Id == coreID {
+				if c.ID == coreID {
 					c.LogicalProcessors = append(
 						c.LogicalProcessors,
 						lpid,
@@ -136,7 +136,7 @@ func (ctx *context) processorsGet() []*Processor {
 				coreLps := make([]int, 1)
 				coreLps[0] = lpid
 				core = &ProcessorCore{
-					Id:                coreID,
+					ID:                coreID,
 					Index:             len(cores),
 					NumThreads:        1,
 					LogicalProcessors: coreLps,

--- a/gpu_linux.go
+++ b/gpu_linux.go
@@ -112,7 +112,7 @@ func (ctx *context) gpuFillNUMANodes(cards []*GraphicsCard) {
 	topo := &TopologyInfo{}
 	if err := ctx.topologyFillInfo(topo); err != nil {
 		for _, card := range cards {
-			if topo.Architecture != NUMA {
+			if topo.Architecture != ARCHITECTURE_NUMA {
 				card.Node = nil
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@
 
 package ghw
 
+import "fmt"
+
 const (
 	UNKNOWN = "unknown"
 )
@@ -17,12 +19,12 @@ type context struct {
 }
 
 type HostInfo struct {
-	Memory   *MemoryInfo
-	Block    *BlockInfo
-	CPU      *CPUInfo
-	Topology *TopologyInfo
-	Network  *NetworkInfo
-	GPU      *GPUInfo
+	Memory   *MemoryInfo   `json:"memory"`
+	Block    *BlockInfo    `json:"block"`
+	CPU      *CPUInfo      `json:"cpu"`
+	Topology *TopologyInfo `json:"topology"`
+	Network  *NetworkInfo  `json:"network"`
+	GPU      *GPUInfo      `json:"gpu"`
 }
 
 // Host returns a pointer to a HostInfo struct that contains fields with
@@ -64,4 +66,28 @@ func Host(opts ...*WithOption) (*HostInfo, error) {
 		Network:  net,
 		GPU:      gpu,
 	}, nil
+}
+
+func (info *HostInfo) String() string {
+	return fmt.Sprintf(
+		"%s\n%s\n%s\n%s\n%s\n%s\n",
+		info.Block.String(),
+		info.CPU.String(),
+		info.GPU.String(),
+		info.Memory.String(),
+		info.Network.String(),
+		info.Topology.String(),
+	)
+}
+
+// YAMLString returns a string with the host information formatted as YAML
+// under a top-level "host:" key
+func (i *HostInfo) YAMLString() string {
+	return safeYAML(i)
+}
+
+// JSONString returns a string with the host information formatted as JSON
+// under a top-level "host:" key
+func (i *HostInfo) JSONString(indent bool) string {
+	return safeJSON(i, indent)
 }

--- a/marshal.go
+++ b/marshal.go
@@ -1,0 +1,46 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ghw
+
+import (
+	"encoding/json"
+
+	"github.com/ghodss/yaml"
+)
+
+// safeYAML returns a string after marshalling the supplied parameter into YAML
+func safeYAML(p interface{}) string {
+	b, err := json.Marshal(p)
+	if err != nil {
+		warn("error marshalling JSON: %s", err)
+		return ""
+	}
+	yb, err := yaml.JSONToYAML(b)
+	if err != nil {
+		warn("error converting JSON to YAML: %s", err)
+		return ""
+	}
+	return string(yb)
+}
+
+// safeJSON returns a string after marshalling the supplied parameter into
+// JSON. Accepts an optional argument to trigger pretty/indented formatting of
+// the JSON string
+func safeJSON(p interface{}, indent bool) string {
+	var b []byte
+	var err error
+	if !indent {
+		b, err = json.Marshal(p)
+	} else {
+		b, err = json.MarshalIndent(&p, "", "  ")
+	}
+	if err != nil {
+		warn("error marshalling JSON: %s", err)
+		return ""
+	}
+	return string(b)
+}

--- a/memory.go
+++ b/memory.go
@@ -12,10 +12,10 @@ import (
 )
 
 type MemoryInfo struct {
-	TotalPhysicalBytes int64
-	TotalUsableBytes   int64
+	TotalPhysicalBytes int64 `json:"total_physical_bytes"`
+	TotalUsableBytes   int64 `json:"total_usable_bytes"`
 	// An array of sizes, in bytes, of memory pages supported by the host
-	SupportedPageSizes []uint64
+	SupportedPageSizes []uint64 `json:"supported_page_sizes"`
 }
 
 func Memory(opts ...*WithOption) (*MemoryInfo, error) {
@@ -46,4 +46,22 @@ func (i *MemoryInfo) String() string {
 		tubs = fmt.Sprintf("%d%s", tub, unitStr)
 	}
 	return fmt.Sprintf("memory (%s physical, %s usable)", tpbs, tubs)
+}
+
+// simple private struct used to encapsulate memory information in a top-level
+// "memory" YAML/JSON map/object key
+type memoryPrinter struct {
+	Info *MemoryInfo `json:"memory"`
+}
+
+// YAMLString returns a string with the memory information formatted as YAML
+// under a top-level "memory:" key
+func (i *MemoryInfo) YAMLString() string {
+	return safeYAML(memoryPrinter{i})
+}
+
+// JSONString returns a string with the memory information formatted as JSON
+// under a top-level "memory:" key
+func (i *MemoryInfo) JSONString(indent bool) string {
+	return safeJSON(memoryPrinter{i}, indent)
 }

--- a/memory_cache.go
+++ b/memory_cache.go
@@ -15,10 +15,29 @@ import (
 type MemoryCacheType int
 
 const (
-	UNIFIED MemoryCacheType = iota
-	INSTRUCTION
-	DATA
+	MEMORY_CACHE_TYPE_UNIFIED MemoryCacheType = iota
+	MEMORY_CACHE_TYPE_INSTRUCTION
+	MEMORY_CACHE_TYPE_DATA
 )
+
+var (
+	memoryCacheTypeString = map[MemoryCacheType]string{
+		MEMORY_CACHE_TYPE_UNIFIED:     "Unified",
+		MEMORY_CACHE_TYPE_INSTRUCTION: "Instruction",
+		MEMORY_CACHE_TYPE_DATA:        "Data",
+	}
+)
+
+func (a MemoryCacheType) String() string {
+	return memoryCacheTypeString[a]
+}
+
+// NOTE(jaypipes): since serialized output is as "official" as we're going to
+// get, let's lowercase the string output when serializing, in order to
+// "normalize" the expected serialized output
+func (a MemoryCacheType) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + strings.ToLower(a.String()) + "\""), nil
+}
 
 type SortByMemoryCacheLevelTypeFirstProcessor []*MemoryCache
 
@@ -46,20 +65,20 @@ func (a SortByLogicalProcessorId) Swap(i, j int)      { a[i], a[j] = a[j], a[i] 
 func (a SortByLogicalProcessorId) Less(i, j int) bool { return a[i] < a[j] }
 
 type MemoryCache struct {
-	Level     uint8
-	Type      MemoryCacheType
-	SizeBytes uint64
+	Level     uint8           `json:"level"`
+	Type      MemoryCacheType `json:"type"`
+	SizeBytes uint64          `json:"size_bytes"`
 	// The set of logical processors (hardware threads) that have access to the
 	// cache
-	LogicalProcessors []uint32
+	LogicalProcessors []uint32 `json:"logical_processors"`
 }
 
 func (c *MemoryCache) String() string {
 	sizeKb := c.SizeBytes / uint64(KB)
 	typeStr := ""
-	if c.Type == INSTRUCTION {
+	if c.Type == MEMORY_CACHE_TYPE_INSTRUCTION {
 		typeStr = "i"
-	} else if c.Type == DATA {
+	} else if c.Type == MEMORY_CACHE_TYPE_DATA {
 		typeStr = "d"
 	}
 	cacheIdStr := fmt.Sprintf("L%d%s", c.Level, typeStr)

--- a/memory_cache_linux.go
+++ b/memory_cache_linux.go
@@ -178,15 +178,15 @@ func (ctx *context) memoryCacheType(nodeID int, lpID int, cacheIndex int) Memory
 	cacheTypeContents, err := ioutil.ReadFile(typePath)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
-		return UNIFIED
+		return MEMORY_CACHE_TYPE_UNIFIED
 	}
 	switch string(cacheTypeContents[:len(cacheTypeContents)-1]) {
 	case "Data":
-		return DATA
+		return MEMORY_CACHE_TYPE_DATA
 	case "Instruction":
-		return INSTRUCTION
+		return MEMORY_CACHE_TYPE_INSTRUCTION
 	default:
-		return UNIFIED
+		return MEMORY_CACHE_TYPE_UNIFIED
 	}
 }
 

--- a/net.go
+++ b/net.go
@@ -11,16 +11,17 @@ import (
 )
 
 type NICCapability struct {
-	Name      string
-	IsEnabled bool
-	CanChange bool
+	Name      string `json:"name"`
+	IsEnabled bool   `json:"is_enabled"`
+	// TODO(jaypipes): Deprecate this and rename to CanEnable
+	CanChange bool `json:"can_enable"`
 }
 
 type NIC struct {
-	Name         string
-	MacAddress   string
-	IsVirtual    bool
-	Capabilities []*NICCapability
+	Name         string           `json:"name"`
+	MacAddress   string           `json:"mac_address"`
+	IsVirtual    bool             `json:"is_virtual"`
+	Capabilities []*NICCapability `json:"capabilities"`
 }
 
 func (n *NIC) String() string {
@@ -36,7 +37,7 @@ func (n *NIC) String() string {
 }
 
 type NetworkInfo struct {
-	NICs []*NIC
+	NICs []*NIC `json:"nics"`
 }
 
 func Network(opts ...*WithOption) (*NetworkInfo, error) {
@@ -56,4 +57,22 @@ func (i *NetworkInfo) String() string {
 		"net (%d NICs)",
 		len(i.NICs),
 	)
+}
+
+// simple private struct used to encapsulate net information in a
+// top-level "net" YAML/JSON map/object key
+type netPrinter struct {
+	Info *NetworkInfo `json:"net"`
+}
+
+// YAMLString returns a string with the net information formatted as YAML
+// under a top-level "net:" key
+func (i *NetworkInfo) YAMLString() string {
+	return safeYAML(netPrinter{i})
+}
+
+// JSONString returns a string with the net information formatted as JSON
+// under a top-level "net:" key
+func (i *NetworkInfo) JSONString(indent bool) string {
+	return safeJSON(netPrinter{i}, indent)
 }

--- a/net.go
+++ b/net.go
@@ -62,7 +62,7 @@ func (i *NetworkInfo) String() string {
 // simple private struct used to encapsulate net information in a
 // top-level "net" YAML/JSON map/object key
 type netPrinter struct {
-	Info *NetworkInfo `json:"net"`
+	Info *NetworkInfo `json:"network"`
 }
 
 // YAMLString returns a string with the net information formatted as YAML

--- a/topology_linux.go
+++ b/topology_linux.go
@@ -18,9 +18,9 @@ func (ctx *context) topologyFillInfo(info *TopologyInfo) error {
 	}
 	info.Nodes = nodes
 	if len(info.Nodes) == 1 {
-		info.Architecture = SMP
+		info.Architecture = ARCHITECTURE_SMP
 	} else {
-		info.Architecture = NUMA
+		info.Architecture = ARCHITECTURE_NUMA
 	}
 	return nil
 }

--- a/topology_test.go
+++ b/topology_test.go
@@ -25,7 +25,7 @@ func TestTopology(t *testing.T) {
 		t.Fatalf("Expected >0 nodes but got 0.")
 	}
 
-	if info.Architecture == NUMA && len(info.Nodes) == 1 {
+	if info.Architecture == ARCHITECTURE_NUMA && len(info.Nodes) == 1 {
 		t.Fatalf("Got NUMA architecture but only 1 node.")
 	}
 


### PR DESCRIPTION
Adds support for serializing the primary XXXInfo structs in `ghw` as
JSON and YAML.

Each `ghw.XXXInfo` struct now has a `YAMLString()` and `JSONString()`
method that returns a string with the struct's information serialized to
that format.

The `ghwc` client has been enhanced with a `--format` CLI option that
allows users to print the hardware information in human-readable (the
default), JSON or YAML format:

```
[jaypipes@uberbox ghw]$ go run cmd/ghwc/main.go -f yaml memory 2>/dev/null
memory:
  supported_page_sizes:
  - 1073741824
  - 2097152
  total_physical_bytes: 25263415296
  total_usable_bytes: 25263415296
[jaypipes@uberbox ghw]$ go run cmd/ghwc/main.go -f json memory 2>/dev/null
{"memory":{"total_physical_bytes":25263415296,"total_usable_bytes":25263415296,"supported_page_sizes":[1073741824,2097152]}}
```

The `--format json` CLI option can be paired with a `--pretty` CLI
option to provide indented output:

```
[jaypipes@uberbox ghw]$ go run cmd/ghwc/main.go -f json --pretty memory 2>/dev/null
{
  "memory": {
    "total_physical_bytes": 25263415296,
    "total_usable_bytes": 25263415296,
    "supported_page_sizes": [
      1073741824,
      2097152
    ]
  }
}
```

Issue #78