### PR TITLE
Address #256

### DIFF
--- a/pkg/block/block_linux.go
+++ b/pkg/block/block_linux.go
@@ -179,7 +179,9 @@ func diskWWN(paths *linuxpath.Paths, disk string) string {
 // diskPartitions takes the name of a disk (note: *not* the path of the disk,
 // but just the name. In other words, "sda", not "/dev/sda" and "nvme0n1" not
 // "/dev/nvme0n1") and returns a slice of pointers to Partition structs
-// representing the partitions in that disk
+// representing the partitions in that disk. If a disk has no partitions,
+// it returns information on the disk instead, but the Partition UUID is set
+// to the empty string (since there isn't one.)
 func diskPartitions(ctx *context.Context, paths *linuxpath.Paths, disk string) []*Partition {
 	out := make([]*Partition, 0)
 	path := filepath.Join(paths.SysBlock, disk)

--- a/pkg/block/block_linux.go
+++ b/pkg/block/block_linux.go
@@ -206,6 +206,23 @@ func diskPartitions(ctx *context.Context, paths *linuxpath.Paths, disk string) [
 		}
 		out = append(out, p)
 	}
+	// this is a disk with no partitions on it.
+	// Consider the filesystem on the disk to be a partition.
+	if len(out) == 0 {
+		size := partitionSizeBytes(paths, disk, "")
+		mp, pt, ro := partitionInfo(paths, disk)
+		du := diskPartUUID(ctx, disk)
+		p := &Partition{
+			Name:       disk,
+			SizeBytes:  size,
+			MountPoint: mp,
+			Type:       pt,
+			IsReadOnly: ro,
+			UUID:       du,
+		}
+		out = append(out, p)
+
+	}
 	return out
 }
 

--- a/pkg/snapshot/clonetree.go
+++ b/pkg/snapshot/clonetree.go
@@ -8,6 +8,7 @@ package snapshot
 
 import (
 	"errors"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -149,7 +150,7 @@ func copyFileTreeInto(paths []string, destDir string, opts *CopyFileOptions) err
 			}
 		} else {
 			trace("    copying file: %q -> %q\n", path, destPath)
-			if err := copyPseudoFile(path, destPath); err != nil {
+			if err := copyPseudoFile(path, destPath); err != nil && !errors.Is(err, fs.ErrPermission) {
 				return err
 			}
 		}


### PR DESCRIPTION
If a disk has no partitions, common use cases for looping over partitions on the disk array created by Block.New() don't work as expected.
Now, underlying partition functions detect partitionless disks and treat a full-disk filesystem as a partition.

The Partition UUID is set to the empty string (since there isn't one), so this behavior can be detected.

This issue will resolve #256 