### PR TITLE
gpu: pass through the context into subsystems

### DIFF
--- a/pkg/gpu/gpu_linux.go
+++ b/pkg/gpu/gpu_linux.go
@@ -93,15 +93,15 @@ func (i *Info) load() error {
 		cards = append(cards, card)
 	}
 	gpuFillNUMANodes(i.ctx, cards)
-	gpuFillPCIDevice(cards)
+	gpuFillPCIDevice(i.ctx, cards)
 	i.GraphicsCards = cards
 	return nil
 }
 
 // Loops through each GraphicsCard struct and attempts to fill the DeviceInfo
 // attribute with PCI device information
-func gpuFillPCIDevice(cards []*GraphicsCard) {
-	pci, err := pci.New()
+func gpuFillPCIDevice(ctx *context.Context, cards []*GraphicsCard) {
+	pci, err := pci.NewWithContext(ctx)
 	if err != nil {
 		return
 	}
@@ -117,7 +117,7 @@ func gpuFillPCIDevice(cards []*GraphicsCard) {
 // system is not a NUMA system, the Node field will be set to nil.
 func gpuFillNUMANodes(ctx *context.Context, cards []*GraphicsCard) {
 	paths := linuxpath.New(ctx)
-	topo, err := topology.New()
+	topo, err := topology.NewWithContext(ctx)
 	if err != nil {
 		// Problem getting topology information so just set the graphics card's
 		// node to nil

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -151,7 +151,13 @@ func (i *Info) String() string {
 // New returns a pointer to an Info struct that contains information about the
 // PCI devices on the host system
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return NewWithContext(context.New(opts...))
+}
+
+// NewWithContext returns a pointer to an Info struct that contains information about
+// the PCI devices on the host system. Use this function when you want to consume
+// the topology package from another package (e.g. gpu)
+func NewWithContext(ctx *context.Context) (*Info, error) {
 	// by default we don't report NUMA information;
 	// we will only if are sure we are running on NUMA architecture
 	arch := topology.ARCHITECTURE_SMP


### PR DESCRIPTION
The GPU package uses the pci and the topology packages internally.
Make sure to pass to them the same context the package is using,
in order to ensure more consistent behaviour, enable snapshot
consumption - and to waste a little less work in general.

Signed-off-by: Francesco Romani <fromani@redhat.com>