### PR TITLE
Case where ioreg returns zero-length output

### DIFF
--- a/block_darwin.go
+++ b/block_darwin.go
@@ -137,6 +137,9 @@ func (ctx *context) getIoregPlist(ioDeviceTreePath string) (*ioregPlist, error) 
 	if err != nil {
 		return nil, errors.Wrapf(err, "ioreg query for %q failed", ioDeviceTreePath)
 	}
+	if out == nil || len(out) == 0 {
+		return nil, nil
+	}
 
 	var data []ioregPlist
 	if _, err := plist.Unmarshal(out, &data); err != nil {
@@ -245,6 +248,9 @@ func (ctx *context) blockFillInfo(info *BlockInfo) error {
 		ioregPlist, err := ctx.getIoregPlist(infoPlist.DeviceTreePath)
 		if err != nil {
 			return err
+		}
+		if ioregPlist == nil {
+			continue
 		}
 
 		// The NUMA node & WWN don't seem to be reported by any tools available by default in macOS.


### PR DESCRIPTION
This is a situation that happened on a:
Darwin MacBook-Pro.local 18.7.0 Darwin Kernel Version 18.7.0:
Tue Aug 20 16:57:14 PDT 2019; root:xnu-4903.271.2~2/RELEASE_X86_64 x86_64

func (ctx *context) getIoregPlist(ioDeviceTreePath string) (*ioregPlist, error)

Can get an argument value of "IODeviceTree:/". This means that it shells
out to ioreg like this: "ioreg -a -d 1 -r -n IODeviceTree:"
It gives back no output. This should handle that case.