### PR TITLE
[windows] handle nil strings in WMI output

### DIFF
--- a/baseboard_windows.go
+++ b/baseboard_windows.go
@@ -10,10 +10,10 @@ import "github.com/StackExchange/wmi"
 const wqlBaseboard = "SELECT Manufacturer, SerialNumber, Tag, Version FROM Win32_BaseBoard"
 
 type win32Baseboard struct {
-	Manufacturer string
-	SerialNumber string
-	Tag          string
-	Version      string
+	Manufacturer *string
+	SerialNumber *string
+	Tag          *string
+	Version      *string
 }
 
 func (ctx *context) baseboardFillInfo(info *BaseboardInfo) error {
@@ -23,10 +23,10 @@ func (ctx *context) baseboardFillInfo(info *BaseboardInfo) error {
 		return err
 	}
 	if len(win32BaseboardDescriptions) > 0 {
-		info.AssetTag = win32BaseboardDescriptions[0].Tag
-		info.SerialNumber = win32BaseboardDescriptions[0].SerialNumber
-		info.Vendor = win32BaseboardDescriptions[0].Manufacturer
-		info.Version = win32BaseboardDescriptions[0].Version
+		info.AssetTag = *win32BaseboardDescriptions[0].Tag
+		info.SerialNumber = *win32BaseboardDescriptions[0].SerialNumber
+		info.Vendor = *win32BaseboardDescriptions[0].Manufacturer
+		info.Version = *win32BaseboardDescriptions[0].Version
 	}
 
 	return nil

--- a/bios_windows.go
+++ b/bios_windows.go
@@ -10,9 +10,9 @@ import "github.com/StackExchange/wmi"
 const wqlBIOS = "SELECT InstallDate, Manufacturer, Version FROM CIM_BIOSElement"
 
 type win32BIOS struct {
-	InstallDate  string
-	Manufacturer string
-	Version      string
+	InstallDate  *string
+	Manufacturer *string
+	Version      *string
 }
 
 func (ctx *context) biosFillInfo(info *BIOSInfo) error {
@@ -22,9 +22,9 @@ func (ctx *context) biosFillInfo(info *BIOSInfo) error {
 		return err
 	}
 	if len(win32BIOSDescriptions) > 0 {
-		info.Vendor = win32BIOSDescriptions[0].Manufacturer
-		info.Version = win32BIOSDescriptions[0].Version
-		info.Date = win32BIOSDescriptions[0].InstallDate
+		info.Vendor = *win32BIOSDescriptions[0].Manufacturer
+		info.Version = *win32BIOSDescriptions[0].Version
+		info.Date = *win32BIOSDescriptions[0].InstallDate
 	}
 	return nil
 }

--- a/chassis_windows.go
+++ b/chassis_windows.go
@@ -12,15 +12,15 @@ import (
 const wqlChassis = "SELECT Caption, Description, Name, Manufacturer, Model, SerialNumber, Tag, TypeDescriptions, Version FROM CIM_Chassis"
 
 type win32Chassis struct {
-	Caption          string
-	Description      string
-	Name             string
-	Manufacturer     string
-	Model            string
-	SerialNumber     string
-	Tag              string
+	Caption          *string
+	Description      *string
+	Name             *string
+	Manufacturer     *string
+	Model            *string
+	SerialNumber     *string
+	Tag              *string
 	TypeDescriptions []string
-	Version          string
+	Version          *string
 }
 
 func (ctx *context) chassisFillInfo(info *ChassisInfo) error {
@@ -30,12 +30,12 @@ func (ctx *context) chassisFillInfo(info *ChassisInfo) error {
 		return err
 	}
 	if len(win32ChassisDescriptions) > 0 {
-		info.AssetTag = win32ChassisDescriptions[0].Tag
-		info.SerialNumber = win32ChassisDescriptions[0].SerialNumber
+		info.AssetTag = *win32ChassisDescriptions[0].Tag
+		info.SerialNumber = *win32ChassisDescriptions[0].SerialNumber
 		info.Type = UNKNOWN // TODO:
-		info.TypeDescription = win32ChassisDescriptions[0].Model
-		info.Vendor = win32ChassisDescriptions[0].Manufacturer
-		info.Version = win32ChassisDescriptions[0].Version
+		info.TypeDescription = *win32ChassisDescriptions[0].Model
+		info.Vendor = *win32ChassisDescriptions[0].Manufacturer
+		info.Version = *win32ChassisDescriptions[0].Version
 	}
 	return nil
 }

--- a/cpu_windows.go
+++ b/cpu_windows.go
@@ -13,8 +13,8 @@ import (
 const wmqlProcessor = "SELECT Manufacturer, Name, NumberOfLogicalProcessors, NumberOfCores FROM Win32_Processor"
 
 type win32Processor struct {
-	Manufacturer              string
-	Name                      string
+	Manufacturer              *string
+	Name                      *string
 	NumberOfLogicalProcessors uint32
 	NumberOfCores             uint32
 }
@@ -44,8 +44,8 @@ func (ctx *context) processorsGet(win32descriptions []win32Processor) []*Process
 	for index, description := range win32descriptions {
 		p := &Processor{
 			Id:         index, // TODO: how to get a decent "Physical ID" to use ?
-			Model:      description.Name,
-			Vendor:     description.Manufacturer,
+			Model:      *description.Name,
+			Vendor:     *description.Manufacturer,
 			NumCores:   description.NumberOfCores,
 			NumThreads: description.NumberOfLogicalProcessors,
 		}

--- a/memory_windows.go
+++ b/memory_windows.go
@@ -19,19 +19,19 @@ type win32OperatingSystem struct {
 const wqlPhysicalMemory = "SELECT BankLabel, Capacity, DataWidth, Description, DeviceLocator, Manufacturer, Model, Name, PartNumber, PositionInRow, SerialNumber, Speed, Tag, TotalWidth FROM Win32_PhysicalMemory"
 
 type win32PhysicalMemory struct {
-	BankLabel     string
+	BankLabel     *string
 	Capacity      uint64
 	DataWidth     uint16
-	Description   string
-	DeviceLocator string
-	Manufacturer  string
-	Model         string
-	Name          string
-	PartNumber    string
+	Description   *string
+	DeviceLocator *string
+	Manufacturer  *string
+	Model         *string
+	Name          *string
+	PartNumber    *string
 	PositionInRow uint32
-	SerialNumber  string
+	SerialNumber  *string
 	Speed         uint32
-	Tag           string
+	Tag           *string
 	TotalWidth    uint16
 }
 
@@ -51,11 +51,11 @@ func (ctx *context) memFillInfo(info *MemoryInfo) error {
 	for _, description := range win32MemDescriptions {
 		totalPhysicalBytes += description.Capacity
 		info.Modules = append(info.Modules, &MemoryModule{
-			Label:        description.BankLabel,
-			Location:     description.DeviceLocator,
-			SerialNumber: description.SerialNumber,
+			Label:        *description.BankLabel,
+			Location:     *description.DeviceLocator,
+			SerialNumber: *description.SerialNumber,
 			SizeBytes:    int64(description.Capacity),
-			Vendor:       description.Manufacturer,
+			Vendor:       *description.Manufacturer,
 		})
 	}
 	var totalUsableBytes uint64

--- a/net_windows.go
+++ b/net_windows.go
@@ -14,16 +14,16 @@ import (
 const wqlNetworkAdapter = "SELECT Description, DeviceID, Index, InterfaceIndex, MACAddress, Manufacturer, Name, NetConnectionID, ProductName, ServiceName  FROM Win32_NetworkAdapter"
 
 type win32NetworkAdapter struct {
-	Description     string
-	DeviceID        string
+	Description     *string
+	DeviceID        *string
 	Index           uint32
 	InterfaceIndex  uint32
-	MACAddress      string
-	Manufacturer    string
-	Name            string
-	NetConnectionID string
-	ProductName     string
-	ServiceName     string
+	MACAddress      *string
+	Manufacturer    *string
+	Name            *string
+	NetConnectionID *string
+	ProductName     *string
+	ServiceName     *string
 }
 
 func (ctx *context) netFillInfo(info *NetworkInfo) error {
@@ -43,7 +43,7 @@ func (ctx *context) nics(win32NetDescriptions []win32NetworkAdapter) []*NIC {
 	for _, nicDescription := range win32NetDescriptions {
 		nic := &NIC{
 			Name:         ctx.netDeviceName(nicDescription),
-			MacAddress:   nicDescription.MACAddress,
+			MacAddress:   *nicDescription.MACAddress,
 			IsVirtual:    false,
 			Capabilities: []*NICCapability{},
 		}
@@ -56,10 +56,10 @@ func (ctx *context) nics(win32NetDescriptions []win32NetworkAdapter) []*NIC {
 
 func (ctx *context) netDeviceName(description win32NetworkAdapter) string {
 	var name string
-	if strings.TrimSpace(description.NetConnectionID) != "" {
-		name = description.NetConnectionID + " - " + description.Description
+	if strings.TrimSpace(*description.NetConnectionID) != "" {
+		name = *description.NetConnectionID + " - " + *description.Description
 	} else {
-		name = description.Description
+		name = *description.Description
 	}
 	return name
 }

--- a/product_windows.go
+++ b/product_windows.go
@@ -12,14 +12,14 @@ import (
 const wqlProduct = "SELECT Caption, Description, IdentifyingNumber, Name, SKUNumber, Vendor, Version, UUID FROM Win32_ComputerSystemProduct"
 
 type win32Product struct {
-	Caption           string
-	Description       string
-	IdentifyingNumber string
-	Name              string
-	SKUNumber         string
-	Vendor            string
-	Version           string
-	UUID              string
+	Caption           *string
+	Description       *string
+	IdentifyingNumber *string
+	Name              *string
+	SKUNumber         *string
+	Vendor            *string
+	Version           *string
+	UUID              *string
 }
 
 func (ctx *context) productFillInfo(info *ProductInfo) error {
@@ -31,12 +31,12 @@ func (ctx *context) productFillInfo(info *ProductInfo) error {
 	}
 	if len(win32ProductDescriptions) > 0 {
 		info.Family = UNKNOWN
-		info.Name = win32ProductDescriptions[0].Name
-		info.Vendor = win32ProductDescriptions[0].Vendor
-		info.SerialNumber = win32ProductDescriptions[0].IdentifyingNumber
-		info.UUID = win32ProductDescriptions[0].UUID
-		info.SKU = win32ProductDescriptions[0].SKUNumber
-		info.Version = win32ProductDescriptions[0].Version
+		info.Name = *win32ProductDescriptions[0].Name
+		info.Vendor = *win32ProductDescriptions[0].Vendor
+		info.SerialNumber = *win32ProductDescriptions[0].IdentifyingNumber
+		info.UUID = *win32ProductDescriptions[0].UUID
+		info.SKU = *win32ProductDescriptions[0].SKUNumber
+		info.Version = *win32ProductDescriptions[0].Version
 	}
 
 	return nil


### PR DESCRIPTION
The github.com/StackExchange/wmi package is great, but handles nil
results from the WMI/WQL call *only* if the type in the receiving struct
is a pointer type:

https://github.com/StackExchange/wmi/blob/cbe66965904dbe8a6cd589e2298e5d8b986bd7dd/wmi.go#L420-L426

So, for various fields (all strings that I can gather so far) that on
*some* systems return nil type from WMI, I've made the fields in the
receiver structs *string instead of string. This should allow nil-types
to be properly handled and not run into the `unsupported type (<nil>)`
issue faced in Issue #189

Closes Issue #189