### PR TITLE
dmi: add support for getting dmi info

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ information about the host computer:
 * [Network](#network)
 * [PCI](#pci)
 * [GPU](#gpu)
+* [DMI](#dmi)
 * [YAML and JSON serialization](#serialization)
 
 ### Overriding the root mountpoint `ghw` uses
@@ -823,6 +824,71 @@ information
 **NOTE**: You can [read more](#topology) about the fields of the
 `ghw.TopologyNode` struct if you'd like to dig deeper into the NUMA/topology
 subsystem
+
+### DMI
+
+The information of the host machine's details such as BIOS, product, board
+and chassis information are accessible from the `ghw.DMI()` function.  This
+function returns a pointer to a `ghw.DMIInfo` struct.
+
+The `ghw.DMIInfo` struct contains multiple fields:
+
+* `ghw.DMIInfo.BIOSInfo` is a struct containing BIOS information including
+  things like date and version.
+* `ghw.DMIInfo.BoardInfo` is a struct containing motherboard information
+  with details on asset tags, serial, type and vendor with version.
+* `ghw.DMIInfo.ChassisInfo` is a struct containing chassis information
+  with specifics to model, serial and vendor.
+* `ghw.DMIInfo.ProductInfo` is a struct containing product information
+  giving you what type of system you have
+* `ghw.DMIInfo.SystemInfo` is a struct containing system information,
+  mostly around system vendor.
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/jaypipes/ghw"
+)
+
+func main() {
+	dmi, err := ghw.DMI()
+	if err != nil {
+		fmt.Printf("Error getting DMI info: %v", err)
+	}
+
+	fmt.Printf("%v\n", dmi)
+}
+```
+
+Example output from my personal workstation:
+
+```
+dmi
+  bios: {Date:08/06/2019 Vendor:LENOVO Version:N2EET42W (1.24 )}
+  board: {AssetTag:Not Available Serial:unknown Vendor:LENOVO Version:SDK0J40697 WIN}
+  chassis: {AssetTag:No Asset Information Serial:unknown Type:10 Vendor:LENOVO Version:None}
+  product: {Name:20MF000DUS Serial:unknown UUID:unknown Version:ThinkPad X1 Extreme}
+  system: {Vendor:LENOVO}
+```
+
+**NOTE**: Some of the values such as serial numbers are shown as unknown because
+the Linux kernel by default disallows access to those fields if you're not running
+as root.  They will be populated if it runs as root or otherwise you may see warnings
+like the following:
+
+```
+WARNING: Unable to read board_serial because of open /sys/class/dmi/id/board_serial: permission denied
+WARNING: Unable to read chassis_serial because of open /sys/class/dmi/id/chassis_serial: permission denied
+WARNING: Unable to read product_serial because of open /sys/class/dmi/id/product_serial: permission denied
+WARNING: Unable to read product_uuid because of open /sys/class/dmi/id/product_uuid: permission denied
+```
+
+You can ignore them or use the [Disabling warning messages](#disabling-warning-messages)
+feature to quiet things down.
+
 
 ## Serialization
 

--- a/cmd/ghwc/commands/dmi.go
+++ b/cmd/ghwc/commands/dmi.go
@@ -1,0 +1,44 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/jaypipes/ghw"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// dmiCmd represents the install command
+var dmiCmd = &cobra.Command{
+	Use:   "dmi",
+	Short: "Show DMI information for the host system",
+	RunE:  showDMI,
+}
+
+// showDMI show DMI information for the host system.
+func showDMI(cmd *cobra.Command, args []string) error {
+	dmi, err := ghw.DMI()
+	if err != nil {
+		return errors.Wrap(err, "error getting DMI info")
+	}
+
+	switch outputFormat {
+	case outputFormatHuman:
+		fmt.Printf("%v\n", dmi)
+	case outputFormatJSON:
+		fmt.Printf("%s\n", dmi.JSONString(pretty))
+	case outputFormatYAML:
+		fmt.Printf("%s", dmi.YAMLString())
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(dmiCmd)
+}

--- a/cmd/ghwc/commands/root.go
+++ b/cmd/ghwc/commands/root.go
@@ -63,6 +63,9 @@ func showAll(cmd *cobra.Command, args []string) error {
 		if err := showBlock(cmd, args); err != nil {
 			return err
 		}
+		if err := showDMI(cmd, args); err != nil {
+			return err
+		}
 		if err := showCPU(cmd, args); err != nil {
 			return err
 		}

--- a/dmi.go
+++ b/dmi.go
@@ -1,0 +1,116 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ghw
+
+import (
+	"fmt"
+)
+
+// DMIInfo describes all the information for the hardware
+type DMIInfo struct {
+	BIOS    BIOSInfo    `json:"bios_info"`
+	Board   BoardInfo   `json:"board"`
+	Chassis ChassisInfo `json:"chassis"`
+	Product ProductInfo `json:"product"`
+	System  SystemInfo  `json:"system"`
+}
+
+// BIOSInfo defines BIOS release information
+type BIOSInfo struct {
+	Date    string `json:"date"`
+	Vendor  string `json:"vendor"`
+	Version string `json:"version"`
+}
+
+// BoardInfo defines motherboard release information
+type BoardInfo struct {
+	AssetTag string `json:"asset_tag"`
+	Serial   string `json:"serial"`
+	Vendor   string `json:"vendor"`
+	Version  string `json:"version"`
+}
+
+// ChassisInfo defines chassis release information
+type ChassisInfo struct {
+	AssetTag string `json:"asset_tag"`
+	Serial   string `json:"serial"`
+	Type     string `json:"type"`
+	Vendor   string `json:"vendor"`
+	Version  string `json:"version"`
+}
+
+// ProductInfo defines product information
+type ProductInfo struct {
+	Name    string `json:"name"`
+	Serial  string `json:"serial"`
+	UUID    string `json:"uuid"`
+	Version string `json:"version"`
+}
+
+// SystemInfo defines system information
+type SystemInfo struct {
+	Vendor string `json:"vendor"`
+}
+
+func (info *DMIInfo) String() string {
+	return fmt.Sprintf(
+		"dmi\n  bios: %+v\n  board: %+v\n  chassis: %+v\n  product: %+v\n  system: %+v",
+		info.BIOS,
+		info.Board,
+		info.Chassis,
+		info.Product,
+		info.System,
+	)
+}
+
+// func (productInfo *ProductInfo) String() string {
+// 	return fmt.Sprintf(
+// 		"%s serial='%s' uuid:'%s' version:'%s'",
+// 		productInfo.Name,
+// 		productInfo.Serial,
+// 		productInfo.UUID,
+// 		productInfo.Version,
+// 	)
+// }
+
+// func (systemInfo *SystemInfo) String() string {
+// 	return fmt.Sprintf(
+// 		"vendor='%s'",
+// 		systemInfo.Vendor,
+// 	)
+// }
+
+// DMI provides motherboard, chassis and BIOS information
+func DMI(opts ...*WithOption) (*DMIInfo, error) {
+	mergeOpts := mergeOptions(opts...)
+	ctx := &context{
+		chroot: *mergeOpts.Chroot,
+	}
+	info := &DMIInfo{}
+	if err := ctx.dmiFillInfo(info); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+// simple private struct used to encapsulate DMI information in a top-level
+// "dmi" YAML/JSON map/object key
+type dmiPrinter struct {
+	Info *DMIInfo `json:"dmi"`
+}
+
+// YAMLString returns a string with the DMI information formatted as YAML
+// under a top-level "dmi:" key
+func (info *DMIInfo) YAMLString() string {
+	return safeYAML(dmiPrinter{info})
+}
+
+// JSONString returns a string with the DMI information formatted as JSON
+// under a top-level "dmi:" key
+func (info *DMIInfo) JSONString(indent bool) string {
+	return safeJSON(dmiPrinter{info}, indent)
+}

--- a/dmi_linux.go
+++ b/dmi_linux.go
@@ -1,0 +1,49 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ghw
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func (ctx *context) dmiFillInfo(info *DMIInfo) error {
+	info.BIOS.Date = readDMI("bios_date")
+	info.BIOS.Vendor = readDMI("bios_vendor")
+	info.BIOS.Version = readDMI("bios_version")
+
+	info.Board.AssetTag = readDMI("board_asset_tag")
+	info.Board.Serial = readDMI("board_serial")
+	info.Board.Vendor = readDMI("board_vendor")
+	info.Board.Version = readDMI("board_version")
+
+	info.Chassis.AssetTag = readDMI("chassis_asset_tag")
+	info.Chassis.Serial = readDMI("chassis_serial")
+	info.Chassis.Type = readDMI("chassis_type")
+	info.Chassis.Vendor = readDMI("chassis_vendor")
+	info.Chassis.Version = readDMI("chassis_version")
+
+	info.Product.Name = readDMI("product_name")
+	info.Product.Serial = readDMI("product_serial")
+	info.Product.UUID = readDMI("product_uuid")
+	info.Product.Version = readDMI("product_version")
+
+	info.System.Vendor = readDMI("sys_vendor")
+
+	return nil
+}
+
+func readDMI(value string) string {
+	path := "/sys/class/dmi/id/" + value
+
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		warn("Unable to read " + value + " because of " + err.Error() + "\n")
+		return UNKNOWN
+	}
+
+	return strings.TrimSpace(string(b))
+}

--- a/dmi_stub.go
+++ b/dmi_stub.go
@@ -1,0 +1,17 @@
+// +build !linux
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ghw
+
+import (
+	"runtime"
+
+	"github.com/pkg/errors"
+)
+
+func (ctx *context) dmiFillInfo(info *DMIInfo) error {
+	return errors.New("dmiFillInfo not implemented on " + runtime.GOOS)
+}

--- a/dmi_test.go
+++ b/dmi_test.go
@@ -1,0 +1,29 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package ghw
+
+import (
+	"testing"
+)
+
+func TestDMI(t *testing.T) {
+	info, err := DMI()
+	if err != nil {
+		t.Fatalf("Expected no error creating DMIInfo, but got %v", err)
+	}
+
+	// NOTE(mnaser): This isn't the most ideal of tests but those two values
+	//               seem to consistently always supply a value in my testing.
+
+	if info.Product.Name == UNKNOWN {
+		t.Fatalf("Got unknown product name.")
+	}
+
+	if info.Product.Version == UNKNOWN {
+		t.Fatalf("Got unknown product version.")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ type HostInfo struct {
 	Topology *TopologyInfo `json:"topology"`
 	Network  *NetworkInfo  `json:"network"`
 	GPU      *GPUInfo      `json:"gpu"`
+	DMI      *DMIInfo      `json:"dmi"`
 }
 
 // Host returns a pointer to a HostInfo struct that contains fields with
@@ -60,6 +61,10 @@ func Host(opts ...*WithOption) (*HostInfo, error) {
 	if err := ctx.gpuFillInfo(gpu); err != nil {
 		return nil, err
 	}
+	dmi := &DMIInfo{}
+	if err := ctx.dmiFillInfo(dmi); err != nil {
+		return nil, err
+	}
 	return &HostInfo{
 		CPU:      cpu,
 		Memory:   mem,
@@ -67,6 +72,7 @@ func Host(opts ...*WithOption) (*HostInfo, error) {
 		Topology: topology,
 		Network:  net,
 		GPU:      gpu,
+		DMI:      dmi,
 	}, nil
 }
 
@@ -74,8 +80,9 @@ func Host(opts ...*WithOption) (*HostInfo, error) {
 // structs' String-ified output
 func (info *HostInfo) String() string {
 	return fmt.Sprintf(
-		"%s\n%s\n%s\n%s\n%s\n%s\n",
+		"%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
 		info.Block.String(),
+		info.DMI.String(),
 		info.CPU.String(),
 		info.GPU.String(),
 		info.Memory.String(),


### PR DESCRIPTION
DMI provides a bunch of useful things such as product name, vendor
manufacturer and a bunch of other things that are useful at identifying
more information regarding the host with regards of what vendor
made the system, etc.