### PR TITLE
Adds JSON/YAML serialization for PCI device info

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,86 +2,62 @@
 
 
 [[projects]]
-  digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
   name = "github.com/ghodss/yaml"
   packages = ["."]
-  pruneopts = ""
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
-  pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
-  digest = "1:04a2745baaf3f123935a565182f40763920c8fea322c141373f8d7bd3ffc6aaa"
   name = "github.com/jaypipes/pcidb"
   packages = ["."]
-  pruneopts = ""
-  revision = "141a53e65d4ad43fdbd2760c714344da88f24adb"
-  version = "0.3"
+  revision = "4d488f78747b8369c9f5bb93462241a30d178059"
+  version = "0.4"
 
 [[projects]]
-  digest = "1:096a8a9182648da3d00ff243b88407838902b6703fc12657f76890e08d1899bf"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
-  pruneopts = ""
   revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = ""
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:a1403cc8a94b8d7956ee5e9694badef0e7b051af289caad1cf668331e3ffa4f6"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  pruneopts = ""
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
   version = "v0.0.3"
 
 [[projects]]
-  digest = "1:0a52bcb568386d98f4894575d53ce3e456f56471de6897bb8b9de13c33d9340e"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = ""
   revision = "9a97c102cda95a86cec2345a6f09f55a939babf5"
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:cedccf16b71e86db87a24f8d4c70b0a855872eb967cb906a66b95de56aefbd0d"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = ""
   revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
   version = "v2.2.2"
 
 [[projects]]
-  digest = "1:e43acd1190dde7223727f1f8aeac537156d33bf87776d5637e672e1c6b354be4"
   name = "howett.net/plist"
   packages = ["."]
-  pruneopts = ""
   revision = "591f970eefbbeb04d7b37f334a0c4c3256e32876"
   source = "github.com/DHowett/go-plist"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/ghodss/yaml",
-    "github.com/jaypipes/pcidb",
-    "github.com/pkg/errors",
-    "github.com/spf13/cobra",
-    "howett.net/plist",
-  ]
+  inputs-digest = "2c29eca540094f0a653a93a94c3ed2fef140e88933bf2df7641cf73a2d810256"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,7 +3,7 @@
 
 [[constraint]]
   name = "github.com/jaypipes/pcidb"
-  version = "0.3"
+  version = "0.4"
 
 [[constraint]]
   name = "github.com/spf13/cobra"

--- a/block.go
+++ b/block.go
@@ -100,6 +100,8 @@ type Disk struct {
 	SerialNumber string       `json:"serial_number"`
 	WWN          string       `json:"wwn"`
 	Partitions   []*Partition `json:"partitions"`
+	// TODO(jaypipes): Add PCI field for accessing PCI device information
+	// PCI *PCIDevice `json:"pci"`
 }
 
 // Partition describes a logical division of a Disk.

--- a/gpu.go
+++ b/gpu.go
@@ -18,9 +18,8 @@ type GraphicsCard struct {
 	Index int `json:"index"`
 	// pointer to a PCIDevice struct that describes the vendor and product
 	// model, etc
-	// NOTE(jaypipes): Don't serialize the PCI device information until pcidb
-	// library is updated to marshal properly
-	DeviceInfo *PCIDevice `json:"-"`
+	// TODO(jaypipes): Rename this field to PCI, instead of DeviceInfo
+	DeviceInfo *PCIDevice `json:"pci"`
 	// Topology node that the graphics card is affined to. Will be nil if the
 	// architecture is not NUMA.
 	Node *TopologyNode `json:"node,omitempty"`

--- a/net.go
+++ b/net.go
@@ -21,6 +21,8 @@ type NIC struct {
 	MacAddress   string           `json:"mac_address"`
 	IsVirtual    bool             `json:"is_virtual"`
 	Capabilities []*NICCapability `json:"capabilities"`
+	// TODO(jaypipes): Add PCI field for accessing PCI device information
+	// PCI *PCIDevice `json:"pci"`
 }
 
 func (n *NIC) String() string {


### PR DESCRIPTION
With this patch, PCI device information (currently only on the
GPU/GraphicsCard struct) is serialized to JSON and YAML. In order to
prevent outputting all of the nested PCIDB structs, we required a custom
MarshalJSON marshaler for the PCIDevice struct pointer that only outputs
the ID and name of the vendor, product, class and subsystem instead of
all the vendor's subproducts, etc.

```
[jaypipes@uberbox ghw]$ go run cmd/ghwc/main.go gpu -fyaml
gpu:
  cards:
  - address: "0000:03:00.0"
    index: 0
    pci:
      address: "0000:03:00.0"
      class:
        id: "03"
        name: Display controller
      product:
        id: 1c82
        name: GP107 [GeForce GTX 1050 Ti]
      programming_interface:
        id: "00"
        name: VGA controller
      subclass:
        id: "00"
        name: VGA compatible controller
      subsystem:
        id: "8613"
        name: unknown
      vendor:
        id: 10de
        name: NVIDIA Corporation
```

Issue #78