### PR TITLE
Dependent contexts

### DIFF
--- a/pkg/baseboard/baseboard.go
+++ b/pkg/baseboard/baseboard.go
@@ -57,7 +57,14 @@ func (i *Info) String() string {
 // New returns a pointer to an Info struct containing information about the
 // host's baseboard
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return NewWithContext(context.New(opts...))
+}
+
+// New returns a pointer to an Info struct containing information about the
+// host's baseboard, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/bios/bios.go
+++ b/pkg/bios/bios.go
@@ -50,7 +50,14 @@ func (i *Info) String() string {
 // New returns a pointer to a Info struct containing information
 // about the host's BIOS
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return NewWithContext(context.New(opts...))
+}
+
+// New returns a pointer to a Info struct containing information
+// about the host's BIOS, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -134,7 +134,14 @@ type Info struct {
 // New returns a pointer to an Info struct that describes the block storage
 // resources of the host system.
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return NewWithContext(context.New(opts...))
+}
+
+// New returns a pointer to an Info struct that describes the block storage
+// resources of the host system, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/chassis/chassis.go
+++ b/pkg/chassis/chassis.go
@@ -94,7 +94,14 @@ func (i *Info) String() string {
 // New returns a pointer to a Info struct containing information
 // about the host's chassis
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return NewWithContext(context.New(opts...))
+}
+
+// New returns a pointer to a Info struct containing information
+// about the host's chassis, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -56,7 +56,7 @@ func New(opts ...*option.Option) *Context {
 	return ctx
 }
 
-// FromEnv returns an Option that has been populated from the environs or
+// FromEnv returns a Context that has been populated from the environs or
 // default options values
 func FromEnv() *Context {
 	chrootVal := option.EnvOrDefaultChroot()

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -40,3 +40,94 @@ func TestSnapshotContext(t *testing.T) {
 		t.Fatalf("Expected the uncompressed dir to be deleted: %s", uncompressedDir)
 	}
 }
+
+// nolint: gocyclo
+func TestContextReadiness(t *testing.T) {
+	ctx := context.New()
+	if ctx.IsReady() {
+		t.Fatalf("context ready before Setup()")
+	}
+
+	ctx.Do(func() error {
+		if !ctx.IsReady() {
+			t.Fatalf("context NOT ready inside Do()")
+		}
+		return nil
+	})
+
+	if ctx.IsReady() {
+		t.Fatalf("context ready after Teardown()")
+	}
+}
+
+// nolint: gocyclo
+func TestContextReadinessNested(t *testing.T) {
+	ctx := context.New()
+	if ctx.IsReady() {
+		t.Fatalf("context ready before Setup()")
+	}
+
+	ctx.Do(func() error {
+		if !ctx.IsReady() {
+			t.Fatalf("context NOT ready inside outer Do()")
+		}
+		ctx.Do(func() error {
+			if !ctx.IsReady() {
+				t.Fatalf("context NOT ready inside inner Do()")
+			}
+			return nil
+		})
+		if !ctx.IsReady() {
+			t.Fatalf("context NOT ready after inner Do()")
+		}
+		return nil
+	})
+
+	if ctx.IsReady() {
+		t.Fatalf("context ready after Teardown() - refcount = %d", ctx.RefCount())
+	}
+}
+
+// nolint: gocyclo
+func TestContextReadinessDeeplyNested(t *testing.T) {
+	// we don't expect more nesting than this atm
+	ctx := context.New()
+	if ctx.IsReady() {
+		t.Fatalf("context ready before Setup()")
+	}
+	if ctx.RefCount() != 0 {
+		t.Fatalf("context refcount unexpected value %d", ctx.RefCount())
+	}
+
+	ctx.Do(func() error {
+		if !ctx.IsReady() {
+			t.Fatalf("context NOT ready inside outer Do()")
+		}
+		ctx.Do(func() error {
+			if !ctx.IsReady() {
+				t.Fatalf("context NOT ready inside middle Do()")
+			}
+			ctx.Do(func() error {
+				if !ctx.IsReady() {
+					t.Fatalf("context NOT ready inside inner Do()")
+				}
+				return nil
+			})
+			if !ctx.IsReady() {
+				t.Fatalf("context NOT ready after inner Do()")
+			}
+			return nil
+		})
+		if !ctx.IsReady() {
+			t.Fatalf("context NOT ready after middle Do()")
+		}
+		return nil
+	})
+
+	if ctx.IsReady() {
+		t.Fatalf("context ready after Teardown() - refcount = %d", ctx.RefCount())
+	}
+	if ctx.RefCount() != 0 {
+		t.Fatalf("context refcount unexpected value %d", ctx.RefCount())
+	}
+}

--- a/pkg/cpu/cpu.go
+++ b/pkg/cpu/cpu.go
@@ -117,7 +117,14 @@ type Info struct {
 // New returns a pointer to an Info struct that contains information about the
 // CPUs on the host system
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return NewWithContext(context.New(opts...))
+}
+
+// New returns a pointer to an Info struct that contains information about the
+// CPUs on the host system, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/gpu/gpu.go
+++ b/pkg/gpu/gpu.go
@@ -56,7 +56,14 @@ type Info struct {
 // New returns a pointer to an Info struct that contains information about the
 // graphics cards on the host system
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return NewWithContext(context.New(opts...))
+}
+
+// New returns a pointer to an Info struct that contains information about the
+// graphics cards on the host system, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -34,8 +34,17 @@ type Info struct {
 	Modules            []*Module `json:"modules"`
 }
 
+// New returns a pointer to an Info struct containing information about the
+// host's memory.
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return NewWithContext(context.New(opts...))
+}
+
+// New returns a pointer to an Info struct containing information about the
+// host's memory, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -49,7 +49,14 @@ type Info struct {
 // New returns a pointer to an Info struct that contains information about the
 // network interface controllers (NICs) on the host system
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return NewWithContext(context.New(opts...))
+}
+
+// New returns a pointer to an Info struct that contains information about the
+// network interface controllers (NICs) on the host system, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -14,7 +14,10 @@ import (
 )
 
 const (
-	defaultChroot           = "/"
+	DefaultChroot = "/"
+)
+
+const (
 	envKeyChroot            = "GHW_CHROOT"
 	envKeyDisableWarnings   = "GHW_DISABLE_WARNINGS"
 	envKeyDisableTools      = "GHW_DISABLE_TOOLS"
@@ -57,7 +60,7 @@ func EnvOrDefaultChroot() string {
 	if val, exists := os.LookupEnv(envKeyChroot); exists {
 		return val
 	}
-	return defaultChroot
+	return DefaultChroot
 }
 
 // EnvOrDefaultSnapshotPath returns the value of the GHW_SNAPSHOT_PATH environs variable

--- a/pkg/product/product.go
+++ b/pkg/product/product.go
@@ -73,7 +73,14 @@ func (i *Info) String() string {
 // New returns a pointer to a Info struct containing information
 // about the host's product
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return NewWithContext(context.New(opts...))
+}
+
+// New returns a pointer to a Info struct containing information
+// about the host's product, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err


### PR DESCRIPTION
In this PR we revisit how we handle context for dependent packages; a good example is the `pci` package, which wants to use the `topology` package internally. But there are more, like `gpu` (uses `pci` and `topology`), and in the future `sriov` wants as well to use `pci` (see https://github.com/jaypipes/ghw/pull/230)

While I'm happy with this PR and I believe the gains outweights the risk, let's discuss if this direction is a good one or if we want to solve the same problem in a different way.