### PR TITLE
warning: support new option to override default

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,20 @@ $ GHW_DISABLE_WARNINGS=1 ghwc memory
 memory (24GB physical, 24GB usable)
 ```
 
+You can disable warning programmatically using the `WithAlerter` option:
+
+```go
+
+import (
+	"io/ioutil"
+	"log"
+
+	"github.com/jaypipes/ghw"
+)
+
+mem, err := ghw.Memory(ghw.WithAlerter(log.New(ioutil.Discard, "", 0))
+```
+
 ### Memory
 
 Information about the host computer's memory can be retrieved using the

--- a/README.md
+++ b/README.md
@@ -207,18 +207,19 @@ $ GHW_DISABLE_WARNINGS=1 ghwc memory
 memory (24GB physical, 24GB usable)
 ```
 
-You can disable warning programmatically using the `WithAlerter` option:
+You can disable warning programmatically using the `WithNullAlerter` option:
 
 ```go
 
 import (
-	"io/ioutil"
-	"log"
-
 	"github.com/jaypipes/ghw"
 )
 
-mem, err := ghw.Memory(ghw.WithAlerter(log.New(ioutil.Discard, "", 0))
+mem, err := ghw.Memory(ghw.WithNullAlerter())
+
+You may also supply an `Alerter` to ghw to handle the warnings.
+In this case, please check the `option.Alerter` interface (compatible with stdlib's
+log.Logger type) and the `ghw.WithAlerter()` function
 ```
 
 ### Memory

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ $ GHW_DISABLE_WARNINGS=1 ghwc memory
 memory (24GB physical, 24GB usable)
 ```
 
-You can disable warning programmatically using the `WithNullAlerter` option:
+You can disable warning programmatically using the `WithDisableWarnings` option:
 
 ```go
 
@@ -215,12 +215,17 @@ import (
 	"github.com/jaypipes/ghw"
 )
 
-mem, err := ghw.Memory(ghw.WithNullAlerter())
-
-You may also supply an `Alerter` to ghw to handle the warnings.
-In this case, please check the `option.Alerter` interface (compatible with stdlib's
-log.Logger type) and the `ghw.WithAlerter()` function
+mem, err := ghw.Memory(ghw.WithDisableWarnings())
 ```
+
+`WithDisableWarnings` is a alias for the `WithNullAlerter` option, which in turn
+leverages the more general `Alerter` feature of ghw.
+
+You may supply a `Alerter` to ghw to redirect all the warnings there, like
+logger objects (see for example golang's stdlib `log.Logger`).
+`Alerter` is in fact the minimal logging interface `ghw needs.
+To learn more, please check the `option.Alerter` interface and the `ghw.WithAlerter()`
+function.
 
 ### Memory
 

--- a/alias.go
+++ b/alias.go
@@ -26,6 +26,7 @@ type WithOption = option.Option
 var (
 	WithChroot   = option.WithChroot
 	WithSnapshot = option.WithSnapshot
+	WithAlterter = option.WithAlerter
 )
 
 type SnapshotOptions = option.SnapshotOptions

--- a/alias.go
+++ b/alias.go
@@ -24,9 +24,10 @@ import (
 type WithOption = option.Option
 
 var (
-	WithChroot   = option.WithChroot
-	WithSnapshot = option.WithSnapshot
-	WithAlterter = option.WithAlerter
+	WithChroot       = option.WithChroot
+	WithSnapshot     = option.WithSnapshot
+	WithAlterter     = option.WithAlerter
+	WithNullAlterter = option.WithNullAlerter
 )
 
 type SnapshotOptions = option.SnapshotOptions

--- a/alias.go
+++ b/alias.go
@@ -28,6 +28,8 @@ var (
 	WithSnapshot     = option.WithSnapshot
 	WithAlterter     = option.WithAlerter
 	WithNullAlterter = option.WithNullAlerter
+	// match the existing environ variable to minimize surprises
+	WithDisableWarnings = option.WithNullAlerter
 )
 
 type SnapshotOptions = option.SnapshotOptions

--- a/host.go
+++ b/host.go
@@ -9,6 +9,8 @@ package ghw
 import (
 	"fmt"
 
+	"github.com/jaypipes/ghw/pkg/context"
+
 	"github.com/jaypipes/ghw/pkg/baseboard"
 	"github.com/jaypipes/ghw/pkg/bios"
 	"github.com/jaypipes/ghw/pkg/block"
@@ -26,6 +28,7 @@ import (
 // HostInfo is a wrapper struct containing information about the host system's
 // memory, block storage, CPU, etc
 type HostInfo struct {
+	ctx       *context.Context
 	Memory    *memory.Info    `json:"memory"`
 	Block     *block.Info     `json:"block"`
 	CPU       *cpu.Info       `json:"cpu"`
@@ -42,6 +45,8 @@ type HostInfo struct {
 // Host returns a pointer to a HostInfo struct that contains fields with
 // information about the host system's CPU, memory, network devices, etc
 func Host(opts ...*WithOption) (*HostInfo, error) {
+	ctx := context.New(opts...)
+
 	memInfo, err := memory.New(opts...)
 	if err != nil {
 		return nil, err
@@ -87,6 +92,7 @@ func Host(opts ...*WithOption) (*HostInfo, error) {
 		return nil, err
 	}
 	return &HostInfo{
+		ctx:       ctx,
 		CPU:       cpuInfo,
 		Memory:    memInfo,
 		Block:     blockInfo,
@@ -123,11 +129,11 @@ func (info *HostInfo) String() string {
 // YAMLString returns a string with the host information formatted as YAML
 // under a top-level "host:" key
 func (i *HostInfo) YAMLString() string {
-	return marshal.SafeYAML(i)
+	return marshal.SafeYAML(i.ctx, i)
 }
 
 // JSONString returns a string with the host information formatted as JSON
 // under a top-level "host:" key
 func (i *HostInfo) JSONString(indent bool) string {
-	return marshal.SafeJSON(i, indent)
+	return marshal.SafeJSON(i.ctx, i, indent)
 }

--- a/pkg/baseboard/baseboard.go
+++ b/pkg/baseboard/baseboard.go
@@ -67,11 +67,11 @@ type baseboardPrinter struct {
 // YAMLString returns a string with the baseboard information formatted as YAML
 // under a top-level "dmi:" key
 func (info *Info) YAMLString() string {
-	return marshal.SafeYAML(baseboardPrinter{info})
+	return marshal.SafeYAML(info.ctx, baseboardPrinter{info})
 }
 
 // JSONString returns a string with the baseboard information formatted as JSON
 // under a top-level "baseboard:" key
 func (info *Info) JSONString(indent bool) string {
-	return marshal.SafeJSON(baseboardPrinter{info}, indent)
+	return marshal.SafeJSON(info.ctx, baseboardPrinter{info}, indent)
 }

--- a/pkg/bios/bios.go
+++ b/pkg/bios/bios.go
@@ -67,11 +67,11 @@ type biosPrinter struct {
 // YAMLString returns a string with the BIOS information formatted as YAML
 // under a top-level "dmi:" key
 func (info *Info) YAMLString() string {
-	return marshal.SafeYAML(biosPrinter{info})
+	return marshal.SafeYAML(info.ctx, biosPrinter{info})
 }
 
 // JSONString returns a string with the BIOS information formatted as JSON
 // under a top-level "bios:" key
 func (info *Info) JSONString(indent bool) string {
-	return marshal.SafeJSON(biosPrinter{info}, indent)
+	return marshal.SafeJSON(info.ctx, biosPrinter{info}, indent)
 }

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -240,11 +240,11 @@ type blockPrinter struct {
 // YAMLString returns a string with the block information formatted as YAML
 // under a top-level "block:" key
 func (i *Info) YAMLString() string {
-	return marshal.SafeYAML(blockPrinter{i})
+	return marshal.SafeYAML(i.ctx, blockPrinter{i})
 }
 
 // JSONString returns a string with the block information formatted as JSON
 // under a top-level "block:" key
 func (i *Info) JSONString(indent bool) string {
-	return marshal.SafeJSON(blockPrinter{i}, indent)
+	return marshal.SafeJSON(i.ctx, blockPrinter{i}, indent)
 }

--- a/pkg/chassis/chassis.go
+++ b/pkg/chassis/chassis.go
@@ -111,11 +111,11 @@ type chassisPrinter struct {
 // YAMLString returns a string with the chassis information formatted as YAML
 // under a top-level "dmi:" key
 func (info *Info) YAMLString() string {
-	return marshal.SafeYAML(chassisPrinter{info})
+	return marshal.SafeYAML(info.ctx, chassisPrinter{info})
 }
 
 // JSONString returns a string with the chassis information formatted as JSON
 // under a top-level "chassis:" key
 func (info *Info) JSONString(indent bool) string {
-	return marshal.SafeJSON(chassisPrinter{info}, indent)
+	return marshal.SafeJSON(info.ctx, chassisPrinter{info}, indent)
 }

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -18,12 +18,14 @@ type Context struct {
 	SnapshotPath      string
 	SnapshotRoot      string
 	SnapshotExclusive bool
+	alert             option.Alerter
 }
 
 // New returns a Context struct pointer that has had various options set on it
 func New(opts ...*option.Option) *Context {
 	merged := option.Merge(opts...)
 	ctx := &Context{
+		alert:  option.EnvOrDefaultAlerter(),
 		Chroot: *merged.Chroot,
 	}
 
@@ -35,6 +37,11 @@ func New(opts ...*option.Option) *Context {
 		}
 		ctx.SnapshotExclusive = merged.Snapshot.Exclusive
 	}
+
+	if merged.Alerter != nil {
+		ctx.alert = merged.Alerter
+	}
+
 	return ctx
 }
 
@@ -103,4 +110,8 @@ func (ctx *Context) Teardown() error {
 		return nil
 	}
 	return snapshot.Cleanup(ctx.SnapshotRoot)
+}
+
+func (ctx *Context) Warn(msg string, args ...interface{}) {
+	ctx.alert.Printf("WARNING: "+msg, args...)
 }

--- a/pkg/cpu/cpu.go
+++ b/pkg/cpu/cpu.go
@@ -159,11 +159,11 @@ type cpuPrinter struct {
 // YAMLString returns a string with the cpu information formatted as YAML
 // under a top-level "cpu:" key
 func (i *Info) YAMLString() string {
-	return marshal.SafeYAML(cpuPrinter{i})
+	return marshal.SafeYAML(i.ctx, cpuPrinter{i})
 }
 
 // JSONString returns a string with the cpu information formatted as JSON
 // under a top-level "cpu:" key
 func (i *Info) JSONString(indent bool) string {
-	return marshal.SafeJSON(cpuPrinter{i}, indent)
+	return marshal.SafeJSON(i.ctx, cpuPrinter{i}, indent)
 }

--- a/pkg/cpu/cpu_linux.go
+++ b/pkg/cpu/cpu_linux.go
@@ -204,7 +204,7 @@ func CoresForNode(ctx *context.Context, nodeID int) ([]*ProcessorCore, error) {
 			continue
 		}
 		coreIDPath := filepath.Join(cpuPath, "topology", "core_id")
-		coreID := util.SafeIntFromFile(coreIDPath)
+		coreID := util.SafeIntFromFile(ctx, coreIDPath)
 		core := findCoreByID(coreID)
 		core.LogicalProcessors = append(
 			core.LogicalProcessors,

--- a/pkg/gpu/gpu.go
+++ b/pkg/gpu/gpu.go
@@ -85,11 +85,11 @@ type gpuPrinter struct {
 // YAMLString returns a string with the gpu information formatted as YAML
 // under a top-level "gpu:" key
 func (i *Info) YAMLString() string {
-	return marshal.SafeYAML(gpuPrinter{i})
+	return marshal.SafeYAML(i.ctx, gpuPrinter{i})
 }
 
 // JSONString returns a string with the gpu information formatted as JSON
 // under a top-level "gpu:" key
 func (i *Info) JSONString(indent bool) string {
-	return marshal.SafeJSON(gpuPrinter{i}, indent)
+	return marshal.SafeJSON(i.ctx, gpuPrinter{i}, indent)
 }

--- a/pkg/gpu/gpu_linux.go
+++ b/pkg/gpu/gpu_linux.go
@@ -57,7 +57,7 @@ func (i *Info) load() error {
 	paths := linuxpath.New(i.ctx)
 	links, err := ioutil.ReadDir(paths.SysClassDRM)
 	if err != nil {
-		util.Warn(_WARN_NO_SYS_CLASS_DRM)
+		i.ctx.Warn(_WARN_NO_SYS_CLASS_DRM)
 		return nil
 	}
 	cards := make([]*GraphicsCard, 0)
@@ -139,7 +139,7 @@ func gpuFillNUMANodes(ctx *context.Context, cards []*GraphicsCard) {
 			"device",
 			"numa_node",
 		)
-		nodeIdx := util.SafeIntFromFile(fpath)
+		nodeIdx := util.SafeIntFromFile(ctx, fpath)
 		if nodeIdx == -1 {
 			continue
 		}

--- a/pkg/linuxdmi/dmi_linux.go
+++ b/pkg/linuxdmi/dmi_linux.go
@@ -21,7 +21,7 @@ func Item(ctx *context.Context, value string) string {
 
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
-		util.Warn("Unable to read %s: %s\n", value, err)
+		ctx.Warn("Unable to read %s: %s\n", value, err)
 		return util.UNKNOWN
 	}
 

--- a/pkg/marshal/marshal.go
+++ b/pkg/marshal/marshal.go
@@ -10,19 +10,19 @@ import (
 	"encoding/json"
 
 	"github.com/ghodss/yaml"
-	"github.com/jaypipes/ghw/pkg/util"
+	"github.com/jaypipes/ghw/pkg/context"
 )
 
 // safeYAML returns a string after marshalling the supplied parameter into YAML
-func SafeYAML(p interface{}) string {
+func SafeYAML(ctx *context.Context, p interface{}) string {
 	b, err := json.Marshal(p)
 	if err != nil {
-		util.Warn("error marshalling JSON: %s", err)
+		ctx.Warn("error marshalling JSON: %s", err)
 		return ""
 	}
 	yb, err := yaml.JSONToYAML(b)
 	if err != nil {
-		util.Warn("error converting JSON to YAML: %s", err)
+		ctx.Warn("error converting JSON to YAML: %s", err)
 		return ""
 	}
 	return string(yb)
@@ -31,7 +31,7 @@ func SafeYAML(p interface{}) string {
 // safeJSON returns a string after marshalling the supplied parameter into
 // JSON. Accepts an optional argument to trigger pretty/indented formatting of
 // the JSON string
-func SafeJSON(p interface{}, indent bool) string {
+func SafeJSON(ctx *context.Context, p interface{}, indent bool) string {
 	var b []byte
 	var err error
 	if !indent {
@@ -40,7 +40,7 @@ func SafeJSON(p interface{}, indent bool) string {
 		b, err = json.MarshalIndent(&p, "", "  ")
 	}
 	if err != nil {
-		util.Warn("error marshalling JSON: %s", err)
+		ctx.Warn("error marshalling JSON: %s", err)
 		return ""
 	}
 	return string(b)

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -70,11 +70,11 @@ type memoryPrinter struct {
 // YAMLString returns a string with the memory information formatted as YAML
 // under a top-level "memory:" key
 func (i *Info) YAMLString() string {
-	return marshal.SafeYAML(memoryPrinter{i})
+	return marshal.SafeYAML(i.ctx, memoryPrinter{i})
 }
 
 // JSONString returns a string with the memory information formatted as JSON
 // under a top-level "memory:" key
 func (i *Info) JSONString(indent bool) string {
-	return marshal.SafeJSON(memoryPrinter{i}, indent)
+	return marshal.SafeJSON(i.ctx, memoryPrinter{i}, indent)
 }

--- a/pkg/memory/memory_linux.go
+++ b/pkg/memory/memory_linux.go
@@ -49,7 +49,7 @@ func (i *Info) load() error {
 	tpb := memTotalPhysicalBytes(paths)
 	i.TotalPhysicalBytes = tpb
 	if tpb < 1 {
-		util.Warn(_WARN_CANNOT_DETERMINE_PHYSICAL_MEMORY)
+		i.ctx.Warn(_WARN_CANNOT_DETERMINE_PHYSICAL_MEMORY)
 		i.TotalPhysicalBytes = tub
 	}
 	i.SupportedPageSizes = memSupportedPageSizes(paths)

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -73,11 +73,11 @@ type netPrinter struct {
 // YAMLString returns a string with the net information formatted as YAML
 // under a top-level "net:" key
 func (i *Info) YAMLString() string {
-	return marshal.SafeYAML(netPrinter{i})
+	return marshal.SafeYAML(i.ctx, netPrinter{i})
 }
 
 // JSONString returns a string with the net information formatted as JSON
 // under a top-level "net:" key
 func (i *Info) JSONString(indent bool) string {
-	return marshal.SafeJSON(netPrinter{i}, indent)
+	return marshal.SafeJSON(i.ctx, netPrinter{i}, indent)
 }

--- a/pkg/net/net_linux.go
+++ b/pkg/net/net_linux.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/jaypipes/ghw/pkg/context"
 	"github.com/jaypipes/ghw/pkg/linuxpath"
-	"github.com/jaypipes/ghw/pkg/util"
 )
 
 const (
@@ -40,7 +39,7 @@ func nics(ctx *context.Context) []*NIC {
 
 	etInstalled := ethtoolInstalled()
 	if !etInstalled {
-		util.Warn(_WARN_ETHTOOL_NOT_INSTALLED)
+		ctx.Warn(_WARN_ETHTOOL_NOT_INSTALLED)
 	}
 	for _, file := range files {
 		filename := file.Name()
@@ -64,7 +63,7 @@ func nics(ctx *context.Context) []*NIC {
 		mac := netDeviceMacAddress(paths, filename)
 		nic.MacAddress = mac
 		if etInstalled {
-			nic.Capabilities = netDeviceCapabilities(filename)
+			nic.Capabilities = netDeviceCapabilities(ctx, filename)
 		} else {
 			nic.Capabilities = []*NICCapability{}
 		}
@@ -99,7 +98,7 @@ func ethtoolInstalled() bool {
 	return err == nil
 }
 
-func netDeviceCapabilities(dev string) []*NICCapability {
+func netDeviceCapabilities(ctx *context.Context, dev string) []*NICCapability {
 	caps := make([]*NICCapability, 0)
 	path, _ := exec.LookPath("ethtool")
 	cmd := exec.Command(path, "-k", dev)
@@ -108,7 +107,7 @@ func netDeviceCapabilities(dev string) []*NICCapability {
 	err := cmd.Run()
 	if err != nil {
 		msg := fmt.Sprintf("could not grab NIC capabilities for %s: %s", dev, err)
-		util.Warn(msg)
+		ctx.Warn(msg)
 		return caps
 	}
 

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -30,6 +30,10 @@ type Alerter interface {
 	Printf(format string, v ...interface{})
 }
 
+var (
+	NullAlerter = log.New(ioutil.Discard, "", 0)
+)
+
 // EnvOrDefaultAlerter returns the default instance ghw will use to emit
 // its warnings. ghw will emit warnings to stderr by default unless the
 // environs variable GHW_DISABLE_WARNINGS is specified; in the latter case
@@ -147,6 +151,13 @@ func WithSnapshot(opts SnapshotOptions) *Option {
 func WithAlerter(alerter Alerter) *Option {
 	return &Option{
 		Alerter: alerter,
+	}
+}
+
+// WithNullAlerter sets No-op alerting options for ghw
+func WithNullAlerter() *Option {
+	return &Option{
+		Alerter: NullAlerter,
 	}
 }
 

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -6,16 +6,44 @@
 
 package option
 
-import "os"
+import (
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+)
 
 const (
 	defaultChroot           = "/"
 	envKeyChroot            = "GHW_CHROOT"
+	envKeyDisableWarnings   = "GHW_DISABLE_WARNINGS"
 	envKeySnapshotPath      = "GHW_SNAPSHOT_PATH"
 	envKeySnapshotRoot      = "GHW_SNAPSHOT_ROOT"
 	envKeySnapshotExclusive = "GHW_SNAPSHOT_EXCLUSIVE"
 	envKeySnapshotPreserve  = "GHW_SNAPSHOT_PRESERVE"
 )
+
+// Alerter emits warnings about undesirable but recoverable errors.
+// We use a subset of a logger interface only to emit warnings, and
+// `Warninger` sounded ugly.
+type Alerter interface {
+	Printf(format string, v ...interface{})
+}
+
+// EnvOrDefaultAlerter returns the default instance ghw will use to emit
+// its warnings. ghw will emit warnings to stderr by default unless the
+// environs variable GHW_DISABLE_WARNINGS is specified; in the latter case
+// all warning will be suppressed.
+func EnvOrDefaultAlerter() Alerter {
+	var dest io.Writer
+	if _, exists := os.LookupEnv(envKeyDisableWarnings); exists {
+		dest = ioutil.Discard
+	} else {
+		// default
+		dest = os.Stderr
+	}
+	return log.New(dest, "", 0)
+}
 
 // EnvOrDefaultChroot returns the value of the GHW_CHROOT environs variable or
 // the default value of "/" if not set
@@ -78,6 +106,9 @@ type Option struct {
 
 	// Snapshot contains options for handling ghw snapshots
 	Snapshot *SnapshotOptions
+
+	// Alerter contains the target for ghw warnings
+	Alerter Alerter
 }
 
 // SnapshotOptions contains options for handling of ghw snapshots
@@ -112,6 +143,13 @@ func WithSnapshot(opts SnapshotOptions) *Option {
 	}
 }
 
+// WithAlerter sets alerting options for ghw
+func WithAlerter(alerter Alerter) *Option {
+	return &Option{
+		Alerter: alerter,
+	}
+}
+
 // There is intentionally no Option related to GHW_SNAPSHOT_PRESERVE because we see that as
 // a debug/troubleshoot aid more something users wants to do regularly.
 // Hence we allow that only via the environment variable for the time being.
@@ -125,11 +163,17 @@ func Merge(opts ...*Option) *Option {
 		if opt.Snapshot != nil {
 			merged.Snapshot = opt.Snapshot
 		}
+		if opt.Alerter != nil {
+			merged.Alerter = opt.Alerter
+		}
 	}
 	// Set the default value if missing from mergeOpts
 	if merged.Chroot == nil {
 		chroot := EnvOrDefaultChroot()
 		merged.Chroot = &chroot
+	}
+	if merged.Alerter == nil {
+		merged.Alerter = EnvOrDefaultAlerter()
 	}
 	if merged.Snapshot == nil {
 		snapRoot := EnvOrDefaultSnapshotRoot()

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -189,11 +189,11 @@ type pciPrinter struct {
 // YAMLString returns a string with the PCI information formatted as YAML
 // under a top-level "pci:" key
 func (i *Info) YAMLString() string {
-	return marshal.SafeYAML(pciPrinter{i})
+	return marshal.SafeYAML(i.ctx, pciPrinter{i})
 }
 
 // JSONString returns a string with the PCI information formatted as JSON
 // under a top-level "pci:" key
 func (i *Info) JSONString(indent bool) string {
-	return marshal.SafeJSON(pciPrinter{i}, indent)
+	return marshal.SafeJSON(i.ctx, pciPrinter{i}, indent)
 }

--- a/pkg/pci/pci_test.go
+++ b/pkg/pci/pci_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/jaypipes/ghw/pkg/context"
 	"github.com/jaypipes/ghw/pkg/marshal"
 	"github.com/jaypipes/ghw/pkg/pci"
 )
@@ -121,7 +122,7 @@ func TestPCIMarshalJSON(t *testing.T) {
 	}
 
 	dev := info.ParseDevice("0000:3c:00.0", "pci:v0000144Dd0000A804sv0000144Dsd0000A801bc01sc08i02")
-	s := marshal.SafeJSON(dev, true)
+	s := marshal.SafeJSON(context.FromEnv(), dev, true)
 	if s == "" {
 		t.Fatalf("Error marshalling device: %v", dev)
 	}

--- a/pkg/product/product.go
+++ b/pkg/product/product.go
@@ -90,11 +90,11 @@ type productPrinter struct {
 // YAMLString returns a string with the product information formatted as YAML
 // under a top-level "dmi:" key
 func (info *Info) YAMLString() string {
-	return marshal.SafeYAML(productPrinter{info})
+	return marshal.SafeYAML(info.ctx, productPrinter{info})
 }
 
 // JSONString returns a string with the product information formatted as JSON
 // under a top-level "product:" key
 func (info *Info) JSONString(indent bool) string {
-	return marshal.SafeJSON(productPrinter{info}, indent)
+	return marshal.SafeJSON(info.ctx, productPrinter{info}, indent)
 }

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -112,11 +112,11 @@ type topologyPrinter struct {
 // YAMLString returns a string with the topology information formatted as YAML
 // under a top-level "topology:" key
 func (i *Info) YAMLString() string {
-	return marshal.SafeYAML(topologyPrinter{i})
+	return marshal.SafeYAML(i.ctx, topologyPrinter{i})
 }
 
 // JSONString returns a string with the topology information formatted as JSON
 // under a top-level "topology:" key
 func (i *Info) JSONString(indent bool) string {
-	return marshal.SafeJSON(topologyPrinter{i}, indent)
+	return marshal.SafeJSON(i.ctx, topologyPrinter{i}, indent)
 }

--- a/pkg/topology/topology_linux.go
+++ b/pkg/topology/topology_linux.go
@@ -16,7 +16,6 @@ import (
 	"github.com/jaypipes/ghw/pkg/cpu"
 	"github.com/jaypipes/ghw/pkg/linuxpath"
 	"github.com/jaypipes/ghw/pkg/memory"
-	"github.com/jaypipes/ghw/pkg/util"
 )
 
 func (i *Info) load() error {
@@ -35,7 +34,7 @@ func topologyNodes(ctx *context.Context) []*Node {
 
 	files, err := ioutil.ReadDir(paths.SysDevicesSystemNode)
 	if err != nil {
-		util.Warn("failed to determine nodes: %s\n", err)
+		ctx.Warn("failed to determine nodes: %s\n", err)
 		return nodes
 	}
 	for _, file := range files {
@@ -46,26 +45,26 @@ func topologyNodes(ctx *context.Context) []*Node {
 		node := &Node{}
 		nodeID, err := strconv.Atoi(filename[4:])
 		if err != nil {
-			util.Warn("failed to determine node ID: %s\n", err)
+			ctx.Warn("failed to determine node ID: %s\n", err)
 			return nodes
 		}
 		node.ID = nodeID
 		cores, err := cpu.CoresForNode(ctx, nodeID)
 		if err != nil {
-			util.Warn("failed to determine cores for node: %s\n", err)
+			ctx.Warn("failed to determine cores for node: %s\n", err)
 			return nodes
 		}
 		node.Cores = cores
 		caches, err := memory.CachesForNode(ctx, nodeID)
 		if err != nil {
-			util.Warn("failed to determine caches for node: %s\n", err)
+			ctx.Warn("failed to determine caches for node: %s\n", err)
 			return nodes
 		}
 		node.Caches = caches
 
 		distances, err := distancesForNode(ctx, nodeID)
 		if err != nil {
-			util.Warn("failed to determine node distances for node: %s\n", err)
+			ctx.Warn("failed to determine node distances for node: %s\n", err)
 			return nodes
 		}
 		node.Distances = distances

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/jaypipes/ghw/pkg/context"
 )
 
 const (
@@ -30,29 +32,21 @@ func SafeClose(c closer) {
 	}
 }
 
-func Warn(msg string, args ...interface{}) {
-	if _, ok := os.LookupEnv(disableWarningsEnv); ok {
-		return
-	}
-	_, _ = fmt.Fprint(os.Stderr, "WARNING: ")
-	_, _ = fmt.Fprintf(os.Stderr, msg, args...)
-}
-
 // Reads a supplied filepath and converts the contents to an integer. Returns
 // -1 if there were file permissions or existence errors or if the contents
 // could not be successfully converted to an integer. In any error, a warning
 // message is printed to STDERR and -1 is returned.
-func SafeIntFromFile(path string) int {
+func SafeIntFromFile(ctx *context.Context, path string) int {
 	msg := "failed to read int from file: %s\n"
 	buf, err := ioutil.ReadFile(path)
 	if err != nil {
-		Warn(msg, err)
+		ctx.Warn(msg, err)
 		return -1
 	}
 	contents := strings.TrimSpace(string(buf))
 	res, err := strconv.Atoi(contents)
 	if err != nil {
-		Warn(msg, err)
+		ctx.Warn(msg, err)
 		return -1
 	}
 	return res


### PR DESCRIPTION
This PR wants to solve https://github.com/jaypipes/ghw/issues/175

This patch add support for a new option, which allow
the caller code to pass a new Alerter to ghw.
`Alerter` is a dead-simple interface, supporting only a
`Printf` method much like the stdlib `log` package.
ghw will send all the warnings to this method.

We use a so simple interface because we want to generalize a bit
the existing `util.Warn` concept, but is not clear if ghw will benefit
of a more complete logging interface; should that be the case, we
can build on the concept we laid in this patch.

Client code can programmatically override the Alerter, or
users can using the faimiliar `GHW_DISABLE_WARNINGS` environ variable,
which keep functioning as usual.

ghw can be configured to swallow all the warnings or to keep emitting them
on stderr, like it used to do up until this patch.

Signed-off-by: Francesco Romani <fromani@redhat.com>