### PR TITLE
pkg: net: report backing device address

### DIFF
--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -25,8 +25,8 @@ type NIC struct {
 	MacAddress   string           `json:"mac_address"`
 	IsVirtual    bool             `json:"is_virtual"`
 	Capabilities []*NICCapability `json:"capabilities"`
-	// TODO(jaypipes): Add PCI field for accessing PCI device information
-	// PCI *PCIDevice `json:"pci"`
+	PCIAddress   *string          `json:"pci_address,omitempty"`
+	// TODO(fromani): add other hw addresses (USB) when we support them
 }
 
 func (n *NIC) String() string {


### PR DESCRIPTION
Report the backing device address - currently PCI only -
in the network interface data.
This allows the client code to fetch the device information using
the specific package, for example `pkg/pci`.

We prefer to add the address, and not a pointer to the relevant
backing device object, the make the net module less coupled with
the other hardware modules.

Signed-off-by: Francesco Romani <fromani@redhat.com>