### PR TITLE
context: introduce dependent context

### DIFF
--- a/pkg/baseboard/baseboard.go
+++ b/pkg/baseboard/baseboard.go
@@ -50,7 +50,14 @@ func (i *Info) String() string {
 // New returns a pointer to an Info struct containing information about the
 // host's baseboard
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return newWithContext(context.New(opts...))
+}
+
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	return newWithContext(context.FromParent(ctx))
+}
+
+func newWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/bios/bios.go
+++ b/pkg/bios/bios.go
@@ -50,7 +50,14 @@ func (i *Info) String() string {
 // New returns a pointer to a Info struct containing information
 // about the host's BIOS
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return newWithContext(context.New(opts...))
+}
+
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	return newWithContext(context.FromParent(ctx))
+}
+
+func newWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -134,7 +134,14 @@ type Info struct {
 // New returns a pointer to an Info struct that describes the block storage
 // resources of the host system.
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return newWithContext(context.New(opts...))
+}
+
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	return newWithContext(context.FromParent(ctx))
+}
+
+func newWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/chassis/chassis.go
+++ b/pkg/chassis/chassis.go
@@ -94,7 +94,14 @@ func (i *Info) String() string {
 // New returns a pointer to a Info struct containing information
 // about the host's chassis
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return newWithContext(context.New(opts...))
+}
+
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	return newWithContext(context.FromParent(ctx))
+}
+
+func newWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -7,6 +7,8 @@
 package context
 
 import (
+	"fmt"
+
 	"github.com/jaypipes/ghw/pkg/option"
 	"github.com/jaypipes/ghw/pkg/snapshot"
 )
@@ -20,6 +22,7 @@ type Context struct {
 	SnapshotRoot      string
 	SnapshotExclusive bool
 	alert             option.Alerter
+	err               error
 	parent            *Context
 }
 
@@ -48,6 +51,13 @@ func New(opts ...*option.Option) *Context {
 		ctx.EnableTools = *merged.EnableTools
 	}
 
+	// New is not allowed to return error - it would break the established API.
+	// so the only way out is to actually do the checks here and record the error,
+	// and return it later, at the earliest possible occasion, in Setup()
+	if ctx.SnapshotPath != "" && ctx.Chroot != option.DefaultChroot {
+		// The env/client code supplied a value, but we are will overwrite it when unpacking shapshots!
+		ctx.err = fmt.Errorf("Conflicting options: chroot %q and snapshot path %q", ctx.Chroot, ctx.SnapshotPath)
+	}
 	return ctx
 }
 
@@ -99,6 +109,9 @@ func (ctx *Context) Do(fn func() error) error {
 // You should call `Setup` just once. It is safe to call `Setup` if you don't make
 // use of optional extra features - `Setup` will do nothing.
 func (ctx *Context) Setup() error {
+	if ctx.err != nil {
+		return ctx.err
+	}
 	if ctx.parent != nil {
 		// nothing to do - the parent is in charge
 		return nil

--- a/pkg/cpu/cpu.go
+++ b/pkg/cpu/cpu.go
@@ -117,7 +117,14 @@ type Info struct {
 // New returns a pointer to an Info struct that contains information about the
 // CPUs on the host system
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return newWithContext(context.New(opts...))
+}
+
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	return newWithContext(context.FromParent(ctx))
+}
+
+func newWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/gpu/gpu.go
+++ b/pkg/gpu/gpu.go
@@ -56,7 +56,14 @@ type Info struct {
 // New returns a pointer to an Info struct that contains information about the
 // graphics cards on the host system
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return newWithContext(context.New(opts...))
+}
+
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	return newWithContext(context.FromParent(ctx))
+}
+
+func newWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -35,7 +35,14 @@ type Info struct {
 }
 
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return newWithContext(context.New(opts...))
+}
+
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	return newWithContext(context.FromParent(ctx))
+}
+
+func newWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -49,7 +49,14 @@ type Info struct {
 // New returns a pointer to an Info struct that contains information about the
 // network interface controllers (NICs) on the host system
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return newWithContext(context.New(opts...))
+}
+
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	return newWithContext(context.FromParent(ctx))
+}
+
+func newWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -14,7 +14,10 @@ import (
 )
 
 const (
-	defaultChroot           = "/"
+	DefaultChroot = "/"
+)
+
+const (
 	envKeyChroot            = "GHW_CHROOT"
 	envKeyDisableWarnings   = "GHW_DISABLE_WARNINGS"
 	envKeyDisableTools      = "GHW_DISABLE_TOOLS"
@@ -57,7 +60,7 @@ func EnvOrDefaultChroot() string {
 	if val, exists := os.LookupEnv(envKeyChroot); exists {
 		return val
 	}
-	return defaultChroot
+	return DefaultChroot
 }
 
 // EnvOrDefaultSnapshotPath returns the value of the GHW_SNAPSHOT_PATH environs variable

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -151,7 +151,14 @@ func (i *Info) String() string {
 // New returns a pointer to an Info struct that contains information about the
 // PCI devices on the host system
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return newWithContext(context.New(opts...))
+}
+
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	return newWithContext(context.FromParent(ctx))
+}
+
+func newWithContext(ctx *context.Context) (*Info, error) {
 	// by default we don't report NUMA information;
 	// we will only if are sure we are running on NUMA architecture
 	arch := topology.ARCHITECTURE_SMP

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -161,18 +161,22 @@ func NewWithContext(ctx *context.Context) (*Info, error) {
 func newWithContext(ctx *context.Context) (*Info, error) {
 	// by default we don't report NUMA information;
 	// we will only if are sure we are running on NUMA architecture
-	arch := topology.ARCHITECTURE_SMP
-	topo, err := topology.NewWithContext(ctx)
-	if err == nil {
-		arch = topo.Architecture
-	} else {
-		ctx.Warn("error detecting system topology: %v", err)
-	}
 	info := &Info{
-		arch: arch,
+		arch: topology.ARCHITECTURE_SMP,
 		ctx:  ctx,
 	}
-	if err := ctx.Do(info.load); err != nil {
+	// we do this trick because we need to make sure ctx.Setup() gets
+	// a chance to run before any subordinate package is created reusing
+	// our context.
+	if err := ctx.Do(func() error {
+		topo, err := topology.NewWithContext(ctx)
+		if err == nil {
+			info.arch = topo.Architecture
+		} else {
+			ctx.Warn("error detecting system topology: %v", err)
+		}
+		return info.load()
+	}); err != nil {
 		return nil, err
 	}
 	return info, nil

--- a/pkg/product/product.go
+++ b/pkg/product/product.go
@@ -73,7 +73,14 @@ func (i *Info) String() string {
 // New returns a pointer to a Info struct containing information
 // about the host's product
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return newWithContext(context.New(opts...))
+}
+
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	return newWithContext(context.FromParent(ctx))
+}
+
+func newWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -79,13 +79,17 @@ type Info struct {
 // New returns a pointer to an Info struct that contains information about the
 // NUMA topology on the host system
 func New(opts ...*option.Option) (*Info, error) {
-	return NewWithContext(context.New(opts...))
+	return newWithContext(context.New(opts...))
 }
 
 // NewWithContext returns a pointer to an Info struct that contains information about
 // the NUMA topology on the host system. Use this function when you want to consume
 // the topology package from another package (e.g. pci, gpu)
 func NewWithContext(ctx *context.Context) (*Info, error) {
+	return newWithContext(context.FromParent(ctx))
+}
+
+func newWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err


### PR DESCRIPTION
The PR https://github.com/jaypipes/ghw/pull/236 fixes a snapshot
directory leakage issue, but also highlight a context
lifecycle/ownership issue.

In general in ghw each package creates its own context, including
the cases on which a package is consumed by another, for example
`topology` and `pci`. However, in this case, it would make more sense
to reuse the context from the parent package, because the two packages
are tightly coupled.

Before the introduction of the the transparent snapshot support
(https://github.com/jaypipes/ghw/pull/202), the above mechanism worked,
because each context, each time, was consuming over and over again the
same parameters (e.g. environment variables); besides some resource
waste, this had no negative effect.

When introducing snapshots in the picture, repeatedly unpacking the
same snapshot to consume the same data is much more wasteful.
So it makes sense to introduce explicitly the concept of dependent
context.

We add a functio to create a context subordinate to another.
The subordinate context will effectively borrow all the resources from
the parent one. The parent is in charge to perform any setup/teardown
(e.g. for snapshot, to learn which chroot should be used, if at all)
and so forth.
Making this dependency explicit allow the client code to manage
correctly the lifecycle of the topmost context, hence of all the
resources.

Signed-off-by: Francesco Romani <fromani@redhat.com>