### PR TITLE
Added Optical drive support for Linux

### DIFF
--- a/block_linux.go
+++ b/block_linux.go
@@ -357,7 +357,12 @@ func (ctx *context) disks() []*Disk {
 			driveType = DRIVE_TYPE_HDD
 			busType = BUS_TYPE_NVME
 			storageController = STORAGE_CONTROLLER_NVME
+		} else if strings.HasPrefix(dname, "sr") {
+			driveType = DRIVE_TYPE_ODD
+			busType = BUS_TYPE_SCSI
+			storageController = STORAGE_CONTROLLER_SCSI
 		}
+
 		if driveType == DRIVE_TYPE_UNKNOWN {
 			continue
 		}


### PR DESCRIPTION
Sets the drive type to DRIVE_TYPE_ODD (optical disk) when the drive name starts with "sr" on Linux.