### PR TITLE
pci: fix typo in struct declaration

### DIFF
--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -50,7 +50,7 @@ type devMarshallable struct {
 	Vendor    devIdent `json:"vendor"`
 	Product   devIdent `json:"product"`
 	Subsystem devIdent `json:"subsystem"`
-	Class     devIdent `json:"class""`
+	Class     devIdent `json:"class"`
 	Subclass  devIdent `json:"subclass"`
 	Interface devIdent `json:"programming_interface"`
 }


### PR DESCRIPTION
Caught just running "make" on my local tree. I wonder why CI didn't catch it earlier.

Signed-off-by: Francesco Romani <fromani@redhat.com>