### PR TITLE
PCI: Add device revision number

### DIFF
--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -31,6 +31,7 @@ type Device struct {
 	Address   string         `json:"address"`
 	Vendor    *pcidb.Vendor  `json:"vendor"`
 	Product   *pcidb.Product `json:"product"`
+	Revision  string         `json:"revision"`
 	Subsystem *pcidb.Product `json:"subsystem"`
 	// optional subvendor/sub-device information
 	Class *pcidb.Class `json:"class"`
@@ -49,6 +50,7 @@ type devMarshallable struct {
 	Address   string   `json:"address"`
 	Vendor    devIdent `json:"vendor"`
 	Product   devIdent `json:"product"`
+	Revision  string   `json:"revision"`
 	Subsystem devIdent `json:"subsystem"`
 	Class     devIdent `json:"class"`
 	Subclass  devIdent `json:"subclass"`
@@ -70,6 +72,7 @@ func (d *Device) MarshalJSON() ([]byte, error) {
 			ID:   d.Product.ID,
 			Name: d.Product.Name,
 		},
+		Revision: d.Revision,
 		Subsystem: devIdent{
 			ID:   d.Subsystem.ID,
 			Name: d.Subsystem.Name,

--- a/pkg/pci/pci_test.go
+++ b/pkg/pci/pci_test.go
@@ -83,6 +83,32 @@ func TestPCI(t *testing.T) {
 	if len(devs) == 0 {
 		t.Fatalf("Expected to find >0 PCI devices from PCIInfo.ListDevices() but got 0.")
 	}
+
+	// Ensure that the data fields are at least populated, even if we don't yet
+	// check for data accuracy
+	for _, dev := range devs {
+		if dev.Class == nil {
+			t.Fatalf("Expected device class for %s to be non-nil", dev.Address)
+		}
+		if dev.Product == nil {
+			t.Fatalf("Expected device product for %s to be non-nil", dev.Address)
+		}
+		if dev.Vendor == nil {
+			t.Fatalf("Expected device vendor for %s to be non-nil", dev.Address)
+		}
+		if dev.Revision == "" {
+			t.Fatalf("Expected device revision for %s to be non-empty", dev.Address)
+		}
+		if dev.Subclass == nil {
+			t.Fatalf("Expected device subclass for %s to be non-nil", dev.Address)
+		}
+		if dev.Subsystem == nil {
+			t.Fatalf("Expected device subsystem for %s to be non-nil", dev.Address)
+		}
+		if dev.ProgrammingInterface == nil {
+			t.Fatalf("Expected device programming interface for %s to be non-nil", dev.Address)
+		}
+	}
 }
 
 func TestPCIMarshalJSON(t *testing.T) {


### PR DESCRIPTION
Providing access to the revision number of hardware can be useful in
identifying or diagnosing problems introduced across versions of single
product line.

Signed-off-by: Kevin Pearson <kevin.pearson@ortmanconsulting.com>