### PR TITLE
add partition information to snapshot

### DIFF
--- a/block_linux.go
+++ b/block_linux.go
@@ -288,8 +288,8 @@ func (ctx *context) diskPartitions(disk string) []*Partition {
 	path := filepath.Join(ctx.pathSysBlock(), disk)
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
-		warn("diskPartitions: failed to read %s: %s", path, err)
-		return nil
+		warn("failed to read disk partitions: %s\n", err)
+		return out
 	}
 	for _, file := range files {
 		fname := file.Name()
@@ -445,7 +445,7 @@ the 1.0 release of ghw. Please use the Partition.SizeBytes attribute.
 	ctx := contextFromEnv()
 	disk := strings.TrimPrefix(part, "/dev")
 	if len(disk) < 3 {
-		warn("PartitionSizeBytes: unknown disk %s, returning 0", disk)
+		warn("PartitionSizeBytes: unknown disk %s, returning 0\n", disk)
 		return 0
 	}
 	switch disk[0:2] {
@@ -466,7 +466,7 @@ the 1.0 release of ghw. Please use the Partition.SizeBytes attribute.
 		var regexNVMeDev = regexp.MustCompile(`^nvme\d+n\d+$`)
 		matches := regexNVMeDev.FindSubmatch([]byte(disk))
 		if len(matches) < 1 {
-			warn("PartitionSizeBytes: unknown disk %s, returning 0", disk)
+			warn("PartitionSizeBytes: unknown disk %s, returning 0\n", disk)
 			return 0
 		}
 		disk = string(matches[0])

--- a/cmd/ghw-snapshot/main.go
+++ b/cmd/ghw-snapshot/main.go
@@ -113,6 +113,7 @@ func createPseudofiles(buildDir string) error {
 			return err
 		}
 		targetPath := filepath.Join(buildDir, path)
+		trace("creating %s\n", targetPath)
 		f, err := os.Create(targetPath)
 		if err != nil {
 			return err
@@ -196,23 +197,27 @@ func createBlockDeviceDir(buildDeviceDir string, srcDeviceDir string) error {
 		if err != nil {
 			return err
 		}
-		// Ignore any symlinks in the deviceDir since they simply point to either
-		// self-referential links or information we aren't interested in like
-		// "subsystem"
 		if fi.Mode()&os.ModeSymlink != 0 {
+			// Ignore any symlinks in the deviceDir since they simply point to
+			// either self-referential links or information we aren't
+			// interested in like "subsystem"
 			continue
-		}
-		if fi.IsDir() {
-			// The only directories we're interested in are the directories
-			// that begin with the block device name. These are directories
-			// with information about the partitions on the device
-			if !strings.HasPrefix(fname, devName) {
+		} else if fi.IsDir() {
+			if strings.HasPrefix(fname, devName) {
+				// We're interested in are the directories that begin with the
+				// block device name. These are directories with information
+				// about the partitions on the device
 				buildPartitionDir := filepath.Join(
 					buildDeviceDir, fname,
 				)
 				srcPartitionDir := filepath.Join(
 					srcDeviceDir, fname,
 				)
+				trace("creating partition directory %s\n", buildPartitionDir)
+				err = os.MkdirAll(buildPartitionDir, os.ModePerm)
+				if err != nil {
+					return err
+				}
 				err = createPartitionDir(buildPartitionDir, srcPartitionDir)
 				if err != nil {
 					return err
@@ -227,6 +232,7 @@ func createBlockDeviceDir(buildDeviceDir string, srcDeviceDir string) error {
 				return err
 			}
 			targetPath := filepath.Join(buildDeviceDir, fname)
+			trace("creating %s\n", targetPath)
 			f, err := os.Create(targetPath)
 			if err != nil {
 				return err
@@ -237,10 +243,80 @@ func createBlockDeviceDir(buildDeviceDir string, srcDeviceDir string) error {
 			f.Close()
 		}
 	}
+	// There is a special file $DEVICE_DIR/queue/rotational that, for some hard
+	// drives, contains a 1 or 0 indicating whether the device is a spinning
+	// disk or not
+	srcQueueDir := filepath.Join(
+		srcDeviceDir,
+		"queue",
+	)
+	buildQueueDir := filepath.Join(
+		buildDeviceDir,
+		"queue",
+	)
+	err = os.MkdirAll(buildQueueDir, os.ModePerm)
+	fp := filepath.Join(srcQueueDir, "rotational")
+	buf, err := ioutil.ReadFile(fp)
+	if err != nil {
+		return err
+	}
+	targetPath := filepath.Join(buildQueueDir, "rotational")
+	trace("creating %s\n", targetPath)
+	f, err := os.Create(targetPath)
+	if err != nil {
+		return err
+	}
+	if _, err = f.Write(buf); err != nil {
+		return err
+	}
+	f.Close()
+
 	return nil
 }
 
 func createPartitionDir(buildPartitionDir string, srcPartitionDir string) error {
+	// Populate the supplied directory (in our build filesystem) with all the
+	// appropriate information pseudofile contents for the partition.
+	partFiles, err := ioutil.ReadDir(srcPartitionDir)
+	if err != nil {
+		return err
+	}
+	for _, f := range partFiles {
+		fname := f.Name()
+		fp := filepath.Join(srcPartitionDir, fname)
+		fi, err := os.Lstat(fp)
+		if err != nil {
+			return err
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			// Ignore any symlinks in the partition directory since they simply
+			// point to information we aren't interested in like "subsystem"
+			continue
+		} else if fi.IsDir() {
+			// The subdirectories in the partition directory are not
+			// interesting for us. They have information about power events and
+			// traces
+			continue
+		} else if fi.Mode().IsRegular() {
+			// Regular files in the block device directory are both regular and
+			// pseudofiles containing information such as the size (in sectors)
+			// and whether the device is read-only
+			buf, err := ioutil.ReadFile(fp)
+			if err != nil {
+				return err
+			}
+			targetPath := filepath.Join(buildPartitionDir, fname)
+			trace("creating %s\n", targetPath)
+			f, err := os.Create(targetPath)
+			if err != nil {
+				return err
+			}
+			if _, err = f.Write(buf); err != nil {
+				return err
+			}
+			f.Close()
+		}
+	}
 	return nil
 }
 

--- a/cmd/ghw-snapshot/main.go
+++ b/cmd/ghw-snapshot/main.go
@@ -35,18 +35,12 @@ var (
 	outPath string
 )
 
-type FileInfoFilter func(os.FileInfo) (bool, error)
-
 var (
-	pseudoFiles = []string{
+	createPseudofilePaths = []string{
 		"/proc/cpuinfo",
 		"/proc/meminfo",
 	}
 )
-
-func regularFileFilter(fi os.FileInfo) (bool, error) {
-	return fi.Mode().IsRegular(), nil
-}
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -111,12 +105,7 @@ func execute(cmd *cobra.Command, args []string) error {
 // Instead, it is necessary to build a directory structure in a tmpdir and
 // create actual files with copies of the pseudofile contents
 func createPseudofiles(buildDir string) error {
-	var createPaths = []string{
-		"/proc/cpuinfo",
-		"/proc/meminfo",
-	}
-
-	for _, path := range createPaths {
+	for _, path := range createPseudofilePaths {
 		buf, err := ioutil.ReadFile(path)
 		if err != nil {
 			return err

--- a/cmd/ghw-snapshot/main.go
+++ b/cmd/ghw-snapshot/main.go
@@ -39,6 +39,7 @@ var (
 	createPseudofilePaths = []string{
 		"/proc/cpuinfo",
 		"/proc/meminfo",
+		"/etc/mtab",
 	}
 )
 
@@ -80,6 +81,7 @@ func execute(cmd *cobra.Command, args []string) error {
 
 	var createPaths = []string{
 		"proc",
+		"etc",
 		"sys/block",
 	}
 

--- a/hack/run-against-snapshot.sh
+++ b/hack/run-against-snapshot.sh
@@ -7,7 +7,7 @@ if [[ ! -f $SNAPSHOT_FILEPATH ]]; then
     exit 1
 fi
 
-root_dir=$(cd "$(dirname "$0").."; pwd)
+root_dir=$(cd "$(dirname "$0")/.."; pwd)
 ghwc_image_name="ghwc"
 local_git_version=$(git describe --tags --always --dirty)
 IMAGE_VERSION=${IMAGE_VERSION:-$local_git_version}

--- a/utils.go
+++ b/utils.go
@@ -39,18 +39,19 @@ func warn(msg string, args ...interface{}) {
 
 // Reads a supplied filepath and converts the contents to an integer. Returns
 // -1 if there were file permissions or existence errors or if the contents
-// could not be successfully converted to an integer. In any error, a message
-// is printed to STDERR, but -1 is returned.
+// could not be successfully converted to an integer. In any error, a warning
+// message is printed to STDERR and -1 is returned.
 func safeIntFromFile(path string) int {
+	msg := "failed to read int from file: %s\n"
 	buf, err := ioutil.ReadFile(path)
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		warn(msg, err)
 		return -1
 	}
 	contents := strings.TrimSpace(string(buf))
 	res, err := strconv.Atoi(contents)
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		warn(msg, err)
 		return -1
 	}
 	return res


### PR DESCRIPTION
Adds information about disk partitions to the static filesystem snapshot
constructed by `ghw-snapshot` by creating the files that `ghw.blockFillInfo()`
ends up querying on Linux. There are still issues, however, with Docker not
respecting symlinks in host-mounted directories, which results in failure to
determine partition information properly:

```
jaypipes@thelio:~/go/src/github.com/jaypipes/ghw$ ./hack/run-against-snapshot.sh linux-amd64-2f07bdc5e6c060b2ad2f6c65799544fa.tar.gz 
extracting snapshot linux-amd64-2f07bdc5e6c060b2ad2f6c65799544fa.tar.gz to /tmp/ghw-snap-test-QhB ...
building Docker image with ghwc ...
<snip>
running ghwc Docker image with volume mount to snapshot dir ...
WARNING: failed to read int from file: open /host/sys/block/nvme0n1/queue/rotational: no such file or directory
WARNING: failed to read disk partitions: open /host/sys/block/nvme0n1: no such file or directory
WARNING: failed to read int from file: open /host/sys/block/sda/queue/rotational: no such file or directory
WARNING: failed to read disk partitions: open /host/sys/block/sda: no such file or directory
block storage (2 disks, unknown physical storage)
 /dev/nvme0n1 SSD (unknown) NVMe [@unknown] vendor=unknown
 /dev/sda SSD (unknown) SCSI [@unknown] vendor=unknown
```

Issue #66