### PR TITLE
Fixes #267 dont compare pointer addresses

### DIFF
--- a/pkg/block/block_windows.go
+++ b/pkg/block/block_windows.go
@@ -115,7 +115,7 @@ func (i *Info) load() error {
 		}
 		for _, diskpartition := range win32DiskPartitionDescriptions {
 			// Finding disk partition linked to current disk drive
-			if diskdrive.Index == diskpartition.DiskIndex {
+			if diskdrive.Index != nil && diskpartition.DiskIndex != nil && *diskdrive.Index == *diskpartition.DiskIndex {
 				disk.PhysicalBlockSizeBytes = *diskpartition.BlockSize
 				// Finding logical partition linked to current disk partition
 				for _, logicaldisk := range win32LogicalDiskDescriptions {


### PR DESCRIPTION
Windows partitions will not populate correctly because the disk index on drive and partition are being compared using the pointer address, not the value.