### PR TITLE
util: add helper to avoid long format strings

### DIFF
--- a/pkg/baseboard/baseboard.go
+++ b/pkg/baseboard/baseboard.go
@@ -7,8 +7,6 @@
 package baseboard
 
 import (
-	"fmt"
-
 	"github.com/jaypipes/ghw/pkg/context"
 	"github.com/jaypipes/ghw/pkg/marshal"
 	"github.com/jaypipes/ghw/pkg/option"
@@ -44,14 +42,12 @@ func (i *Info) String() string {
 		productStr = " product=" + i.Product
 	}
 
-	res := fmt.Sprintf(
-		"baseboard%s%s%s%s",
+	return "baseboard" + util.ConcatStrings(
 		vendorStr,
 		serialStr,
 		versionStr,
 		productStr,
 	)
-	return res
 }
 
 // New returns a pointer to an Info struct containing information about the

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -248,18 +248,20 @@ func (d *Disk) String() string {
 		removable = " removable=true"
 	}
 	return fmt.Sprintf(
-		"%s %s (%s) %s [@%s%s]%s%s%s%s%s",
+		"%s %s (%s) %s [@%s%s]%s",
 		d.Name,
 		d.DriveType.String(),
 		sizeStr,
 		d.StorageController.String(),
 		d.BusPath,
 		atNode,
-		vendor,
-		model,
-		serial,
-		wwn,
-		removable,
+		util.ConcatStrings(
+			vendor,
+			model,
+			serial,
+			wwn,
+			removable,
+		),
 	)
 }
 

--- a/pkg/chassis/chassis.go
+++ b/pkg/chassis/chassis.go
@@ -7,8 +7,6 @@
 package chassis
 
 import (
-	"fmt"
-
 	"github.com/jaypipes/ghw/pkg/context"
 	"github.com/jaypipes/ghw/pkg/marshal"
 	"github.com/jaypipes/ghw/pkg/option"
@@ -81,14 +79,12 @@ func (i *Info) String() string {
 		versionStr = " version=" + i.Version
 	}
 
-	res := fmt.Sprintf(
-		"chassis type=%s%s%s%s",
+	return "chassis type=" + util.ConcatStrings(
 		i.TypeDescription,
 		vendorStr,
 		serialStr,
 		versionStr,
 	)
-	return res
 }
 
 // New returns a pointer to a Info struct containing information

--- a/pkg/product/product.go
+++ b/pkg/product/product.go
@@ -7,8 +7,6 @@
 package product
 
 import (
-	"fmt"
-
 	"github.com/jaypipes/ghw/pkg/context"
 	"github.com/jaypipes/ghw/pkg/marshal"
 	"github.com/jaypipes/ghw/pkg/option"
@@ -57,8 +55,7 @@ func (i *Info) String() string {
 		versionStr = " version=" + i.Version
 	}
 
-	res := fmt.Sprintf(
-		"product%s%s%s%s%s%s%s",
+	return "product" + util.ConcatStrings(
 		familyStr,
 		nameStr,
 		vendorStr,
@@ -67,7 +64,6 @@ func (i *Info) String() string {
 		skuStr,
 		versionStr,
 	)
-	return res
 }
 
 // New returns a pointer to a Info struct containing information

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -50,3 +50,10 @@ func SafeIntFromFile(ctx *context.Context, path string) int {
 	}
 	return res
 }
+
+// ConcatStrings concatenate strings in a larger one. This function
+// addresses a very specific ghw use case. For a more general approach,
+// just use strings.Join()
+func ConcatStrings(items ...string) string {
+	return strings.Join(items, "")
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,57 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package util_test
+
+import (
+	"testing"
+
+	"github.com/jaypipes/ghw/pkg/util"
+)
+
+// nolint: gocyclo
+func TestConcatStrings(t *testing.T) {
+	type testCase struct {
+		items    []string
+		expected string
+	}
+
+	testCases := []testCase{
+		{
+			items:    []string{},
+			expected: "",
+		},
+		{
+			items:    []string{"simple"},
+			expected: "simple",
+		},
+		{
+			items: []string{
+				"foo",
+				"bar",
+				"baz",
+			},
+			expected: "foobarbaz",
+		},
+		{
+			items: []string{
+				"foo ",
+				" bar ",
+				" baz",
+			},
+			expected: "foo  bar  baz",
+		},
+	}
+
+	for _, tCase := range testCases {
+		t.Run(tCase.expected, func(t *testing.T) {
+			got := util.ConcatStrings(tCase.items...)
+			if got != tCase.expected {
+				t.Errorf("expected %q got %q", tCase.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A relatively common pattern in the ghw codebase
is concatenating quite a lot of strings inside
a format string. This leads to a pattern like '%s%s%s%s%s'
which are hard to read and to debug.

Ad a simple helper to concatenate strings to simplify the
format strings.

This may be the definitive solution here, but
it should improve the maintenability and readability,
and it's very cheap to implement and maintain.

Signed-off-by: Francesco Romani <fromani@redhat.com>