### PR TITLE
context.memTotalPhysicalBytes(): Use a Syscall

### DIFF
--- a/path_linux.go
+++ b/path_linux.go
@@ -9,10 +9,6 @@ import (
 	"path/filepath"
 )
 
-func (ctx *context) pathVarLog() string {
-	return filepath.Join(ctx.chroot, "var", "log")
-}
-
 func (ctx *context) pathProcMeminfo() string {
 	return filepath.Join(ctx.chroot, "proc", "meminfo")
 }


### PR DESCRIPTION
This looks to be either:

1. Me not understanding a corner case that requires getting memory information out of logfiles.

2. A good place to use `syscall`.

If you're open to using system calls instead of parsing files, there are probably a few more commits like this in me.