### PR TITLE
correct calculation of NICCapability.CanChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,8 +414,8 @@ The `ghw.NICCapability` struct contains the following fields:
   "tcp-segmentation-offload")
 * `ghw.NICCapability.IsEnabled` is a boolean indicating whether the capability
   is currently enabled/active on the NIC
-* `ghw.NICCapability.CanChange` is a boolean indicating whether the capability
-  may be turned on or off
+* `ghw.NICCapability.CanEnable` is a boolean indicating whether the capability
+  may be enabled
 
 ```go
 package main

--- a/net.go
+++ b/net.go
@@ -13,8 +13,7 @@ import (
 type NICCapability struct {
 	Name      string `json:"name"`
 	IsEnabled bool   `json:"is_enabled"`
-	// TODO(jaypipes): Deprecate this and rename to CanEnable
-	CanChange bool `json:"can_enable"`
+	CanEnable bool   `json:"can_enable"`
 }
 
 type NIC struct {

--- a/net_linux.go
+++ b/net_linux.go
@@ -120,9 +120,7 @@ func (ctx *context) netDeviceCapabilities(dev string) []*NICCapability {
 	}
 
 	// The out variable will now contain something that looks like the
-	// following. Note that [fixed] indicates that the capability may not be
-	// turned on/off. It makes no difference whether a privileged user runs
-	// `ethtool -k` when determining whether [fixed] appears for a capability.
+	// following.
 	//
 	// Features for enp58s0f1:
 	// rx-checksumming: on
@@ -146,15 +144,29 @@ func (ctx *context) netDeviceCapabilities(dev string) []*NICCapability {
 	scanner.Scan()
 	for scanner.Scan() {
 		line := strings.TrimPrefix(scanner.Text(), "\t")
-		parts := strings.Fields(line)
-		cap := strings.TrimSuffix(parts[0], ":")
-		enabled := parts[1] == "on"
-		fixed := len(parts) < 3 || parts[2] == "fixed"
-		caps = append(caps, &NICCapability{
-			Name:      cap,
-			IsEnabled: enabled,
-			CanChange: !fixed,
-		})
+		caps = append(caps, netParseEthtoolFeature(line))
 	}
 	return caps
+}
+
+// netParseEthtoolFeature parses a line from the ethtool -k output and returns
+// a NICCapability.
+//
+// The supplied line will look like the following:
+//
+// tx-checksum-ip-generic: off [fixed]
+//
+// [fixed] indicates that the feature may not be turned on/off. Note: it makes
+// no difference whether a privileged user runs `ethtool -k` when determining
+// whether [fixed] appears for a feature.
+func netParseEthtoolFeature(line string) *NICCapability {
+	parts := strings.Fields(line)
+	cap := strings.TrimSuffix(parts[0], ":")
+	enabled := parts[1] == "on"
+	fixed := len(parts) == 3 && parts[2] == "[fixed]"
+	return &NICCapability{
+		Name:      cap,
+		IsEnabled: enabled,
+		CanEnable: !fixed,
+	}
 }

--- a/net_linux_test.go
+++ b/net_linux_test.go
@@ -1,0 +1,58 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+// +build linux
+
+package ghw
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestParseEthtoolFeature(t *testing.T) {
+	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_NET"); ok {
+		t.Skip("Skipping network tests.")
+	}
+
+	tests := []struct {
+		line     string
+		expected *NICCapability
+	}{
+		{
+			line: "scatter-gather: off",
+			expected: &NICCapability{
+				Name:      "scatter-gather",
+				IsEnabled: false,
+				CanEnable: true,
+			},
+		},
+		{
+			line: "scatter-gather: on",
+			expected: &NICCapability{
+				Name:      "scatter-gather",
+				IsEnabled: true,
+				CanEnable: true,
+			},
+		},
+		{
+			line: "scatter-gather: off [fixed]",
+			expected: &NICCapability{
+				Name:      "scatter-gather",
+				IsEnabled: false,
+				CanEnable: false,
+			},
+		},
+	}
+
+	for x, test := range tests {
+		actual := netParseEthtoolFeature(test.line)
+		if !reflect.DeepEqual(test.expected, actual) {
+			t.Fatalf("In test %d, expected %v == %v", x, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Fixes a buggy calculation of whether a NIC capability/feature can be
changed. There were two errors in the previous way of parsing the
feature line in the `ethtool -k` output.

The first error was that any line that did not have three parts was
considered non-changeable. This was incorrect, since this:

 scatter-gather: off

actually indicates that the feature can be enabled, and the line has two
fields (parts) not three.

The second error was that we were looking for the string "fixed" instead
of what actually appears, which is "[fixed]", like so:

 scatter-gather: off [fixed]

This patch corrects these errors and adds a unit test to prevent
regressions.

We also change the field name of `NICCapability.CanChange` to
`NICCapability.CanEnable` since this is more congruent with the existing
field `NICCapability.IsEnabled`. Changing the field name like this is
considered fine since anyone relying on the old field name was relying
on bad/buggy behaviour and we might as well hard-break those folks and
let them know about the bug...

Issue #111