### PR TITLE
Revert "Detect iSCSI devices"

### DIFF
--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -29,7 +29,6 @@ const (
 	DRIVE_TYPE_FDD               // Floppy disk drive
 	DRIVE_TYPE_ODD               // Optical disk drive
 	DRIVE_TYPE_SSD               // Solid-state drive
-	DRIVE_TYPE_ISCSI             // iSCSI drive
 )
 
 var (
@@ -39,7 +38,6 @@ var (
 		DRIVE_TYPE_FDD:     "FDD",
 		DRIVE_TYPE_ODD:     "ODD",
 		DRIVE_TYPE_SSD:     "SSD",
-		DRIVE_TYPE_ISCSI:   "ISCSI",
 	}
 
 	// NOTE(fromani): the keys are all lowercase and do not match
@@ -53,7 +51,6 @@ var (
 		"fdd":     DRIVE_TYPE_FDD,
 		"odd":     DRIVE_TYPE_ODD,
 		"ssd":     DRIVE_TYPE_SSD,
-		"iscsi":   DRIVE_TYPE_ISCSI,
 	}
 )
 

--- a/pkg/block/block_linux.go
+++ b/pkg/block/block_linux.go
@@ -322,9 +322,6 @@ func disks(ctx *context.Context, paths *linuxpath.Paths) []*Disk {
 		size := diskSizeBytes(paths, dname)
 		pbs := diskPhysicalBlockSizeBytes(paths, dname)
 		busPath := diskBusPath(paths, dname)
-		if strings.Contains(busPath, "-iscsi-") {
-			driveType = DRIVE_TYPE_ISCSI
-		}
 		node := diskNUMANodeID(paths, dname)
 		vendor := diskVendor(paths, dname)
 		model := diskModel(paths, dname)

--- a/pkg/block/block_linux_test.go
+++ b/pkg/block/block_linux_test.go
@@ -11,7 +11,6 @@ package block
 
 import (
 	"fmt"
-	"github.com/jaypipes/ghw/pkg/util"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -20,6 +19,7 @@ import (
 
 	"github.com/jaypipes/ghw/pkg/context"
 	"github.com/jaypipes/ghw/pkg/linuxpath"
+	"github.com/jaypipes/ghw/pkg/util"
 )
 
 func TestParseMountEntry(t *testing.T) {
@@ -184,40 +184,6 @@ func TestDiskTypes(t *testing.T) {
 				test.line, test.expected.storageController, gotStorageController,
 			)
 		}
-	}
-}
-
-func TestISCSI(t *testing.T) {
-	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_BLOCK"); ok {
-		t.Skip("Skipping block tests.")
-	}
-
-	baseDir, _ := ioutil.TempDir("", "test")
-	defer os.RemoveAll(baseDir)
-	ctx := context.New()
-	ctx.Chroot = baseDir
-	paths := linuxpath.New(ctx)
-
-	_ = os.MkdirAll(paths.SysBlock, 0755)
-	_ = os.MkdirAll(paths.RunUdevData, 0755)
-
-	// Emulate an iSCSI device
-	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda"), 0755)
-	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, "sda", "size"), []byte("500118192\n"), 0644)
-	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, "sda", "dev"), []byte("259:0\n"), 0644)
-	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda", "queue"), 0755)
-	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, "sda", "queue", "rotational"), []byte("0\n"), 0644)
-	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, "sda", "queue", "physical_block_size"), []byte("512\n"), 0644)
-	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda", "device"), 0755)
-	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, "sda", "device", "vendor"), []byte("LIO-ORG\n"), 0644)
-	udevData := "E:ID_MODEL=disk0\nE:ID_SERIAL=6001405961d8b6f55cf48beb0de296b2\n" +
-		"E:ID_PATH=ip-192.168.130.10:3260-iscsi-iqn.2022-01.com.redhat.foo:disk0-lun-0\n" +
-		"E:ID_WWN=0x6001405961d8b6f55cf48beb0de296b2\n"
-	_ = ioutil.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(udevData), 0644)
-
-	diskInventory := disks(ctx, paths)
-	if diskInventory[0].DriveType != DRIVE_TYPE_ISCSI {
-		t.Fatalf("Got drive type %s, but expected ISCSI", diskInventory[0].DriveType)
 	}
 }
 


### PR DESCRIPTION
This reverts commit 3171315ec3b21f49a6d7f61a02c6a6edb46cf843.

We can discuss whether there are merits to `ghw` determining whether a
SCSI storage controller communicates via a local storage bus or via
TCP/IP (iSCSI), but iSCSI is not a new drive type so I'm reverting this
particular commit.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>