### PR TITLE
Map macOS bus protocols to BusType enum

### DIFF
--- a/block_darwin.go
+++ b/block_darwin.go
@@ -178,6 +178,15 @@ func (ctx *context) makePartition(disk, s diskOrPartitionPlistNode, isAPFS bool)
 	}, nil
 }
 
+func busTypeFromBusProtocol(busProtocol string) BusType {
+	switch busProtocol {
+	case "PCI-Express":
+		return BUS_TYPE_NVME // is this even correct?
+	default:
+		return BUS_TYPE_UNKNOWN
+	}
+}
+
 func (ctx *context) blockFillInfo(info *BlockInfo) error {
 	listPlist, err := ctx.getDiskUtilListPlist()
 	if err != nil {
@@ -214,7 +223,7 @@ func (ctx *context) blockFillInfo(info *BlockInfo) error {
 			Name:                   disk.DeviceIdentifier,
 			SizeBytes:              uint64(disk.Size),
 			PhysicalBlockSizeBytes: uint64(infoPlist.DeviceBlockSize),
-			BusType:                infoPlist.BusProtocol,
+			BusType:                busTypeFromBusProtocol(infoPlist.BusProtocol),
 			BusPath:                busPath,
 			NUMANodeID:             -1,
 			Vendor:                 ioregPlist.VendorName,


### PR DESCRIPTION
In macOS, the bus type is a string that comes from the IOKit BusProtocol field, whose legal values are not documented, and whose source is not available. The only value I've seen is `PCI-Express`, but this does not mean other things are not possible, just that I have not seen them so far.

BusType now being a string let me just pass them through and let the caller have something useful in cases I have not anticipated, but now I don't have a clean option. Always passing `BUS_TYPE_UNKNOWN` seems less than ideal...

