### PR TITLE
add PCI device info to ghwc

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,31 +692,29 @@ are exposed on the `ghw.PCIInfo` struct.
 The `ghw.PCI()` function returns a `ghw.PCIInfo` struct. The `ghw.PCIInfo`
 struct contains a number of fields that may be queried for PCI information:
 
+* `ghw.PCIInfo.Devices` is a slice of pointers to `ghw.PCIDevice` structs that
+  describe the PCI devices on the host system
 * `ghw.PCIInfo.Classes` is a map, keyed by the PCI class ID (a hex-encoded
   string) of pointers to `pcidb.Class` structs, one for each class of PCI
   device known to `ghw`
+  (**DEPRECATED**, will be removed in `ghw` `v1.0`. Use the
+  `github.com/jaypipes/pcidb` library for exploring PCI database information)
 * `ghw.PCIInfo.Vendors` is a map, keyed by the PCI vendor ID (a hex-encoded
   string) of pointers to `pcidb.Vendor` structs, one for each PCI vendor
   known to `ghw`
-* `ghw.PCIInfo.Products` is a map, keyed by the PCI product ID* (a hex-encoded
+  (**DEPRECATED**, will be removed in `ghw` `v1.0`. Use the
+  `github.com/jaypipes/pcidb` library for exploring PCI database information)
+* `ghw.PCIInfo.Products` is a map, keyed by the PCI product ID (a hex-encoded
   string) of pointers to `pcidb.Product` structs, one for each PCI product
   known to `ghw`
+  (**DEPRECATED**, will be removed in `ghw` `v1.0`. Use the
+  `github.com/jaypipes/pcidb` library for exploring PCI database information)
 
 **NOTE**: PCI products are often referred to by their "device ID". We use
 the term "product ID" in `ghw` because it more accurately reflects what the
 identifier is for: a specific product line produced by the vendor.
 
-#### Listing and accessing host PCI device information
-
-In addition to the above information, the `ghw.PCIInfo` struct has the
-following methods:
-
-* `ghw.PCIInfo.ListDevices() []*PCIDevice`
-* `ghw.PCIInfo.GetDevice(address string) *PCIDevice`
-
-This methods return either an array of or a single pointer to a `ghw.PCIDevice`
-struct, which has the following fields:
-
+The `ghw.PCIDevice` struct has the following fields:
 
 * `ghw.PCIDevice.Vendor` is a pointer to a `pcidb.Vendor` struct that
   describes the device's primary vendor. This will always be non-nil.
@@ -731,6 +729,13 @@ struct, which has the following fields:
 * `ghw.PCIDevice.ProgrammingInterface` is a pointer to a
   `pcidb.ProgrammingInterface` struct that describes the device subclass'
   programming interface. This will always be non-nil.
+
+#### Finding a PCI device by PCI address
+
+In addition to the above information, the `ghw.PCIInfo` struct has the
+following method:
+
+* `ghw.PCIInfo.GetDevice(address string)`
 
 The following code snippet shows how to call the `ghw.PCIInfo.ListDevices()`
 method and output a simple list of PCI address and vendor/product information:
@@ -751,13 +756,8 @@ func main() {
 	}
 	fmt.Printf("host PCI devices:\n")
 	fmt.Println("====================================================")
-	devices := pci.ListDevices()
-	if len(devices) == 0 {
-		fmt.Printf("error: could not retrieve PCI devices\n")
-		return
-	}
 
-	for _, device := range devices {
+	for _, device := range pci.Devices {
 		vendor := device.Vendor
 		vendorName := vendor.Name
 		if len(vendor.Name) > 20 {

--- a/cmd/ghwc/commands/pci.go
+++ b/cmd/ghwc/commands/pci.go
@@ -1,0 +1,35 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package commands
+
+import (
+	"github.com/jaypipes/ghw"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// pciCmd represents the install command
+var pciCmd = &cobra.Command{
+	Use:   "pci",
+	Short: "Show information about PCI devices on the host system",
+	RunE:  showPCI,
+}
+
+// showPCI shows information for PCI devices on the host system.
+func showPCI(cmd *cobra.Command, args []string) error {
+	pci, err := ghw.PCI()
+	if err != nil {
+		return errors.Wrap(err, "error getting PCI info")
+	}
+
+	printInfo(pci)
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(pciCmd)
+}

--- a/host.go
+++ b/host.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jaypipes/ghw/pkg/marshal"
 	"github.com/jaypipes/ghw/pkg/memory"
 	"github.com/jaypipes/ghw/pkg/net"
+	"github.com/jaypipes/ghw/pkg/pci"
 	"github.com/jaypipes/ghw/pkg/product"
 	"github.com/jaypipes/ghw/pkg/topology"
 )
@@ -35,6 +36,7 @@ type HostInfo struct {
 	BIOS      *bios.Info      `json:"bios"`
 	Baseboard *baseboard.Info `json:"baseboard"`
 	Product   *product.Info   `json:"product"`
+	PCI       *pci.Info       `json:"pci"`
 }
 
 // Host returns a pointer to a HostInfo struct that contains fields with
@@ -80,6 +82,10 @@ func Host(opts ...*WithOption) (*HostInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	pciInfo, err := pci.New(opts...)
+	if err != nil {
+		return nil, err
+	}
 	return &HostInfo{
 		CPU:       cpuInfo,
 		Memory:    memInfo,
@@ -91,6 +97,7 @@ func Host(opts ...*WithOption) (*HostInfo, error) {
 		BIOS:      biosInfo,
 		Baseboard: baseboardInfo,
 		Product:   productInfo,
+		PCI:       pciInfo,
 	}, nil
 }
 
@@ -98,7 +105,7 @@ func Host(opts ...*WithOption) (*HostInfo, error) {
 // structs' String-ified output
 func (info *HostInfo) String() string {
 	return fmt.Sprintf(
-		"%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
+		"%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
 		info.Block.String(),
 		info.CPU.String(),
 		info.GPU.String(),
@@ -109,6 +116,7 @@ func (info *HostInfo) String() string {
 		info.BIOS.String(),
 		info.Baseboard.String(),
 		info.Product.String(),
+		info.PCI.String(),
 	)
 }
 

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -27,6 +27,7 @@ func (i *Info) load() error {
 	i.Classes = db.Classes
 	i.Vendors = db.Vendors
 	i.Products = db.Products
+	i.Devices = i.ListDevices()
 	return nil
 }
 
@@ -272,6 +273,8 @@ func (info *Info) GetDevice(address string) *Device {
 
 // ListDevices returns a list of pointers to Device structs present on the
 // host system
+// DEPRECATED. Will be removed in v1.0. Please use
+// github.com/jaypipes/pcidb to explore PCIDB information
 func (info *Info) ListDevices() []*Device {
 	paths := linuxpath.New(info.ctx)
 	devs := make([]*Device, 0)


### PR DESCRIPTION
Adds a new `ghwc pci` subcommand that lists PCI devices. Deprecates the
old PCIInfo.Products, PCIInfo.Classes and PCIInfo.Vendors maps because
these are now fully contained in the github.com/jaypipes/pcidb library.

```
[jaypipes@thelio ghw]$ go run cmd/ghwc/main.go pci
PCI (45 devices)
[jaypipes@thelio ghw]$ go run cmd/ghwc/main.go pci --format yaml | head -n30
pci:
  Devices:
  - address: "0000:00:00.0"
    class:
      id: "06"
      name: Bridge
    product:
      id: "1450"
      name: Family 17h (Models 00h-0fh) Root Complex
    programming_interface:
      id: "00"
      name: unknown
    subclass:
      id: "00"
      name: Host bridge
    subsystem:
      id: "1450"
      name: unknown
    vendor:
      id: "1022"
      name: Advanced Micro Devices, Inc. [AMD]
  - address: "0000:00:00.2"
    class:
      id: "08"
      name: Generic system peripheral
    product:
      id: "1451"
      name: Family 17h (Models 00h-0fh) I/O Memory Management Unit
    programming_interface:
      id: "00"
```

Issue #207