### PR TITLE
Fix partitionSizeBytes for MMC/SD block devices

### DIFF
--- a/block_linux.go
+++ b/block_linux.go
@@ -20,9 +20,6 @@ const (
 	sectorSize = 512
 )
 
-var regexNVMeDev = regexp.MustCompile(`^nvme\d+n\d+$`)
-var regexNVMePart = regexp.MustCompile(`^(nvme\d+n\d+)p\d+$`)
-
 func (ctx *context) blockFillInfo(info *BlockInfo) error {
 	info.Disks = ctx.disks()
 	var tpb uint64
@@ -282,11 +279,16 @@ The DiskPartitions() function has been DEPRECATED and will be removed in the
 	return ctx.diskPartitions(disk)
 }
 
+// diskPartitions takes the name of a disk (note: *not* the path of the disk,
+// but just the name. In other words, "sda", not "/dev/sda" and "nvme0n1" not
+// "/dev/nvme0n1") and returns a slice of pointers to Partition structs
+// representing the partitions in that disk
 func (ctx *context) diskPartitions(disk string) []*Partition {
 	out := make([]*Partition, 0)
 	path := filepath.Join(ctx.pathSysBlock(), disk)
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
+		warn("diskPartitions: failed to read %s: %s", path, err)
 		return nil
 	}
 	for _, file := range files {
@@ -294,7 +296,7 @@ func (ctx *context) diskPartitions(disk string) []*Partition {
 		if !strings.HasPrefix(fname, disk) {
 			continue
 		}
-		size := ctx.partitionSizeBytes(fname)
+		size := ctx.partitionSizeBytes(disk, fname)
 		mp, pt, ro := ctx.partitionInfo(fname)
 		p := &Partition{
 			Name:       fname,
@@ -405,7 +407,7 @@ func diskTypes(dname string) (
 		driveType = DRIVE_TYPE_HDD
 		busType = BUS_TYPE_VIRTIO
 		storageController = STORAGE_CONTROLLER_VIRTIO
-	} else if regexNVMeDev.MatchString(dname) {
+	} else if strings.HasPrefix(dname, "nvme") {
 		driveType = DRIVE_TYPE_SSD
 		busType = BUS_TYPE_NVME
 		storageController = STORAGE_CONTROLLER_NVME
@@ -441,17 +443,42 @@ the 1.0 release of ghw. Please use the Partition.SizeBytes attribute.
 `
 	warn(msg)
 	ctx := contextFromEnv()
-	return ctx.partitionSizeBytes(part)
+	disk := strings.TrimPrefix(part, "/dev")
+	if len(disk) < 3 {
+		warn("PartitionSizeBytes: unknown disk %s, returning 0", disk)
+		return 0
+	}
+	switch disk[0:2] {
+	case "fd":
+	case "sd":
+	case "hd":
+	case "vd":
+	case "sr":
+	case "mm":
+		disk = disk[0:3]
+	case "xv":
+		disk = disk[0:4]
+	case "nv":
+		// NOTE(jaypipes): I'm putting this regex here instead of a const
+		// because this function is the only thing that uses it and I'm
+		// deprecating this function in 1.0
+		// nvme0n1p2
+		var regexNVMeDev = regexp.MustCompile(`^nvme\d+n\d+$`)
+		matches := regexNVMeDev.FindSubmatch([]byte(disk))
+		if len(matches) < 1 {
+			warn("PartitionSizeBytes: unknown disk %s, returning 0", disk)
+			return 0
+		}
+		disk = string(matches[0])
+	}
+	return ctx.partitionSizeBytes(disk, part)
 }
 
-func (ctx *context) partitionSizeBytes(part string) uint64 {
-	// Allow calling PartitionSize with either the full partition name
-	// "/dev/sda1" or just "sda1"
-	part = strings.TrimPrefix(part, "/dev")
-	disk := part[0:3]
-	if m := regexNVMePart.FindStringSubmatch(part); len(m) > 0 {
-		disk = m[1]
-	}
+// partitionSizeBytes returns the size in bytes of the partition given a disk
+// name and a partition name. Note: disk name and partition name do *not*
+// contain any leading "/dev" parts. In other words, they are *names*, not
+// paths.
+func (ctx *context) partitionSizeBytes(disk string, part string) uint64 {
 	path := filepath.Join(ctx.pathSysBlock(), disk, part, "size")
 	contents, err := ioutil.ReadFile(path)
 	if err != nil {

--- a/block_test.go
+++ b/block_test.go
@@ -67,7 +67,7 @@ func TestBlock(t *testing.T) {
 	for _, p := range d0.Partitions {
 		// Check that all the singular functions return the same information as
 		// the information constructed by ghw.Block()
-		ps := ctx.partitionSizeBytes(p.Name)
+		ps := ctx.partitionSizeBytes(d0.Name, p.Name)
 		if ps != p.SizeBytes {
 			t.Fatalf("Expected matching size, but got %d != %d",
 				ps, p.SizeBytes)


### PR DESCRIPTION
Due to the way the `ctx.partitionSizeBytes` method was attempting to
determine the disk name by examining the partition name, we were not
properly handling MMC/SD drives. This patch resolves this issue by
moving the regex handling for determining disk names from a single
partition name string into the (deprecated in 0.2)
`ghw.PartitionSizeBytes` function and doing some string prefix matching
that handles all known disk types, including MMC/SD. This is no longer
necessary for the `ctx.partitionSizeBytes` method since this method now
takes the disk name and partition name as separate arguments.

Closes Issue #139