### PR TITLE
test: snapshot: don't leak unpack directory

### DIFF
--- a/pkg/snapshot/clonetree_test.go
+++ b/pkg/snapshot/clonetree_test.go
@@ -18,12 +18,17 @@ import (
 	"github.com/jaypipes/ghw/pkg/snapshot"
 )
 
+// NOTE: we intentionally use `os.RemoveAll` - not `snapshot.Cleanup` because we
+// want to make sure we never leak directories. `snapshot.Cleanup` is used and
+// tested explicitely in `unpack_test.go`.
+
 // nolint: gocyclo
 func TestCloneTree(t *testing.T) {
 	root, err := snapshot.Unpack(testDataSnapshot)
 	if err != nil {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}
+	defer os.RemoveAll(root)
 
 	cloneRoot, err := ioutil.TempDir("", "ghw-test-clonetree-*")
 	if err != nil {

--- a/pkg/snapshot/pack_test.go
+++ b/pkg/snapshot/pack_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/jaypipes/ghw/pkg/snapshot"
 )
 
+// NOTE: we intentionally use `os.RemoveAll` - not `snapshot.Cleanup` because we
+// want to make sure we never leak directories. `snapshot.Cleanup` is used and
+// tested explicitely in `unpack_test.go`.
+
 // nolint: gocyclo
 func TestPackUnpack(t *testing.T) {
 	root, err := snapshot.Unpack(testDataSnapshot)
@@ -44,6 +48,7 @@ func TestPackUnpack(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}
+	defer os.RemoveAll(cloneRoot)
 
 	verifyTestData(t, cloneRoot)
 }


### PR DESCRIPTION
Errors in the tests caused leaks of unpacked test directory.
Make sure to clean up after ourselves.

Signed-off-by: Francesco Romani <fromani@redhat.com>