### PR TITLE
utility for generating static filesystem snapshot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.13-stretch as builder
+WORKDIR /go/src/github.com/jaypipes/ghw
+
+# Force the go compiler to use modules.
+ENV GO111MODULE=on
+ENV GOPROXY=direct
+
+# go.mod and go.sum go into their own layers.
+COPY go.mod .
+COPY go.sum .
+
+# This ensures `go mod download` happens only when go.mod and go.sum change.
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 go build -o ghwc ./cmd/ghwc/
+
+FROM alpine:3.7
+RUN apk add --no-cache ethtool
+
+WORKDIR /bin
+
+COPY --from=builder /go/src/github.com/jaypipes/ghw/ghwc /bin
+
+CMD ghwc

--- a/cmd/ghw-snapshot/main.go
+++ b/cmd/ghw-snapshot/main.go
@@ -1,0 +1,215 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// version of application at compile time (-X 'main.version=$(VERSION)').
+	version = "(Unknown Version)"
+	// buildHash GIT hash of application at compile time (-X 'main.buildHash=$(GITCOMMIT)').
+	buildHash = "No Git-hash Provided."
+	// buildDate of application at compile time (-X 'main.buildDate=$(BUILDDATE)').
+	buildDate = "No Build Date Provided."
+	// show debug output
+	debug = false
+	// output filepath to save snapshot to
+	outPath string
+)
+
+type FileInfoFilter func(os.FileInfo) (bool, error)
+
+var (
+	pseudoFiles = []string{
+		"/proc/cpuinfo",
+		"/proc/meminfo",
+	}
+)
+
+func regularFileFilter(fi os.FileInfo) (bool, error) {
+	return fi.Mode().IsRegular(), nil
+}
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "ghw-snapshot",
+	Short: "ghw-snapshot - Snapshot filesystem containing system information.",
+	RunE:  execute,
+}
+
+func trace(msg string, args ...interface{}) {
+	if !debug {
+		return
+	}
+	fmt.Printf(msg, args...)
+}
+
+func systemFingerprint() string {
+	return "jaypipes"
+}
+
+func defaultOutPath() string {
+	fp := systemFingerprint()
+	return fmt.Sprintf("%s-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH, fp)
+}
+
+func execute(cmd *cobra.Command, args []string) error {
+	// Attempting to tar up pseudofiles like /proc/cpuinfo is an exercise in
+	// futility. Instead, it is necessary to build a directory structure in a
+	// tmpdir and create actual files with copies of the pseudofile contents
+	scratchDir, err := ioutil.TempDir("", "ghw-snapshot")
+	if err != nil {
+		return err
+	}
+
+	var createPaths = []string{
+		"proc",
+		"sys/block",
+	}
+
+	for _, path := range createPaths {
+		if err = os.MkdirAll(filepath.Join(scratchDir, path), os.ModePerm); err != nil {
+			return err
+		}
+	}
+
+	if err = createProcfiles(scratchDir); err != nil {
+		return err
+	}
+	return doSnapshot(scratchDir)
+}
+
+func createProcfiles(buildDir string) error {
+	var createPaths = []string{
+		"/proc/cpuinfo",
+		"/proc/meminfo",
+	}
+
+	for _, path := range createPaths {
+		buf, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		targetPath := filepath.Join(buildDir, path)
+		f, err := os.Create(targetPath)
+		if err != nil {
+			return err
+		}
+		if _, err = f.Write(buf); err != nil {
+			return err
+		}
+		f.Close()
+	}
+	return nil
+}
+
+func doSnapshot(buildDir string) error {
+	if outPath == "" {
+		outPath = defaultOutPath()
+		trace("using default output filepath %s\n", outPath)
+	}
+
+	var f *os.File
+	var err error
+
+	if _, err = os.Stat(outPath); os.IsNotExist(err) {
+		if f, err = os.Create(outPath); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	} else {
+		f, err := os.OpenFile(outPath, os.O_WRONLY, 0600)
+		if err != nil {
+			return err
+		}
+		fs, err := f.Stat()
+		if err != nil {
+			return err
+		}
+		if fs.Size() > 0 {
+			return fmt.Errorf("File %s already exists and is of size >0", outPath)
+		}
+	}
+	defer f.Close()
+
+	gzw := gzip.NewWriter(f)
+	defer gzw.Close()
+
+	tw := tar.NewWriter(gzw)
+	defer tw.Close()
+
+	return createSnapshot(tw, buildDir)
+}
+
+func main() {
+	rootCmd.Execute()
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(
+		&outPath,
+		"out", "o",
+		outPath,
+		"Path to place snapshot. Defaults to file in current directory with name $OS-$ARCH-$HASHSYSTEMNAME.tar.gz",
+	)
+	rootCmd.PersistentFlags().BoolVarP(
+		&debug, "debug", "d", false, "Enable or disable debug mode",
+	)
+}
+
+func createSnapshot(tw *tar.Writer, buildDir string) error {
+	return filepath.Walk(buildDir, func(path string, fi os.FileInfo, err error) error {
+		if path == buildDir {
+			return nil
+		}
+		var link string
+
+		if fi.Mode()&os.ModeSymlink != 0 {
+			trace("processing symlink %s\n", path)
+			link, err = os.Readlink(path)
+			if err != nil {
+				return err
+			}
+		}
+
+		hdr, err := tar.FileInfoHeader(fi, link)
+		if err != nil {
+			return err
+		}
+		hdr.Name = strings.TrimPrefix(strings.TrimPrefix(path, buildDir), string(os.PathSeparator))
+
+		if err = tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeReg, tar.TypeRegA:
+			f, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			if _, err = io.Copy(tw, f); err != nil {
+				return err
+			}
+			f.Close()
+		}
+		return nil
+	})
+}

--- a/cmd/ghw-snapshot/main.go
+++ b/cmd/ghw-snapshot/main.go
@@ -1,3 +1,4 @@
+// +build linux
 //
 // Use and distribution licensed under the Apache license version 2.
 //

--- a/cmd/ghw-snapshot/main.go
+++ b/cmd/ghw-snapshot/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"archive/tar"
 	"compress/gzip"
+	"crypto/md5"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -61,7 +62,13 @@ func trace(msg string, args ...interface{}) {
 }
 
 func systemFingerprint() string {
-	return "jaypipes"
+	hn, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	m := md5.New()
+	io.WriteString(m, hn)
+	return fmt.Sprintf("%x", m.Sum(nil))
 }
 
 func defaultOutPath() string {
@@ -161,7 +168,16 @@ func createBlockDevices(buildDir string) error {
 		if err = os.Symlink(linkTargetPath, linkPath); err != nil {
 			return err
 		}
+		if err = createBlockDeviceDir(linkTargetPath); err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+func createBlockDeviceDir(deviceDir string) error {
+	// Populate the supplied directory (in our build filesystem) with all the
+	// appropriate information pseudofile contents for the block device
 	return nil
 }
 

--- a/hack/run-against-snapshot.sh
+++ b/hack/run-against-snapshot.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+SNAPSHOT_FILEPATH=${SNAPSHOT_FILEPATH:-$1}
+
+if [[ ! -f $SNAPSHOT_FILEPATH ]]; then
+    echo "Cannot find snapshot file. Please call $0 with path to snapshot or set SNAPSHOT_FILEPATH envvar."
+    exit 1
+fi
+
+root_dir=$(cd "$(dirname "$0").."; pwd)
+ghwc_image_name="ghwc"
+local_git_version=$(git describe --tags --always --dirty)
+IMAGE_VERSION=${IMAGE_VERSION:-$local_git_version}
+
+snap_tmp_dir=$(mktemp -d -t ghw-snap-test-XXX)
+
+echo "extracting snapshot $SNAPSHOT_FILEPATH to $snap_tmp_dir ..."
+tar -xf $SNAPSHOT_FILEPATH -C $snap_tmp_dir
+
+echo "building Docker image with ghwc ..."
+
+docker build -f $root_dir/Dockerfile -t $ghwc_image_name:$IMAGE_VERSION $root_dir
+
+echo "running ghwc Docker image with volume mount to snapshot dir ..."
+
+docker run -it -v $snap_tmp_dir:/host -e GHW_CHROOT="/host" $ghwc_image_name:$IMAGE_VERSION 


### PR DESCRIPTION
Issue #66 

Adds a new `ghw-snapshot` binary that creates a tarball containing
a static filesystem snapshot of the various pseudofiles in sysfs that
describe CPU, memory and block devices. A hack/run-against-snapshot.sh
script is included that builds the ghwc binary into a Docker image,
extracts a snapshot created by ghwc-snapshot into a tmpdir, and
runs the ghwc Docker image after bind-mounting the snapshot tmpdir
as /host.

This allows us to test ghw against a snapshot static filesystem from a
user's machine (Linux only for now)

Still remaining to do is include in the snapshot filesystem information
about graphics cards, NICs and udev database entries.