### PR TITLE
block: honour EnableTools flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1345,6 +1345,11 @@ To prevent ghw from calling external tools, set the environs variable `GHW_DISAB
 or, programmatically, check the `WithDisableTools` function.
 The default behaviour of ghw is to call external tools when available.
 
+**WARNING**:
+- on all platforms, disabling external tools make ghw return less data.
+  Unless noted otherwise, there is _no fallback flow_ if external tools are disabled.
+- on darwin, disabling external tools disable block support entirely
+
 ## Developers
 
 Contributions to `ghw` are welcomed! Fork the repo on GitHub and submit a pull

--- a/pkg/block/block_darwin.go
+++ b/pkg/block/block_darwin.go
@@ -207,6 +207,10 @@ func storageControllerFromPlist(infoPlist *diskUtilInfoPlist) StorageController 
 }
 
 func (info *Info) load() error {
+	if !info.ctx.EnableTools {
+		return fmt.Errorf("EnableTools=false on darwin disables block support entirely.")
+	}
+
 	listPlist, err := getDiskUtilListPlist()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/pkg/block/block_linux.go
+++ b/pkg/block/block_linux.go
@@ -210,6 +210,10 @@ func diskPartitions(ctx *context.Context, paths *linuxpath.Paths, disk string) [
 }
 
 func diskPartUUID(ctx *context.Context, part string) string {
+	if !ctx.EnableTools {
+		ctx.Warn("EnableTools=false disables partition UUID detection.")
+		return ""
+	}
 	if !strings.HasPrefix(part, "/dev") {
 		part = "/dev/" + part
 	}


### PR DESCRIPTION
turns out we call external tools in the block subpackage, hence
we need to handle the EnableTools flag we added in commit
591a1bababf9ac1446a13e75ab3cae2df40b9619

Signed-off-by: Francesco Romani <fromani@redhat.com>