### PR TITLE
pci: check against corrupted modalias data

### DIFF
--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -20,6 +20,11 @@ import (
 	"github.com/jaypipes/ghw/pkg/util"
 )
 
+const (
+	// found running `wc` against real linux systems
+	modAliasExpectedLength = 54
+)
+
 func (i *Info) load() error {
 	db, err := pcidb.New(pcidb.WithChroot(i.ctx.Chroot))
 	if err != nil {
@@ -112,6 +117,13 @@ func parseModaliasFile(fp string) *deviceModaliasInfo {
 }
 
 func parseModaliasData(data string) *deviceModaliasInfo {
+	// extra sanity check to avoid segfaults. We actually expect
+	// the data to be exactly long `modAliasExpectedlength`, but
+	// we will happily ignore any extra data we don't know how to
+	// handle.
+	if len(data) < modAliasExpectedLength {
+		return nil
+	}
 	// The modalias file is an encoded file that looks like this:
 	//
 	// $ cat /sys/devices/pci0000\:00/0000\:00\:03.0/0000\:03\:00.0/modalias

--- a/pkg/pci/pci_linux_test.go
+++ b/pkg/pci/pci_linux_test.go
@@ -107,6 +107,28 @@ func TestPCIMarshalJSON(t *testing.T) {
 	}
 }
 
+// the sriov-device-plugin code has a test like this
+func TestPCIMalformedModalias(t *testing.T) {
+	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_PCI"); ok {
+		t.Skip("Skipping PCI tests.")
+	}
+	info, err := pci.New()
+	if err != nil {
+		t.Fatalf("Expected no error creating PciInfo, but got %v", err)
+	}
+
+	var dev *pci.Device
+	dev = info.ParseDevice("0000:00:01.0", "pci:junk")
+	if dev != nil {
+		t.Fatalf("Parsed succesfully junk data")
+	}
+
+	dev = info.ParseDevice("0000:00:01.0", "pci:v00008086d00005916sv000017AAsd0000224Bbc03sc00i00extrajunkextradataextraextra")
+	if dev == nil {
+		t.Fatalf("Failed to parse valid modalias with extra data")
+	}
+}
+
 func pciTestSetup(t *testing.T) *pci.Info {
 	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_PCI"); ok {
 		t.Skip("Skipping PCI tests.")


### PR DESCRIPTION
Add a sanity check against bad modalias data (corrupted/truncated).
Thsi should never happen in practice, but it's a trivial check,
prevents a nasty segfault and looks like the sriov device plugin
checks for this case (https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/blob/v3.3.2/cmd/sriovdp/manager_test.go#L322)
so let's add it.

Signed-off-by: Francesco Romani <fromani@redhat.com>