### PR TITLE
pci: add and use LookupDevice

### DIFF
--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -171,6 +171,16 @@ func New(opts ...*option.Option) (*Info, error) {
 	return info, nil
 }
 
+// lookupDevice gets a device from cached data
+func (info *Info) lookupDevice(address string) *Device {
+	for _, dev := range info.Devices {
+		if dev.Address == address {
+			return dev
+		}
+	}
+	return nil
+}
+
 // simple private struct used to encapsulate PCI information in a top-level
 // "pci" YAML/JSON map/object key
 type pciPrinter struct {

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -271,9 +271,14 @@ func findPCIProgrammingInterface(
 }
 
 // GetDevice returns a pointer to a Device struct that describes the PCI
-// device at the requested address. If no such device could be found, returns
-// nil
+// device at the requested address. If no such device could be found, returns nil.
 func (info *Info) GetDevice(address string) *Device {
+	// check cached data first
+	if dev := info.lookupDevice(address); dev != nil {
+		return dev
+	}
+
+	// no cached data, let's get the information from system.
 	fp := getDeviceModaliasPath(info.ctx, address)
 	if fp == "" {
 		info.ctx.Warn("error finding modalias info for device %q", address)


### PR DESCRIPTION
Add a simple helper to find a device among the `pci.Info.Devices`.
Up until now, client code had to reimplement the find function
every time, or to call `GetDevice`. Problem is:
`GetDevice`  access the system every time.

In most cases, besides a tiny performance hit, this is no issue.
When consuming snapshots, however, this may lead to surprising behaviour
because the caller need to ensure the snapshot is available when
`GetDevice` is called, or it will return unpredictable result (!!!).

The wrong code looks like that:

1. PCI info is created supplying snapshot data with automatic management
1.a ghw unpacks the snapshot on a temporary dir
1.b ghw loads all the info from the snapshot. info.Devices contains
    correct data
1.c ghw cleans up the snapshot (see:
  https://github.com/jaypipes/ghw/pull/236)
2. the client (test) code calls GetDevice
2.a GetDevice will try to access the unpacked snapshot data, which is
    gone
2.b GetDevice will fail

Signed-off-by: Francesco Romani <fromani@redhat.com>