### PR TITLE
cmd/ghw-snapshot: fix dropped error

### DIFF
--- a/cmd/ghw-snapshot/main.go
+++ b/cmd/ghw-snapshot/main.go
@@ -255,6 +255,9 @@ func createBlockDeviceDir(buildDeviceDir string, srcDeviceDir string) error {
 		"queue",
 	)
 	err = os.MkdirAll(buildQueueDir, os.ModePerm)
+	if err != nil {
+		return err
+	}
 	fp := filepath.Join(srcQueueDir, "rotational")
 	buf, err := ioutil.ReadFile(fp)
 	if err != nil {


### PR DESCRIPTION
This fixes a dropped `err` variable in `cmd/ghw-snapshot`.