### PR TITLE
trivial: spell: fix misspells

### DIFF
--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -113,7 +113,7 @@ func EnvOrDefaultTools() bool {
 type Option struct {
 	// To facilitate querying of sysfs filesystems that are bind-mounted to a
 	// non-default root mountpoint, we allow users to set the GHW_CHROOT environ
-	// vairable to an alternate mountpoint. For instance, assume that the user of
+	// variable to an alternate mountpoint. For instance, assume that the user of
 	// ghw is a Golang binary being executed from an application container that has
 	// certain host filesystems bind-mounted into the container at /host. The user
 	// would ensure the GHW_CHROOT environ variable is set to "/host" and ghw will

--- a/pkg/option/option_test.go
+++ b/pkg/option/option_test.go
@@ -93,7 +93,7 @@ func TestOption(t *testing.T) {
 				option.WithChroot("/my/chroot/dir"),
 				option.WithSnapshot(option.SnapshotOptions{
 					Path:      "/my/snapshot/dir",
-					Root:      stringPtr("/my/overriden/chroot/dir"),
+					Root:      stringPtr("/my/overridden/chroot/dir"),
 					Exclusive: true,
 				}),
 			},
@@ -102,7 +102,7 @@ func TestOption(t *testing.T) {
 				Chroot: stringPtr("/my/chroot/dir"),
 				Snapshot: &option.SnapshotOptions{
 					Path:      "/my/snapshot/dir",
-					Root:      stringPtr("/my/overriden/chroot/dir"),
+					Root:      stringPtr("/my/overridden/chroot/dir"),
 					Exclusive: true,
 				},
 			},

--- a/pkg/pci/pci_linux_test.go
+++ b/pkg/pci/pci_linux_test.go
@@ -152,7 +152,7 @@ func TestPCIMalformedModalias(t *testing.T) {
 	var dev *pci.Device
 	dev = info.ParseDevice("0000:00:01.0", "pci:junk")
 	if dev != nil {
-		t.Fatalf("Parsed succesfully junk data")
+		t.Fatalf("Parsed successfully junk data")
 	}
 
 	dev = info.ParseDevice("0000:00:01.0", "pci:v00008086d00005916sv000017AAsd0000224Bbc03sc00i00extrajunkextradataextraextra")

--- a/pkg/snapshot/clonetree.go
+++ b/pkg/snapshot/clonetree.go
@@ -128,7 +128,7 @@ func copyFileTreeInto(paths []string, destDir string, opts *CopyFileOptions) err
 		if err != nil {
 			return err
 		}
-		// directories must be listed explicitely and created separately.
+		// directories must be listed explicitly and created separately.
 		// In the future we may want to expose this decision as hook point in
 		// CopyFileOptions, when clear use cases emerge.
 		destPath := filepath.Join(destDir, path)

--- a/pkg/snapshot/clonetree_linux.go
+++ b/pkg/snapshot/clonetree_linux.go
@@ -55,7 +55,7 @@ type filterFunc func(string) bool
 // symbolic link. We can filter out entries depending on the link target.
 // Each filter is a simple function which takes the entry name or the link
 // target and must return true if the entry should be collected, false
-// otherwise. Last, explicitely collect a list of attributes for each entry,
+// otherwise. Last, explicitly collect a list of attributes for each entry,
 // given as list of glob patterns as `subEntries`.
 // Return the final list of glob patterns to be collected.
 func cloneContentByClass(devClass string, subEntries []string, filterName filterFunc, filterLink filterFunc) []string {

--- a/pkg/snapshot/clonetree_linux_test.go
+++ b/pkg/snapshot/clonetree_linux_test.go
@@ -20,7 +20,7 @@ import (
 
 // NOTE: we intentionally use `os.RemoveAll` - not `snapshot.Cleanup` because we
 // want to make sure we never leak directories. `snapshot.Cleanup` is used and
-// tested explicitely in `unpack_test.go`.
+// tested explicitly in `unpack_test.go`.
 
 // nolint: gocyclo
 func TestCloneTree(t *testing.T) {

--- a/pkg/snapshot/pack_test.go
+++ b/pkg/snapshot/pack_test.go
@@ -16,7 +16,7 @@ import (
 
 // NOTE: we intentionally use `os.RemoveAll` - not `snapshot.Cleanup` because we
 // want to make sure we never leak directories. `snapshot.Cleanup` is used and
-// tested explicitely in `unpack_test.go`.
+// tested explicitly in `unpack_test.go`.
 
 // nolint: gocyclo
 func TestPackUnpack(t *testing.T) {


### PR DESCRIPTION
As reported by
```
find . -type f -iname "*.go" | xargs misspell
```

Signed-off-by: Francesco Romani <fromani@redhat.com>