### PR TITLE
Correct issues on Windows with pkg cleanup

### DIFF
--- a/pkg/block/block_windows.go
+++ b/pkg/block/block_windows.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/StackExchange/wmi"
+
+	"github.com/jaypipes/ghw/pkg/util"
 )
 
 const wqlDiskDrive = "SELECT Caption, CreationClassName, DefaultBlockSize, Description, DeviceID, Index, InterfaceType, Manufacturer, MediaType, Model, Name, Partitions, SerialNumber, Size, TotalCylinders, TotalHeads, TotalSectors, TotalTracks, TracksPerCylinder FROM Win32_DiskDrive"
@@ -103,13 +105,12 @@ func (i *Info) load() error {
 			PhysicalBlockSizeBytes: *diskdrive.DefaultBlockSize,
 			DriveType:              toDriveType(*diskdrive.MediaType, *diskdrive.Caption),
 			StorageController:      toStorageController(*diskdrive.InterfaceType),
-			BusType:                toBusType(*diskdrive.InterfaceType),
-			BusPath:                UNKNOWN, // TODO: add information
+			BusPath:                util.UNKNOWN, // TODO: add information
 			NUMANodeID:             -1,
 			Vendor:                 strings.TrimSpace(*diskdrive.Manufacturer),
 			Model:                  strings.TrimSpace(*diskdrive.Caption),
 			SerialNumber:           strings.TrimSpace(*diskdrive.SerialNumber),
-			WWN:                    UNKNOWN, // TODO: add information
+			WWN:                    util.UNKNOWN, // TODO: add information
 			Partitions:             make([]*Partition, 0),
 		}
 		for _, diskpartition := range win32DiskPartitionDescriptions {
@@ -141,12 +142,12 @@ func (i *Info) load() error {
 		disks = append(disks, disk)
 	}
 
-	info.Disks = disks
+	i.Disks = disks
 	var tpb uint64
-	for _, d := range info.Disks {
+	for _, d := range i.Disks {
 		tpb += d.SizeBytes
 	}
-	info.TotalPhysicalBytes = tpb
+	i.TotalPhysicalBytes = tpb
 	return nil
 }
 
@@ -209,20 +210,6 @@ func toStorageController(interfaceType string) StorageController {
 		storageController = STORAGE_CONTROLLER_UNKNOWN
 	}
 	return storageController
-}
-
-// TODO: improve
-func toBusType(interfaceType string) BusType {
-	var busType BusType
-	switch interfaceType {
-	case "SCSI":
-		busType = BUS_TYPE_SCSI
-	case "IDE":
-		busType = BUS_TYPE_IDE
-	default:
-		busType = BUS_TYPE_UNKNOWN
-	}
-	return busType
 }
 
 // TODO: improve

--- a/pkg/cpu/cpu_windows.go
+++ b/pkg/cpu/cpu_windows.go
@@ -4,7 +4,7 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package ghw
+package cpu
 
 import (
 	"github.com/StackExchange/wmi"
@@ -26,15 +26,15 @@ func (i *Info) load() error {
 		return err
 	}
 	// Converting into standard structures
-	info.Processors = processorsGet(win32descriptions)
+	i.Processors = processorsGet(win32descriptions)
 	var totCores uint32
 	var totThreads uint32
-	for _, p := range info.Processors {
+	for _, p := range i.Processors {
 		totCores += p.NumCores
 		totThreads += p.NumThreads
 	}
-	info.TotalCores = totCores
-	info.TotalThreads = totThreads
+	i.TotalCores = totCores
+	i.TotalThreads = totThreads
 	return nil
 }
 
@@ -43,7 +43,7 @@ func processorsGet(win32descriptions []win32Processor) []*Processor {
 	// Converting into standard structures
 	for index, description := range win32descriptions {
 		p := &Processor{
-			Id:         index, // TODO: how to get a decent "Physical ID" to use ?
+			ID:         index,
 			Model:      *description.Name,
 			Vendor:     *description.Manufacturer,
 			NumCores:   description.NumberOfCores,

--- a/pkg/gpu/gpu_windows.go
+++ b/pkg/gpu/gpu_windows.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/StackExchange/wmi"
 	"github.com/jaypipes/pcidb"
+
+	"github.com/jaypipes/ghw/pkg/pci"
+	"github.com/jaypipes/ghw/pkg/util"
 )
 
 const wqlVideoController = "SELECT Caption, CreationClassName, Description, DeviceID, Name, PNPDeviceID, SystemCreationClassName, SystemName, VideoArchitecture, VideoMemoryType, VideoModeDescription, VideoProcessor FROM Win32_VideoController"
@@ -78,40 +81,40 @@ func (i *Info) load() error {
 	return nil
 }
 
-func GetDevice(id string, entities []win32PnPEntity) *PCIDevice {
+func GetDevice(id string, entities []win32PnPEntity) *pci.Device {
 	// Backslashing PnP address ID as requested by JSON and VMI query: https://docs.microsoft.com/en-us/windows/win32/wmisdk/where-clause
 	var queryAddress = strings.Replace(id, "\\", `\\`, -1)
 	// Preparing default structure
-	var device = &PCIDevice{
+	var device = &pci.Device{
 		Address: queryAddress,
 		Vendor: &pcidb.Vendor{
-			ID:       UNKNOWN,
-			Name:     UNKNOWN,
+			ID:       util.UNKNOWN,
+			Name:     util.UNKNOWN,
 			Products: []*pcidb.Product{},
 		},
 		Subsystem: &pcidb.Product{
-			ID:         UNKNOWN,
-			Name:       UNKNOWN,
+			ID:         util.UNKNOWN,
+			Name:       util.UNKNOWN,
 			Subsystems: []*pcidb.Product{},
 		},
 		Product: &pcidb.Product{
-			ID:         UNKNOWN,
-			Name:       UNKNOWN,
+			ID:         util.UNKNOWN,
+			Name:       util.UNKNOWN,
 			Subsystems: []*pcidb.Product{},
 		},
 		Class: &pcidb.Class{
-			ID:         UNKNOWN,
-			Name:       UNKNOWN,
+			ID:         util.UNKNOWN,
+			Name:       util.UNKNOWN,
 			Subclasses: []*pcidb.Subclass{},
 		},
 		Subclass: &pcidb.Subclass{
-			ID:                    UNKNOWN,
-			Name:                  UNKNOWN,
+			ID:                    util.UNKNOWN,
+			Name:                  util.UNKNOWN,
 			ProgrammingInterfaces: []*pcidb.ProgrammingInterface{},
 		},
 		ProgrammingInterface: &pcidb.ProgrammingInterface{
-			ID:   UNKNOWN,
-			Name: UNKNOWN,
+			ID:   util.UNKNOWN,
+			Name: util.UNKNOWN,
 		},
 	}
 	// If an entity is found we get its data inside the standard structure

--- a/pkg/pci/pci_stub.go
+++ b/pkg/pci/pci_stub.go
@@ -4,7 +4,7 @@
 // See the COPYING file in the root project directory for full text.
 //
 
-package ghw
+package pci
 
 import (
 	"runtime"

--- a/pkg/topology/topology_windows.go
+++ b/pkg/topology/topology_windows.go
@@ -38,8 +38,8 @@ func (i *Info) load() error {
 	return nil
 }
 
-func topologyNodes() ([]*TopologyNode, error) {
-	nodes := make([]*TopologyNode, 0)
+func topologyNodes() ([]*Node, error) {
+	nodes := make([]*Node, 0)
 	lpis, err := getWin32LogicalProcessorInfos()
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func topologyNodes() ([]*TopologyNode, error) {
 	for _, lpi := range lpis {
 		switch lpi.relationship {
 		case relationNUMANode:
-			nodes = append(nodes, &TopologyNode{
+			nodes = append(nodes, &Node{
 				ID: lpi.numaNodeID(),
 			})
 		case relationProcessorCore:


### PR DESCRIPTION
There were some typos and package renames that messed up on Windows for
the pkg-cleanup commits. This fixes them all and gets Windows back
working.