### PR TITLE
Rename withAlterter to withAlerter

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -27,8 +27,8 @@ type WithOption = option.Option
 var (
 	WithChroot       = option.WithChroot
 	WithSnapshot     = option.WithSnapshot
-	WithAlerter     = option.WithAlerter
-	WithNullAlerter = option.WithNullAlerter
+	WithAlerter      = option.WithAlerter
+	WithNullAlerter  = option.WithNullAlerter
 	// match the existing environ variable to minimize surprises
 	WithDisableWarnings = option.WithNullAlerter
 	WithDisableTools    = option.WithDisableTools

--- a/alias.go
+++ b/alias.go
@@ -33,6 +33,10 @@ var (
 	WithDisableWarnings = option.WithNullAlerter
 	WithDisableTools    = option.WithDisableTools
 	WithPathOverrides   = option.WithPathOverrides
+	// Deprecated: WithAlterter is misspelled, Instead, use WithAlerter.
+	WithAlterter      = option.WithAlerter
+	// Deprecated: WithNullAlterter is misspelled. Instead, use WithNullAlerter.
+	WithNullAlterter  = option.WithNullAlerter
 )
 
 type SnapshotOptions = option.SnapshotOptions

--- a/alias.go
+++ b/alias.go
@@ -27,8 +27,8 @@ type WithOption = option.Option
 var (
 	WithChroot       = option.WithChroot
 	WithSnapshot     = option.WithSnapshot
-	WithAlterter     = option.WithAlerter
-	WithNullAlterter = option.WithNullAlerter
+	WithAlerter     = option.WithAlerter
+	WithNullAlerter = option.WithNullAlerter
 	// match the existing environ variable to minimize surprises
 	WithDisableWarnings = option.WithNullAlerter
 	WithDisableTools    = option.WithDisableTools


### PR DESCRIPTION
There was an misspelling in alias.go.
I propose to :

- rename `alterter` to `alerter`.
- add the old `withAlterter` (for compatibility reasons) but put them deprecated.