### PR TITLE
fix spelling/grammar mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1280,13 +1280,13 @@ memory:
 
 ## Calling external programs
 
-By default ghw may call external programs, for example `ethtool` to learn about hardware capabilities.
+By default ghw may call external programs, for example `ethtool`, to learn about hardware capabilities.
 In some rare circumstances it may be useful to opt out from this behaviour and rely only on the data
 provided by pseudo-filesystems, like sysfs.
 The most common use case is when we want to consume a snapshot from ghw. In these cases the information
 provided by tools will be most likely inconsistent with the data from the snapshot - they will run on
 a different host!
-To make ghw not calling external tools, set the environs variable `GHW_DISABLE_TOOLS` to any value,
+To prevent ghw from calling external tools, set the environs variable `GHW_DISABLE_TOOLS` to any value,
 or, programmatically, check the `WithDisableTools` function.
 The default behaviour of ghw is to call external tools when available.
 

--- a/pkg/snapshot/clonetree_net.go
+++ b/pkg/snapshot/clonetree_net.go
@@ -17,9 +17,9 @@ const (
 	sysClassNet = "/sys/class/net"
 )
 
-// ExpectedCloneNetContent returns a slice of strings pertaning the network interfaces ghw
+// ExpectedCloneNetContent returns a slice of strings pertaning to the network interfaces ghw
 // cares about. We cannot use a static list because we want to filter away the virtual devices,
-// which  ghw doesn't concerns itself about. So we need to do some runtime discovery.
+// which  ghw doesn't concern itself about. So we need to do some runtime discovery.
 // Additionally, we want to make sure to clone the backing device data.
 func ExpectedCloneNetContent() []string {
 	var fileSpecs []string
@@ -41,7 +41,7 @@ func ExpectedCloneNetContent() []string {
 		}
 		if strings.Contains(dest, "devices/virtual/net") {
 			// there is no point in cloning data for virtual devices,
-			// becahse ghw concerns itself with HardWare.
+			// because ghw concerns itself with HardWare.
 			continue
 		}
 


### PR DESCRIPTION
Some spelling error sneaked in alongside https://github.com/jaypipes/ghw/pull/227
Let's fix them.

Signed-off-by: Francesco Romani <fromani@redhat.com>