### PR TITLE
Fix #306

### DIFF
--- a/pkg/snapshot/clonetree.go
+++ b/pkg/snapshot/clonetree.go
@@ -8,6 +8,7 @@ package snapshot
 
 import (
 	"errors"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -149,7 +150,7 @@ func copyFileTreeInto(paths []string, destDir string, opts *CopyFileOptions) err
 			}
 		} else {
 			trace("    copying file: %q -> %q\n", path, destPath)
-			if err := copyPseudoFile(path, destPath); err != nil {
+			if err := copyPseudoFile(path, destPath); err != nil && !errors.Is(err, fs.ErrPermission) {
 				return err
 			}
 		}

--- a/pkg/snapshot/clonetree.go
+++ b/pkg/snapshot/clonetree.go
@@ -8,7 +8,6 @@ package snapshot
 
 import (
 	"errors"
-	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -150,7 +149,7 @@ func copyFileTreeInto(paths []string, destDir string, opts *CopyFileOptions) err
 			}
 		} else {
 			trace("    copying file: %q -> %q\n", path, destPath)
-			if err := copyPseudoFile(path, destPath); err != nil && !errors.Is(err, fs.ErrPermission) {
+			if err := copyPseudoFile(path, destPath); err != nil && !errors.Is(err, os.ErrPermission) {
 				return err
 			}
 		}


### PR DESCRIPTION
Please see #306 
The HEAD of main already fails existing test cases, and this patch causes those test cases to pass.

```
tai@juggernaut:~/code/foss/ghw/pkg/snapshot[jaypipes ?]$ go test
--- FAIL: TestCloneSystemTree (0.07s)
    clonetree_linux_test.go:85: Expected nil err, but got open /sys/devices/system/node/node0/hugepages/hugepages-1048576kB/demote: permission denied
FAIL
exit status 1
FAIL    github.com/jaypipes/ghw/pkg/snapshot    0.076s
tai@juggernaut:~/code/foss/ghw/pkg/snapshot[jaypipes ?]$ git co hugepages-demote
Switched to branch 'hugepages-demote'
Your branch is up to date with 'origin/hugepages-demote'.
tai@juggernaut:~/code/foss/ghw/pkg/snapshot[hugepages-demote ?]$ go test
PASS
ok      github.com/jaypipes/ghw/pkg/snapshot    0.100s
tai@juggernaut:~/code/foss/ghw/pkg/snapshot[hugepages-demote ?]$
```