### PR TITLE
pci: fix revision reporting

### DIFF
--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -64,7 +64,7 @@ func getDeviceRevision(ctx *context.Context, address string) string {
 	if err != nil {
 		return ""
 	}
-	return string(revision)
+	return strings.TrimSpace(string(revision))
 }
 
 func getDeviceNUMANode(ctx *context.Context, address string) *topology.Node {

--- a/pkg/pci/pci_linux_test.go
+++ b/pkg/pci/pci_linux_test.go
@@ -18,40 +18,17 @@ import (
 	"github.com/jaypipes/ghw/testdata"
 )
 
-type pciNumaTestCase struct {
-	addr string
-	node int
+type pciTestCase struct {
+	addr     string
+	node     int
+	revision string
 }
 
 // nolint: gocyclo
 func TestPCINUMANode(t *testing.T) {
-	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_PCI"); ok {
-		t.Skip("Skipping PCI tests.")
-	}
+	info := pciTestSetup(t)
 
-	testdataPath, err := testdata.SnapshotsDirectory()
-	if err != nil {
-		t.Fatalf("Expected nil err, but got %v", err)
-	}
-
-	multiNumaSnapshot := filepath.Join(testdataPath, "linux-amd64-intel-xeon-L5640.tar.gz")
-	// from now on we use constants reflecting the content of the snapshot we requested,
-	// which we reviewed beforehand. IOW, you need to know the content of the
-	// snapshot to fully understand this test. Inspect it using
-	// GHW_SNAPSHOT_PATH="/path/to/linux-amd64-intel-xeon-L5640.tar.gz" ghwc topology
-
-	info, err := pci.New(option.WithSnapshot(option.SnapshotOptions{
-		Path: multiNumaSnapshot,
-	}))
-
-	if err != nil {
-		t.Fatalf("Expected nil err, but got %v", err)
-	}
-	if info == nil {
-		t.Fatalf("Expected non-nil PCIInfo, but got nil")
-	}
-
-	tCases := []pciNumaTestCase{
+	tCases := []pciTestCase{
 		{
 			addr: "0000:07:03.0",
 			// -1 is actually what we get out of the box on the snapshotted box
@@ -83,5 +60,60 @@ func TestPCINUMANode(t *testing.T) {
 			}
 		})
 	}
+}
 
+// nolint: gocyclo
+func TestPCIDeviceRevision(t *testing.T) {
+	info := pciTestSetup(t)
+
+	var tCases []pciTestCase = []pciTestCase{
+		{
+			addr:     "0000:07:03.0",
+			revision: "0x0a",
+		},
+		{
+			addr:     "0000:05:00.0",
+			revision: "0x01",
+		},
+	}
+	for _, tCase := range tCases {
+		t.Run(fmt.Sprintf("%s", tCase.addr), func(t *testing.T) {
+			dev := info.GetDevice(tCase.addr)
+			if dev == nil {
+				t.Fatalf("got nil device for address %q", tCase.addr)
+			}
+			if dev.Revision != tCase.revision {
+				t.Errorf("device %q got revision %q expected %q", tCase.addr, dev.Revision, tCase.revision)
+			}
+		})
+	}
+}
+
+func pciTestSetup(t *testing.T) *pci.Info {
+	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_PCI"); ok {
+		t.Skip("Skipping PCI tests.")
+	}
+
+	testdataPath, err := testdata.SnapshotsDirectory()
+	if err != nil {
+		t.Fatalf("Expected nil err, but got %v", err)
+	}
+
+	multiNumaSnapshot := filepath.Join(testdataPath, "linux-amd64-intel-xeon-L5640.tar.gz")
+	// from now on we use constants reflecting the content of the snapshot we requested,
+	// which we reviewed beforehand. IOW, you need to know the content of the
+	// snapshot to fully understand this test. Inspect it using
+	// GHW_SNAPSHOT_PATH="/path/to/linux-amd64-intel-xeon-L5640.tar.gz" ghwc topology
+
+	info, err := pci.New(option.WithSnapshot(option.SnapshotOptions{
+		Path: multiNumaSnapshot,
+	}))
+
+	if err != nil {
+		t.Fatalf("Expected nil err, but got %v", err)
+	}
+	if info == nil {
+		t.Fatalf("Expected non-nil PCIInfo, but got nil")
+	}
+	return info
 }


### PR DESCRIPTION
Strip unnecessary whitespaces from the pci.Device.Revision field.
Add unit test to allow to catch up these errors in the future.

Signed-off-by: Francesco Romani <fromani@redhat.com>