### PR TITLE
linuxpaths: allow to override mount points

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,34 @@ Alternately, you can use the `ghw.WithChroot()` function like so:
 cpu, err := ghw.CPU(ghw.WithChroot("/host"))
 ```
 
+### Overriding the per-mountpoint `ghw` uses
+
+When running inside containers, it could be a bit cumbersome to just override
+the root mountpoint. Inside containers, when granting access to the host
+file systems, is more common to bind-mount them in non standard location,
+like `/sys` on `/host-sys` or `/proc` on `/host-proc`.
+Is rarer to mount them in a common subtree (e.g. `/sys` on `/host/sys` and
+ `/proc` on /host/proc...)
+
+To better cover this use case, `ghw` allows to *programmatically* override
+the initial component of filesystems subtrees, allowing to access `sysfs`
+(or `procfs` or...) mounted on non-standard locations.
+
+
+```go
+cpu, err := ghw.CPU(ghw.WithPathOverrides(ghw.PathOverrides{
+	"/proc": "/host-proc",
+	"/sys": "/host-sys",
+}))
+```
+
+Please note
+- this feature works in addition and is composable with the
+  `WithChroot`/`GHW_CHROOT` feature.
+- `ghw` doesn't support yet environs variable to override individual
+   mountpoints, because this could lead to significant environs variables
+   proliferation.
+
 ### Consuming snapshots
 
 You can make `ghw` read from snapshots (created with `ghw-snapshot`) using

--- a/alias.go
+++ b/alias.go
@@ -32,9 +32,12 @@ var (
 	// match the existing environ variable to minimize surprises
 	WithDisableWarnings = option.WithNullAlerter
 	WithDisableTools    = option.WithDisableTools
+	WithPathOverrides   = option.WithPathOverrides
 )
 
 type SnapshotOptions = option.SnapshotOptions
+
+type PathOverrides = option.PathOverrides
 
 type CPUInfo = cpu.Info
 

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -19,6 +19,7 @@ type Context struct {
 	SnapshotPath         string
 	SnapshotRoot         string
 	SnapshotExclusive    bool
+	PathOverrides        option.PathOverrides
 	snapshotUnpackedPath string
 	alert                option.Alerter
 }
@@ -46,6 +47,10 @@ func New(opts ...*option.Option) *Context {
 
 	if merged.EnableTools != nil {
 		ctx.EnableTools = *merged.EnableTools
+	}
+
+	if merged.PathOverrides != nil {
+		ctx.PathOverrides = merged.PathOverrides
 	}
 
 	return ctx

--- a/pkg/linuxpath/path_linux.go
+++ b/pkg/linuxpath/path_linux.go
@@ -12,6 +12,49 @@ import (
 	"github.com/jaypipes/ghw/pkg/context"
 )
 
+// PathRoots holds the roots of all the filesystem subtrees
+// ghw wants to access.
+type PathRoots struct {
+	Etc  string
+	Proc string
+	Run  string
+	Sys  string
+	Var  string
+}
+
+// DefaultPathRoots return the canonical default value for PathRoots
+func DefaultPathRoots() PathRoots {
+	return PathRoots{
+		Etc:  "/etc",
+		Proc: "/proc",
+		Run:  "/run",
+		Sys:  "/sys",
+		Var:  "/var",
+	}
+}
+
+// PathRootsFromContext initialize PathRoots from the given Context,
+// allowing overrides of the canonical default paths.
+func PathRootsFromContext(ctx *context.Context) PathRoots {
+	roots := DefaultPathRoots()
+	if pathEtc, ok := ctx.PathOverrides["/etc"]; ok {
+		roots.Etc = pathEtc
+	}
+	if pathProc, ok := ctx.PathOverrides["/proc"]; ok {
+		roots.Proc = pathProc
+	}
+	if pathRun, ok := ctx.PathOverrides["/run"]; ok {
+		roots.Run = pathRun
+	}
+	if pathSys, ok := ctx.PathOverrides["/sys"]; ok {
+		roots.Sys = pathSys
+	}
+	if pathVar, ok := ctx.PathOverrides["/var"]; ok {
+		roots.Var = pathVar
+	}
+	return roots
+}
+
 type Paths struct {
 	VarLog                 string
 	ProcMeminfo            string
@@ -31,20 +74,21 @@ type Paths struct {
 // New returns a new Paths struct containing filepath fields relative to the
 // supplied Context
 func New(ctx *context.Context) *Paths {
+	roots := PathRootsFromContext(ctx)
 	return &Paths{
-		VarLog:                 filepath.Join(ctx.Chroot, "var", "log"),
-		ProcMeminfo:            filepath.Join(ctx.Chroot, "proc", "meminfo"),
-		ProcCpuinfo:            filepath.Join(ctx.Chroot, "proc", "cpuinfo"),
-		SysKernelMMHugepages:   filepath.Join(ctx.Chroot, "sys", "kernel", "mm", "hugepages"),
-		EtcMtab:                filepath.Join(ctx.Chroot, "etc", "mtab"),
-		SysBlock:               filepath.Join(ctx.Chroot, "sys", "block"),
-		SysDevicesSystemNode:   filepath.Join(ctx.Chroot, "sys", "devices", "system", "node"),
-		SysDevicesSystemMemory: filepath.Join(ctx.Chroot, "sys", "devices", "system", "memory"),
-		SysBusPciDevices:       filepath.Join(ctx.Chroot, "sys", "bus", "pci", "devices"),
-		SysClassDRM:            filepath.Join(ctx.Chroot, "sys", "class", "drm"),
-		SysClassDMI:            filepath.Join(ctx.Chroot, "sys", "class", "dmi"),
-		SysClassNet:            filepath.Join(ctx.Chroot, "sys", "class", "net"),
-		RunUdevData:            filepath.Join(ctx.Chroot, "run", "udev", "data"),
+		VarLog:                 filepath.Join(ctx.Chroot, roots.Var, "log"),
+		ProcMeminfo:            filepath.Join(ctx.Chroot, roots.Proc, "meminfo"),
+		ProcCpuinfo:            filepath.Join(ctx.Chroot, roots.Proc, "cpuinfo"),
+		SysKernelMMHugepages:   filepath.Join(ctx.Chroot, roots.Sys, "kernel", "mm", "hugepages"),
+		EtcMtab:                filepath.Join(ctx.Chroot, roots.Etc, "mtab"),
+		SysBlock:               filepath.Join(ctx.Chroot, roots.Sys, "block"),
+		SysDevicesSystemNode:   filepath.Join(ctx.Chroot, roots.Sys, "devices", "system", "node"),
+		SysDevicesSystemMemory: filepath.Join(ctx.Chroot, roots.Sys, "devices", "system", "memory"),
+		SysBusPciDevices:       filepath.Join(ctx.Chroot, roots.Sys, "bus", "pci", "devices"),
+		SysClassDRM:            filepath.Join(ctx.Chroot, roots.Sys, "class", "drm"),
+		SysClassDMI:            filepath.Join(ctx.Chroot, roots.Sys, "class", "dmi"),
+		SysClassNet:            filepath.Join(ctx.Chroot, roots.Sys, "class", "net"),
+		RunUdevData:            filepath.Join(ctx.Chroot, roots.Run, "udev", "data"),
 	}
 }
 

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -129,6 +129,10 @@ type Option struct {
 	// EnableTools optionally request ghw to not call any external program to learn
 	// about the hardware. The default is to use such tools if available.
 	EnableTools *bool
+
+	// PathOverrides optionally allows to override the default paths ghw uses internally
+	// to learn about the system resources.
+	PathOverrides PathOverrides
 }
 
 // SnapshotOptions contains options for handling of ghw snapshots
@@ -152,6 +156,7 @@ type SnapshotOptions struct {
 	Exclusive bool
 }
 
+// WithChroot allows to override the root directory ghw uses.
 func WithChroot(dir string) *Option {
 	return &Option{Chroot: &dir}
 }
@@ -183,6 +188,16 @@ func WithDisableTools() *Option {
 	return &Option{EnableTools: &false_}
 }
 
+// PathOverrides is a map, keyed by the string name of a mount path, of override paths
+type PathOverrides map[string]string
+
+// WithPathOverrides supplies path-specific overrides for the context
+func WithPathOverrides(overrides PathOverrides) *Option {
+	return &Option{
+		PathOverrides: overrides,
+	}
+}
+
 // There is intentionally no Option related to GHW_SNAPSHOT_PRESERVE because we see that as
 // a debug/troubleshoot aid more something users wants to do regularly.
 // Hence we allow that only via the environment variable for the time being.
@@ -201,6 +216,10 @@ func Merge(opts ...*Option) *Option {
 		}
 		if opt.EnableTools != nil {
 			merged.EnableTools = opt.EnableTools
+		}
+		// intentionally only programmatically
+		if opt.PathOverrides != nil {
+			merged.PathOverrides = opt.PathOverrides
 		}
 	}
 	// Set the default value if missing from mergeOpts

--- a/pkg/option/option_test.go
+++ b/pkg/option/option_test.go
@@ -118,6 +118,38 @@ func TestOption(t *testing.T) {
 				EnableTools: boolPtr(false),
 			},
 		},
+		{
+			name: "paths",
+			opts: []*option.Option{
+				option.WithPathOverrides(option.PathOverrides{
+					"/run": "/host-run",
+					"/var": "/host-var",
+				}),
+			},
+			merged: &option.Option{
+				PathOverrides: option.PathOverrides{
+					"/run": "/host-run",
+					"/var": "/host-var",
+				},
+			},
+		},
+		{
+			name: "chroot paths",
+			opts: []*option.Option{
+				option.WithChroot("/my/chroot/dir"),
+				option.WithPathOverrides(option.PathOverrides{
+					"/run": "/host-run",
+					"/var": "/host-var",
+				}),
+			},
+			merged: &option.Option{
+				Chroot: stringPtr("/my/chroot/dir"),
+				PathOverrides: option.PathOverrides{
+					"/run": "/host-run",
+					"/var": "/host-var",
+				},
+			},
+		},
 	}
 	for _, optTCase := range optTCases {
 		t.Run(optTCase.name, func(t *testing.T) {


### PR DESCRIPTION
Inside containers, when granting access to the host file systems, is
common practice to bind-mount specific host subtrees on nonstandard
locations, like `/sys` on `/host-sys` or `/proc` on `/host-proc`.

To better cover this use case, `ghw` allows to *programmatically* override
the initial component of filesystems subtrees, allowing to access `sysfs`
(or `procfs` or...) mounted on these non-standard locations.

Signed-off-by: Francesco Romani <fromani@redhat.com>