### PR TITLE
allow passing in existing Context as an Option

### DIFF
--- a/pkg/gpu/gpu_linux.go
+++ b/pkg/gpu/gpu_linux.go
@@ -101,7 +101,7 @@ func (i *Info) load() error {
 // Loops through each GraphicsCard struct and attempts to fill the DeviceInfo
 // attribute with PCI device information
 func gpuFillPCIDevice(ctx *context.Context, cards []*GraphicsCard) {
-	pci, err := pci.NewWithContext(ctx)
+	pci, err := pci.New(context.WithContext(ctx))
 	if err != nil {
 		return
 	}
@@ -117,7 +117,7 @@ func gpuFillPCIDevice(ctx *context.Context, cards []*GraphicsCard) {
 // system is not a NUMA system, the Node field will be set to nil.
 func gpuFillNUMANodes(ctx *context.Context, cards []*GraphicsCard) {
 	paths := linuxpath.New(ctx)
-	topo, err := topology.NewWithContext(ctx)
+	topo, err := topology.New(context.WithContext(ctx))
 	if err != nil {
 		// Problem getting topology information so just set the graphics card's
 		// node to nil

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -133,6 +133,11 @@ type Option struct {
 	// PathOverrides optionally allows to override the default paths ghw uses internally
 	// to learn about the system resources.
 	PathOverrides PathOverrides
+
+	// Context may contain a pointer to a `Context` struct that is constructed
+	// during a call to the `context.WithContext` function. Only used internally.
+	// This is an interface to get around recursive package import issues.
+	Context interface{}
 }
 
 // SnapshotOptions contains options for handling of ghw snapshots
@@ -202,6 +207,8 @@ func WithPathOverrides(overrides PathOverrides) *Option {
 // a debug/troubleshoot aid more something users wants to do regularly.
 // Hence we allow that only via the environment variable for the time being.
 
+// Merge accepts one or more Options and merges them together, returning the
+// merged Option
 func Merge(opts ...*Option) *Option {
 	merged := &Option{}
 	for _, opt := range opts {
@@ -220,6 +227,9 @@ func Merge(opts ...*Option) *Option {
 		// intentionally only programmatically
 		if opt.PathOverrides != nil {
 			merged.PathOverrides = opt.PathOverrides
+		}
+		if opt.Context != nil {
+			merged.Context = opt.Context
 		}
 	}
 	// Set the default value if missing from mergeOpts

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -155,27 +155,29 @@ func (i *Info) String() string {
 // New returns a pointer to an Info struct that contains information about the
 // PCI devices on the host system
 func New(opts ...*option.Option) (*Info, error) {
-	return NewWithContext(context.New(opts...))
-}
-
-// NewWithContext returns a pointer to an Info struct that contains information about
-// the PCI devices on the host system. Use this function when you want to consume
-// the topology package from another package (e.g. gpu)
-func NewWithContext(ctx *context.Context) (*Info, error) {
+	merged := option.Merge(opts...)
+	ctx := context.New(merged)
 	// by default we don't report NUMA information;
 	// we will only if are sure we are running on NUMA architecture
-	arch := topology.ARCHITECTURE_SMP
-	topo, err := topology.NewWithContext(ctx)
-	if err == nil {
-		arch = topo.Architecture
-	} else {
-		ctx.Warn("error detecting system topology: %v", err)
-	}
 	info := &Info{
-		arch: arch,
+		arch: topology.ARCHITECTURE_SMP,
 		ctx:  ctx,
 	}
-	if err := ctx.Do(info.load); err != nil {
+	// we do this trick because we need to make sure ctx.Setup() gets
+	// a chance to run before any subordinate package is created reusing
+	// our context.
+	if err := ctx.Do(func() error {
+		topo, err := topology.New(context.WithContext(ctx))
+		if err == nil {
+			info.arch = topo.Architecture
+		} else {
+			ctx.Warn("error detecting system topology: %v", err)
+		}
+		if context.Exists(merged) {
+			return info.load()
+		}
+		return ctx.Do(info.load)
+	}); err != nil {
 		return nil, err
 	}
 	return info, nil

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -79,15 +79,16 @@ type Info struct {
 // New returns a pointer to an Info struct that contains information about the
 // NUMA topology on the host system
 func New(opts ...*option.Option) (*Info, error) {
-	return NewWithContext(context.New(opts...))
-}
-
-// NewWithContext returns a pointer to an Info struct that contains information about
-// the NUMA topology on the host system. Use this function when you want to consume
-// the topology package from another package (e.g. pci, gpu)
-func NewWithContext(ctx *context.Context) (*Info, error) {
+	merged := option.Merge(opts...)
+	ctx := context.New(merged)
 	info := &Info{ctx: ctx}
-	if err := ctx.Do(info.load); err != nil {
+	var err error
+	if context.Exists(merged) {
+		err = info.load()
+	} else {
+		err = ctx.Do(info.load)
+	}
+	if err != nil {
 		return nil, err
 	}
 	for _, node := range info.Nodes {


### PR DESCRIPTION
This patch simplifies some internal-only code that was added to ghw to
prevent re-creating Context objects inefficiently during snapshot
creation. We add a `context.WithContext` function that returns an
`option.Option` containing a pre-existing `Context` struct pointer,
embedded in the `Option` as a raw `interface{}` to get around package
recursive import issues.

Now, when packages like `pkg/gpu` or `pkg/pci` need to load the
`pkg/topology` package, they call
`topology.New(context.WithContext(ctx))`, passing in the
already-existing `Context` object. This preserves the original `New`
function signature without adding a new `NewWithContext` function
signature to all packages.

Alternative to #278

Signed-off-by: Jay Pipes <jaypipes@gmail.com>