### PR TITLE
snapshot: actually copy the 'driver' entry

### DIFF
--- a/pkg/snapshot/clonetree_linux_test.go
+++ b/pkg/snapshot/clonetree_linux_test.go
@@ -90,9 +90,21 @@ func TestCloneSystemTree(t *testing.T) {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}
 
-	if len(missing) > 0 {
+	if len(missing) > 0 && areEntriesOnSysfs(missing) {
 		t.Fatalf("Expected content %#v missing into the cloned tree %q", missing, cloneRoot)
 	}
+}
+
+func areEntriesOnSysfs(sysfsEntries []string) bool {
+	// turns out some ISA bridges do not actually expose the driver entry. The reason is not clear.
+	// So let's check if we actually have the entry we were looking for on sysfs. If so, we
+	// actually failed to clone an entry, and we must fail the test. Otherwise we carry on.
+	for _, sysfsEntry := range sysfsEntries {
+		if _, err := os.Lstat(sysfsEntry); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func scanTree(root, prefix string, excludeList []string) ([]string, error) {

--- a/pkg/snapshot/clonetree_pci_linux.go
+++ b/pkg/snapshot/clonetree_pci_linux.go
@@ -62,6 +62,7 @@ func scanPCIDeviceRoot(root string) (fileSpecs []string, pciRoots []string) {
 	perDevEntries := []string{
 		"class",
 		"device",
+		"driver",
 		"irq",
 		"local_cpulist",
 		"modalias",


### PR DESCRIPTION
In commits 3500903a6e and f15e79ca87 we added support to copy
the "driver" entries from sysfs to a snapshot.
Due to a rebase glitch, we actually missed to merge the last
bit which enables the actual copy.

This bug is not evident until a new snapshot is created,
and this is why it wasn't noticed up until now.

Signed-off-by: Francesco Romani <fromani@redhat.com>