### PR TITLE
allow warnings to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,28 @@ Alternately, you can use the `ghw.WithChroot()` function like so:
 cpu, err := ghw.CPU(ghw.WithChroot("/host"))
 ```
 
+### Disabling warning messages
+
+When `ghw` isn't able to retrieve some information, it may print certain
+warning messages to `stderr`. To disable these warnings, simply set the
+`GHW_DISABLE_WARNINGS` environs variable:
+
+```
+$ ghwc memory
+WARNING:
+Could not determine total physical bytes of memory. This may
+be due to the host being a virtual machine or container with no
+/var/log/syslog file, or the current user may not have necessary
+privileges to read the syslog. We are falling back to setting the
+total physical amount of memory to the total usable amount of memory
+memory (24GB physical, 24GB usable)
+```
+
+```
+$ GHW_DISABLE_WARNINGS=1 ghwc memory
+memory (24GB physical, 24GB usable)
+```
+
 ### Memory
 
 Information about the host computer's memory can be retrieved using the

--- a/utils.go
+++ b/utils.go
@@ -14,6 +14,10 @@ import (
 	"strings"
 )
 
+const (
+	disableWarningsEnv = "GHW_DISABLE_WARNINGS"
+)
+
 type closer interface {
 	Close() error
 }
@@ -26,6 +30,9 @@ func safeClose(c closer) {
 }
 
 func warn(msg string, args ...interface{}) {
+	if _, ok := os.LookupEnv(disableWarningsEnv); ok {
+		return
+	}
 	_, _ = fmt.Fprint(os.Stderr, "WARNING: ")
 	_, _ = fmt.Fprintf(os.Stderr, msg, args...)
 }


### PR DESCRIPTION
With this patch, `ghw` now disables printing of warning messages when a
`GHW_DISABLE_WARNINGS` environ variable is set:

```
[jaypipes@uberbox ghw]$ go run cmd/ghwc/main.go memory
WARNING:
Could not determine total physical bytes of memory. This may
be due to the host being a virtual machine or container with no
/var/log/syslog file, or the current user may not have necessary
privileges to read the syslog. We are falling back to setting the
total physical amount of memory to the total usable amount of memory
memory (24GB physical, 24GB usable)
[jaypipes@uberbox ghw]$ GHW_DISABLE_WARNINGS=1 go run cmd/ghwc/main.go memory
memory (24GB physical, 24GB usable)
```

Issue #110