### PR TITLE
pci: add String() method to pci.Device

### DIFF
--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -144,6 +144,11 @@ type Address struct {
 	Function string
 }
 
+// String() returns the canonical [D]BSF representation of this Address
+func (addr *Address) String() string {
+	return addr.Domain + ":" + addr.Bus + ":" + addr.Slot + "." + addr.Function
+}
+
 // Given a string address, returns a complete Address struct, filled in with
 // domain, bus, slot and function components. The address string may either
 // be in $BUS:$SLOT.$FUNCTION (BSF) format or it can be a full PCI address

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -52,7 +52,7 @@ func getDeviceRevision(ctx *context.Context, address string) string {
 	}
 	revisionPath := filepath.Join(
 		paths.SysBusPciDevices,
-		pciAddr.Domain+":"+pciAddr.Bus+":"+pciAddr.Slot+"."+pciAddr.Function,
+		pciAddr.String(),
 		"revision",
 	)
 


### PR DESCRIPTION
We have AddressFromString(), so it seems natural to add
the symmetric, which we can also use in few places internally
to make the code more readable.

Signed-off-by: Francesco Romani <fromani@redhat.com>