### PR TITLE
context: allow reuse in auxiliary packages

### DIFF
--- a/pkg/baseboard/baseboard.go
+++ b/pkg/baseboard/baseboard.go
@@ -65,6 +65,18 @@ func New(opts ...*option.Option) (*Info, error) {
 	return info, nil
 }
 
+// New returns a pointer to an Info struct containing information about the
+// host's baseboard, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	info := &Info{ctx: ctx}
+	if err := info.load(); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
 // simple private struct used to encapsulate baseboard information in a top-level
 // "baseboard" YAML/JSON map/object key
 type baseboardPrinter struct {

--- a/pkg/bios/bios.go
+++ b/pkg/bios/bios.go
@@ -58,6 +58,18 @@ func New(opts ...*option.Option) (*Info, error) {
 	return info, nil
 }
 
+// New returns a pointer to a Info struct containing information
+// about the host's BIOS, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	info := &Info{ctx: ctx}
+	if err := info.load(); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
 // simple private struct used to encapsulate BIOS information in a top-level
 // "bios" YAML/JSON map/object key
 type biosPrinter struct {

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -142,6 +142,18 @@ func New(opts ...*option.Option) (*Info, error) {
 	return info, nil
 }
 
+// New returns a pointer to an Info struct that describes the block storage
+// resources of the host system, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	info := &Info{ctx: ctx}
+	if err := info.load(); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
 func (i *Info) String() string {
 	tpbs := util.UNKNOWN
 	if i.TotalPhysicalBytes > 0 {

--- a/pkg/chassis/chassis.go
+++ b/pkg/chassis/chassis.go
@@ -102,6 +102,18 @@ func New(opts ...*option.Option) (*Info, error) {
 	return info, nil
 }
 
+// New returns a pointer to a Info struct containing information
+// about the host's chassis, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	info := &Info{ctx: ctx}
+	if err := info.load(); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
 // simple private struct used to encapsulate chassis information in a top-level
 // "chassis" YAML/JSON map/object key
 type chassisPrinter struct {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -56,7 +56,7 @@ func New(opts ...*option.Option) *Context {
 	return ctx
 }
 
-// FromEnv returns an Option that has been populated from the environs or
+// FromEnv returns a Context that has been populated from the environs or
 // default options values
 func FromEnv() *Context {
 	chrootVal := option.EnvOrDefaultChroot()

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -73,12 +73,13 @@ func FromEnv() *Context {
 	}
 }
 
-// Do wraps a Setup/Teardown pair around the given function
+// Do manages a context by wrapping a Setup/Teardown pair around the given function
 func (ctx *Context) Do(fn func() error) error {
 	err := ctx.Setup()
 	if err != nil {
 		return err
 	}
+	// TODO: any error returned by teardown is lost
 	defer ctx.Teardown()
 	return fn()
 }

--- a/pkg/cpu/cpu.go
+++ b/pkg/cpu/cpu.go
@@ -125,6 +125,18 @@ func New(opts ...*option.Option) (*Info, error) {
 	return info, nil
 }
 
+// New returns a pointer to an Info struct that contains information about the
+// CPUs on the host system, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	info := &Info{ctx: ctx}
+	if err := info.load(); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
 // String returns a short string indicating a summary of CPU information
 func (i *Info) String() string {
 	nps := "packages"

--- a/pkg/gpu/gpu.go
+++ b/pkg/gpu/gpu.go
@@ -62,6 +62,19 @@ func New(opts ...*option.Option) (*Info, error) {
 		return nil, err
 	}
 	return info, nil
+
+}
+
+// New returns a pointer to an Info struct that contains information about the
+// graphics cards on the host system, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	info := &Info{ctx: ctx}
+	if err := info.load(); err != nil {
+		return nil, err
+	}
+	return info, nil
 }
 
 func (i *Info) String() string {

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -34,10 +34,25 @@ type Info struct {
 	Modules            []*Module `json:"modules"`
 }
 
+// New returns a pointer to an Info struct containing information about the
+// host's memory.
 func New(opts ...*option.Option) (*Info, error) {
 	ctx := context.New(opts...)
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
+		return nil, err
+	}
+	return info, nil
+
+}
+
+// New returns a pointer to an Info struct containing information about the
+// host's memory, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	info := &Info{ctx: ctx}
+	if err := info.load(); err != nil {
 		return nil, err
 	}
 	return info, nil

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -55,6 +55,19 @@ func New(opts ...*option.Option) (*Info, error) {
 		return nil, err
 	}
 	return info, nil
+
+}
+
+// New returns a pointer to an Info struct that contains information about the
+// network interface controllers (NICs) on the host system, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	info := &Info{ctx: ctx}
+	if err := info.load(); err != nil {
+		return nil, err
+	}
+	return info, nil
 }
 
 func (i *Info) String() string {

--- a/pkg/product/product.go
+++ b/pkg/product/product.go
@@ -81,6 +81,18 @@ func New(opts ...*option.Option) (*Info, error) {
 	return info, nil
 }
 
+// New returns a pointer to a Info struct containing information
+// about the host's product, reusing a given context.
+// Use this function when you want to consume this package from another,
+// ensuring the two see a coherent set of resources.
+func NewWithContext(ctx *context.Context) (*Info, error) {
+	info := &Info{ctx: ctx}
+	if err := info.load(); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
 // simple private struct used to encapsulate product information in a top-level
 // "product" YAML/JSON map/object key
 type productPrinter struct {


### PR DESCRIPTION
The PR #236 fixes a snapshot directory leakage issue, but also highlight a context lifecycle/ownership issue.

In general in ghw each package creates its own context, including the cases on which a package is consumed by another, for example `topology` and `pci`.
However, in this case, it would make more sense to reuse the context from the parent package.

Before the introduction of the the transparent snapshot support (#202), the above mechanism worked,
because each context, each time, was consuming over and over again the same parameters (e.g. environment variables); besides some resource waste, this had no negative effect.

When introducing snapshots in the picture, repeatedly unpacking the same snapshot to consume the same data is much more wasteful. So it makes sense now to introduce explicitly the concept of dependent context.

To move forward and make the ownership more explicit, we add a new function `NewWithContext` in all the subpackages.
The function `NewWithContext` will assume the context it gets as argument is ready to be consumed and it will use as-is, attempting no setup or teardown in any circumstances.

The usage rules are pretty simple:
1. In your client code, you most likely just need to use `New` as usual.
2. When consuming a package from another (e.g. `topology` from `pci`),    always use the `NewWithContext` function to get a handle for  the auxiliary package, passing through the context from the top-level  package.
3. Within a `NewWithContext` function, all calls to other   `NewWithContext` functions should be made to preserve the properties.