### PR TITLE
janitorial: modernize error detection

### DIFF
--- a/pkg/gpu/gpu_test.go
+++ b/pkg/gpu/gpu_test.go
@@ -7,6 +7,7 @@
 package gpu_test
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -17,7 +18,7 @@ func TestGPU(t *testing.T) {
 	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_GPU"); ok {
 		t.Skip("Skipping GPU tests.")
 	}
-	if _, err := os.Stat("/sys/class/drm"); os.IsNotExist(err) {
+	if _, err := os.Stat("/sys/class/drm"); errors.Is(err, os.ErrNotExist) {
 		t.Skip("Skipping GPU tests. The environment has no /sys/class/drm directory.")
 	}
 	info, err := gpu.New()

--- a/pkg/memory/memory_cache_linux.go
+++ b/pkg/memory/memory_cache_linux.go
@@ -6,6 +6,7 @@
 package memory
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -62,7 +63,7 @@ func CachesForNode(ctx *context.Context, nodeID int) ([]*Cache, error) {
 		// directories contains information about the size of that level of
 		// cache and the processors mapped to it.
 		cachePath := filepath.Join(cpuPath, "cache")
-		if _, err = os.Stat(cachePath); os.IsNotExist(err) {
+		if _, err = os.Stat(cachePath); errors.Is(err, os.ErrNotExist) {
 			continue
 		}
 		cacheDirFiles, err := ioutil.ReadDir(cachePath)

--- a/pkg/snapshot/clonetree_block.go
+++ b/pkg/snapshot/clonetree_block.go
@@ -7,6 +7,7 @@
 package snapshot
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -120,7 +121,7 @@ func createBlockDeviceDir(buildDeviceDir string, srcDeviceDir string) error {
 			// and whether the device is read-only
 			buf, err := ioutil.ReadFile(fp)
 			if err != nil {
-				if os.IsPermission(err) {
+				if errors.Is(err, os.ErrPermission) {
 					// example: /sys/devices/virtual/block/zram0/compact is 0400
 					trace("permission denied reading %q - skipped\n", fp)
 					continue

--- a/pkg/snapshot/pack.go
+++ b/pkg/snapshot/pack.go
@@ -9,6 +9,7 @@ package snapshot
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -35,7 +36,7 @@ func OpenDestination(snapshotName string) (*os.File, error) {
 	var f *os.File
 	var err error
 
-	if _, err = os.Stat(snapshotName); os.IsNotExist(err) {
+	if _, err = os.Stat(snapshotName); errors.Is(err, os.ErrNotExist) {
 		if f, err = os.Create(snapshotName); err != nil {
 			return nil, err
 		}

--- a/pkg/snapshot/unpack_test.go
+++ b/pkg/snapshot/unpack_test.go
@@ -7,6 +7,7 @@
 package snapshot_test
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -33,7 +34,7 @@ func TestUnpack(t *testing.T) {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}
 
-	if _, err := os.Stat(root); !os.IsNotExist(err) {
+	if _, err := os.Stat(root); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("Expected %q to be gone, but still exists", root)
 	}
 }
@@ -60,7 +61,7 @@ func TestUnpackInto(t *testing.T) {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}
 
-	if _, err := os.Stat(testRoot); !os.IsNotExist(err) {
+	if _, err := os.Stat(testRoot); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("Expected %q to be gone, but still exists", testRoot)
 	}
 }
@@ -103,7 +104,7 @@ func TestUnpackIntoPresrving(t *testing.T) {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}
 
-	if _, err := os.Stat(testRoot); !os.IsNotExist(err) {
+	if _, err := os.Stat(testRoot); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("Expected %q to be gone, but still exists", testRoot)
 	}
 }


### PR DESCRIPTION
Reading the documentation of `os.IsNotExist` and similar functions
(see https://golang.org/pkg/os/#IsNotExist), we learn that

```
This function predates errors.Is. It only supports errors returned
by the os package. New code should use errors.Is(err, os.ErrNotExist).
```

ghw uses these functions but sparsely, so we take the chance
in this PR to modernize the codebase.

No intended changes in behaviour.

Signed-off-by: Francesco Romani <fromani@redhat.com>