### PR TITLE
Determine total physical memory from sysfs for linux as primary method

### DIFF
--- a/pkg/linuxpath/path_linux.go
+++ b/pkg/linuxpath/path_linux.go
@@ -13,36 +13,38 @@ import (
 )
 
 type Paths struct {
-	VarLog               string
-	ProcMeminfo          string
-	ProcCpuinfo          string
-	SysKernelMMHugepages string
-	EtcMtab              string
-	SysBlock             string
-	SysDevicesSystemNode string
-	SysBusPciDevices     string
-	SysClassDRM          string
-	SysClassDMI          string
-	SysClassNet          string
-	RunUdevData          string
+	VarLog                 string
+	ProcMeminfo            string
+	ProcCpuinfo            string
+	SysKernelMMHugepages   string
+	EtcMtab                string
+	SysBlock               string
+	SysDevicesSystemNode   string
+	SysDevicesSystemMemory string
+	SysBusPciDevices       string
+	SysClassDRM            string
+	SysClassDMI            string
+	SysClassNet            string
+	RunUdevData            string
 }
 
 // New returns a new Paths struct containing filepath fields relative to the
 // supplied Context
 func New(ctx *context.Context) *Paths {
 	return &Paths{
-		VarLog:               filepath.Join(ctx.Chroot, "var", "log"),
-		ProcMeminfo:          filepath.Join(ctx.Chroot, "proc", "meminfo"),
-		ProcCpuinfo:          filepath.Join(ctx.Chroot, "proc", "cpuinfo"),
-		SysKernelMMHugepages: filepath.Join(ctx.Chroot, "sys", "kernel", "mm", "hugepages"),
-		EtcMtab:              filepath.Join(ctx.Chroot, "etc", "mtab"),
-		SysBlock:             filepath.Join(ctx.Chroot, "sys", "block"),
-		SysDevicesSystemNode: filepath.Join(ctx.Chroot, "sys", "devices", "system", "node"),
-		SysBusPciDevices:     filepath.Join(ctx.Chroot, "sys", "bus", "pci", "devices"),
-		SysClassDRM:          filepath.Join(ctx.Chroot, "sys", "class", "drm"),
-		SysClassDMI:          filepath.Join(ctx.Chroot, "sys", "class", "dmi"),
-		SysClassNet:          filepath.Join(ctx.Chroot, "sys", "class", "net"),
-		RunUdevData:          filepath.Join(ctx.Chroot, "run", "udev", "data"),
+		VarLog:                 filepath.Join(ctx.Chroot, "var", "log"),
+		ProcMeminfo:            filepath.Join(ctx.Chroot, "proc", "meminfo"),
+		ProcCpuinfo:            filepath.Join(ctx.Chroot, "proc", "cpuinfo"),
+		SysKernelMMHugepages:   filepath.Join(ctx.Chroot, "sys", "kernel", "mm", "hugepages"),
+		EtcMtab:                filepath.Join(ctx.Chroot, "etc", "mtab"),
+		SysBlock:               filepath.Join(ctx.Chroot, "sys", "block"),
+		SysDevicesSystemNode:   filepath.Join(ctx.Chroot, "sys", "devices", "system", "node"),
+		SysDevicesSystemMemory: filepath.Join(ctx.Chroot, "sys", "devices", "system", "memory"),
+		SysBusPciDevices:       filepath.Join(ctx.Chroot, "sys", "bus", "pci", "devices"),
+		SysClassDRM:            filepath.Join(ctx.Chroot, "sys", "class", "drm"),
+		SysClassDMI:            filepath.Join(ctx.Chroot, "sys", "class", "dmi"),
+		SysClassNet:            filepath.Join(ctx.Chroot, "sys", "class", "net"),
+		RunUdevData:            filepath.Join(ctx.Chroot, "run", "udev", "data"),
 	}
 }
 


### PR DESCRIPTION
This PR allows to first determine on Linux systems the total of physical memory from sysfs (`/sys/devices/system/memory`) as primary method and fallback to syslog file method if `/sys/devices/system/memory` is not present for some reasons