### PR TITLE
doc: don't claim we clean up user-supplied dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ leftovers.
 The rest of the environment variables are relevant iff `GHW_SNAPSHOT_PATH` is given.
 `GHW_SNAPSHOT_ROOT` let users specify the directory
 on which the snapshot should be unpacked. This moves the ownership of that
-directory from `ghw` to users. `ghw` will still clean up the unpacked snapshot
-when no longer needed.
+directory from `ghw` to users. For this reason, `ghw` will *not* clean up automatically
+the content unpacked in `GHW_SNAPSHOT_ROOT`.
 
 `GHW_SNAPSHOT_EXCLUSIVE` is relevant iff `GHW_SNAPSHOT_ROOT` is given.
 Set it to any value to toggle it on. This tells `ghw` that the directory is meant


### PR DESCRIPTION
Previously the documentation claimed the snapshot support code
could clean up properly when `GHW_SNAPSHOT_ROOT` is given.
This is too risky to be done safely, and having shared ownership
(client code owns the directory, ghw owns _some_ of its content)
is a bad idea anyway.

Thus, better not to attempt half-baked work: ghw will leave the
GHW_SNAPSHOT_ROOT directory alone completely.

Please note this also reflects what the code actually does
and the intention expressed in the comment in `pkg/context/context.go`

Signed-off-by: Francesco Romani <fromani@redhat.com>