### PR TITLE
Added support for parsing AWS xvd prefixed block devices

### DIFF
--- a/block_linux.go
+++ b/block_linux.go
@@ -361,6 +361,10 @@ func (ctx *context) disks() []*Disk {
 			driveType = DRIVE_TYPE_ODD
 			busType = BUS_TYPE_SCSI
 			storageController = STORAGE_CONTROLLER_SCSI
+		} else if strings.HasPrefix(dname, "xvd") {
+			driveType = DRIVE_TYPE_HDD
+			busType = BUS_TYPE_SCSI
+			storageController = STORAGE_CONTROLLER_SCSI
 		}
 
 		if driveType == DRIVE_TYPE_UNKNOWN {


### PR DESCRIPTION
The current parser ignores `/dev/xvd*` block devices :( this should fix it