### PR TITLE
rename PCIAddress.Slot to PCIAddress.Device

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,8 +811,23 @@ The `ghw.PCIDevice` struct has the following fields:
 
 The `ghw.PCIAddress` (which is an alias for the `ghw.pci.address.Address`
 struct) contains the PCI address fields. It has a `ghw.PCIAddress.String()`
-method that returns the canonical Domain:Bus:Slot.Function ([D]BSF)
-representation of this Address
+method that returns the canonical Domain:Bus:Device.Function ([D]BDF)
+representation of this Address.
+
+The `ghw.PCIAddress` struct has the following fields:
+
+* `ghw.PCIAddress.Domain` is a string representing the PCI domain component of
+  the address.
+* `ghw.PCIAddress.Bus` is a string representing the PCI bus component of
+  the address.
+* `ghw.PCIAddress.Device` is a string representing the PCI device component of
+  the address.
+* `ghw.PCIAddress.Function` is a string representing the PCI function component of
+  the address.
+
+**NOTE**: Older versions (pre-`v0.9.0`) erroneously referred to the `Device`
+field as the `Slot` field. As noted by [@pearsonk](https://github.com/pearsonk)
+in [#220](https://github.com/jaypipes/ghw/issues/220), this was a misnomer.
 
 #### Finding a PCI device by PCI address
 

--- a/pkg/pci/address/address.go
+++ b/pkg/pci/address/address.go
@@ -17,23 +17,23 @@ var (
 	)
 )
 
+// Address contains the components of a PCI Address
 type Address struct {
 	Domain   string
 	Bus      string
-	Slot     string
+	Device   string
 	Function string
 }
 
-// String() returns the canonical [D]BSF representation of this Address
+// String() returns the canonical [D]BDF representation of this Address
 func (addr *Address) String() string {
-	return addr.Domain + ":" + addr.Bus + ":" + addr.Slot + "." + addr.Function
+	return addr.Domain + ":" + addr.Bus + ":" + addr.Device + "." + addr.Function
 }
 
-// Given a string address, returns a complete Address struct, filled in with
-// domain, bus, slot and function components. The address string may either
-// be in $BUS:$SLOT.$FUNCTION (BSF) format or it can be a full PCI address
-// that includes the 4-digit $DOMAIN information as well:
-// $DOMAIN:$BUS:$SLOT.$FUNCTION.
+// FromString returns an Address struct from an ddress string in either
+// $BUS:$DEVICE.$FUNCTION (BDF) format or it can be a full PCI address that
+// includes the 4-digit $DOMAIN information as well:
+// $DOMAIN:$BUS:$DEVICE.$FUNCTION.
 //
 // Returns "" if the address string wasn't a valid PCI address.
 func FromString(address string) *Address {
@@ -47,7 +47,7 @@ func FromString(address string) *Address {
 		return &Address{
 			Domain:   dom,
 			Bus:      matches[3],
-			Slot:     matches[4],
+			Device:   matches[4],
 			Function: matches[5],
 		}
 	}

--- a/pkg/pci/address/address_test.go
+++ b/pkg/pci/address/address_test.go
@@ -30,7 +30,7 @@ func TestPCIAddressFromString(t *testing.T) {
 			expected: &pciaddr.Address{
 				Domain:   "0000",
 				Bus:      "00",
-				Slot:     "00",
+				Device:   "00",
 				Function: "0",
 			},
 			skipStringTest: true,
@@ -40,7 +40,7 @@ func TestPCIAddressFromString(t *testing.T) {
 			expected: &pciaddr.Address{
 				Domain:   "0000",
 				Bus:      "00",
-				Slot:     "00",
+				Device:   "00",
 				Function: "0",
 			},
 		},
@@ -49,7 +49,7 @@ func TestPCIAddressFromString(t *testing.T) {
 			expected: &pciaddr.Address{
 				Domain:   "0000",
 				Bus:      "03",
-				Slot:     "00",
+				Device:   "00",
 				Function: "0",
 			},
 		},
@@ -58,7 +58,7 @@ func TestPCIAddressFromString(t *testing.T) {
 			expected: &pciaddr.Address{
 				Domain:   "0000",
 				Bus:      "03",
-				Slot:     "00",
+				Device:   "00",
 				Function: "a",
 			},
 		},

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -40,7 +40,7 @@ func getDeviceModaliasPath(ctx *context.Context, address string) string {
 	}
 	return filepath.Join(
 		paths.SysBusPciDevices,
-		pciAddr.Domain+":"+pciAddr.Bus+":"+pciAddr.Slot+"."+pciAddr.Function,
+		pciAddr.String(),
 		"modalias",
 	)
 }


### PR DESCRIPTION
As noted by @pearsonk in #220, the PCIAddress.Slot field was a bit of a
misnomer, since the more common representation of a PCIAddress is
Bus:Device.Function, not Bus:Slot.Function. Actual PCI slot information
may be retrieved from DMI, but what we were referring to was not the
actual PCI slot information but rather the PCI address device component.

Fixes Issue #220