### PR TITLE
Add aarch64 and RISCV64 support

### DIFF
--- a/cmd/ghwc/commands/cpu.go
+++ b/cmd/ghwc/commands/cpu.go
@@ -43,12 +43,12 @@ func showCPU(cmd *cobra.Command, args []string) error {
 				// pretty-print the (large) block of capability strings into rows
 				// of 6 capability strings
 				rows := int(math.Ceil(float64(len(proc.Capabilities)) / float64(6)))
-				for row := 1; row < rows; row = row + 1 {
-					rowStart := (row * 6) - 1
+				for row := 0; row < rows; row = row + 1 {
+					rowStart := (row * 6)
 					rowEnd := int(math.Min(float64(rowStart+6), float64(len(proc.Capabilities))))
 					rowElems := proc.Capabilities[rowStart:rowEnd]
 					capStr := strings.Join(rowElems, " ")
-					if row == 1 {
+					if row == 0 {
 						fmt.Printf("  capabilities: [%s\n", capStr)
 					} else if rowEnd < len(proc.Capabilities) {
 						fmt.Printf("                 %s\n", capStr)

--- a/pkg/linuxpath/path_linux.go
+++ b/pkg/linuxpath/path_linux.go
@@ -64,6 +64,7 @@ type Paths struct {
 	SysBlock               string
 	SysDevicesSystemNode   string
 	SysDevicesSystemMemory string
+	SysDevicesSystemCPU    string
 	SysBusPciDevices       string
 	SysClassDRM            string
 	SysClassDMI            string
@@ -84,6 +85,7 @@ func New(ctx *context.Context) *Paths {
 		SysBlock:               filepath.Join(ctx.Chroot, roots.Sys, "block"),
 		SysDevicesSystemNode:   filepath.Join(ctx.Chroot, roots.Sys, "devices", "system", "node"),
 		SysDevicesSystemMemory: filepath.Join(ctx.Chroot, roots.Sys, "devices", "system", "memory"),
+		SysDevicesSystemCPU:    filepath.Join(ctx.Chroot, roots.Sys, "devices", "system", "cpu"),
 		SysBusPciDevices:       filepath.Join(ctx.Chroot, roots.Sys, "bus", "pci", "devices"),
 		SysClassDRM:            filepath.Join(ctx.Chroot, roots.Sys, "class", "drm"),
 		SysClassDMI:            filepath.Join(ctx.Chroot, roots.Sys, "class", "dmi"),


### PR DESCRIPTION
Depend on sysfs instead of /proc/cpuinfo, for content of this file varies
across CPU architectures, and doesn't offer unified info tag.

Solves issue #199 .

Signed-off-by: Xingyou Chen <rockrush@rockwork.org>