### PR TITLE
Update travis to test go1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ matrix:
     - os: linux
       go: "1.13"
       env: GO111MODULE=on
+    - os: linux
+      go: "1.14.x"
+      env: GO111MODULE=on
+
     # Tests that ghw builds on MacOSX (even though there is currently only
     # support for block devices)
     #- os: osx


### PR DESCRIPTION
If now is the time, here is an update to `.travis.yml` to test against Go 1.14.x.