### PR TITLE
Fix wrong fs label as partition label

### DIFF
--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -183,6 +183,7 @@ type Partition struct {
 	Type       string `json:"type"`
 	IsReadOnly bool   `json:"read_only"`
 	UUID       string `json:"uuid"` // This would be volume UUID on macOS, PartUUID on linux, empty on Windows
+	FSLabel    string
 }
 
 // Info describes all disk drives and partitions in the host system.

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -175,15 +175,15 @@ type Disk struct {
 
 // Partition describes a logical division of a Disk.
 type Partition struct {
-	Disk       *Disk  `json:"-"`
-	Name       string `json:"name"`
-	Label      string `json:"label"`
-	MountPoint string `json:"mount_point"`
-	SizeBytes  uint64 `json:"size_bytes"`
-	Type       string `json:"type"`
-	IsReadOnly bool   `json:"read_only"`
-	UUID       string `json:"uuid"` // This would be volume UUID on macOS, PartUUID on linux, empty on Windows
-	FSLabel    string
+	Disk            *Disk  `json:"-"`
+	Name            string `json:"name"`
+	Label           string `json:"label"`
+	MountPoint      string `json:"mount_point"`
+	SizeBytes       uint64 `json:"size_bytes"`
+	Type            string `json:"type"`
+	IsReadOnly      bool   `json:"read_only"`
+	UUID            string `json:"uuid"` // This would be volume UUID on macOS, PartUUID on linux, empty on Windows
+	FilesystemLabel string `json:"filesystem_label"`
 }
 
 // Info describes all disk drives and partitions in the host system.

--- a/pkg/block/block_linux.go
+++ b/pkg/block/block_linux.go
@@ -216,14 +216,14 @@ func diskPartitions(ctx *context.Context, paths *linuxpath.Paths, disk string) [
 		}
 		fsLabel := diskFSLabel(paths, disk, fname)
 		p := &Partition{
-			Name:       fname,
-			SizeBytes:  size,
-			MountPoint: mp,
-			Type:       pt,
-			IsReadOnly: ro,
-			UUID:       du,
-			Label:      label,
-			FSLabel:    fsLabel,
+			Name:            fname,
+			SizeBytes:       size,
+			MountPoint:      mp,
+			Type:            pt,
+			IsReadOnly:      ro,
+			UUID:            du,
+			Label:           label,
+			FilesystemLabel: fsLabel,
 		}
 		out = append(out, p)
 	}

--- a/pkg/block/block_linux.go
+++ b/pkg/block/block_linux.go
@@ -214,6 +214,7 @@ func diskPartitions(ctx *context.Context, paths *linuxpath.Paths, disk string) [
 		if pt == "" {
 			pt = diskPartTypeUdev(paths, disk, fname)
 		}
+		fsLabel := diskFSLabel(paths, disk, fname)
 		p := &Partition{
 			Name:       fname,
 			SizeBytes:  size,
@@ -222,10 +223,23 @@ func diskPartitions(ctx *context.Context, paths *linuxpath.Paths, disk string) [
 			IsReadOnly: ro,
 			UUID:       du,
 			Label:      label,
+			FSLabel:    fsLabel,
 		}
 		out = append(out, p)
 	}
 	return out
+}
+
+func diskFSLabel(paths *linuxpath.Paths, disk string, partition string) string {
+	info, err := udevInfoPartition(paths, disk, partition)
+	if err != nil {
+		return util.UNKNOWN
+	}
+
+	if label, ok := info["ID_FS_LABEL"]; ok {
+		return label
+	}
+	return util.UNKNOWN
 }
 
 func diskPartLabel(paths *linuxpath.Paths, disk string, partition string) string {
@@ -234,7 +248,7 @@ func diskPartLabel(paths *linuxpath.Paths, disk string, partition string) string
 		return util.UNKNOWN
 	}
 
-	if label, ok := info["ID_FS_LABEL"]; ok {
+	if label, ok := info["ID_PART_ENTRY_NAME"]; ok {
 		return label
 	}
 	return util.UNKNOWN

--- a/pkg/block/block_linux_test.go
+++ b/pkg/block/block_linux_test.go
@@ -213,6 +213,37 @@ func TestDiskPartLabel(t *testing.T) {
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda"), 0755)
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda", "sda1"), 0755)
 	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, "sda", "sda1", "dev"), []byte("259:0\n"), 0644)
+	_ = ioutil.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(fmt.Sprintf("E:ID_PART_ENTRY_NAME=%s\n", partLabel)), 0644)
+	label := diskPartLabel(paths, "sda", "sda1")
+	if label != partLabel {
+		t.Fatalf("Got label %s but expected %s", label, partLabel)
+	}
+
+	// Check empty label if not found
+	label = diskPartLabel(paths, "sda", "sda2")
+	if label != util.UNKNOWN {
+		t.Fatalf("Got label %s, but expected %s label", label, util.UNKNOWN)
+	}
+}
+
+func TestDiskFSLabel(t *testing.T) {
+	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_BLOCK"); ok {
+		t.Skip("Skipping block tests.")
+	}
+	baseDir, _ := ioutil.TempDir("", "test")
+	defer os.RemoveAll(baseDir)
+	ctx := context.New()
+	ctx.Chroot = baseDir
+	paths := linuxpath.New(ctx)
+	partLabel := "TEST_LABEL_GHW"
+
+	_ = os.MkdirAll(paths.SysBlock, 0755)
+	_ = os.MkdirAll(paths.RunUdevData, 0755)
+
+	// Emulate a disk with one partition with label TEST_LABEL_GHW
+	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda"), 0755)
+	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda", "sda1"), 0755)
+	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, "sda", "sda1", "dev"), []byte("259:0\n"), 0644)
 	_ = ioutil.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(fmt.Sprintf("E:ID_FS_LABEL=%s\n", partLabel)), 0644)
 	label := diskPartLabel(paths, "sda", "sda1")
 	if label != partLabel {

--- a/pkg/block/block_linux_test.go
+++ b/pkg/block/block_linux_test.go
@@ -235,7 +235,7 @@ func TestDiskFSLabel(t *testing.T) {
 	ctx := context.New()
 	ctx.Chroot = baseDir
 	paths := linuxpath.New(ctx)
-	partLabel := "TEST_LABEL_GHW"
+	fsLabel := "TEST_LABEL_GHW"
 
 	_ = os.MkdirAll(paths.SysBlock, 0755)
 	_ = os.MkdirAll(paths.RunUdevData, 0755)
@@ -244,14 +244,14 @@ func TestDiskFSLabel(t *testing.T) {
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda"), 0755)
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda", "sda1"), 0755)
 	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, "sda", "sda1", "dev"), []byte("259:0\n"), 0644)
-	_ = ioutil.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(fmt.Sprintf("E:ID_FS_LABEL=%s\n", partLabel)), 0644)
-	label := diskPartLabel(paths, "sda", "sda1")
-	if label != partLabel {
-		t.Fatalf("Got label %s but expected %s", label, partLabel)
+	_ = ioutil.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(fmt.Sprintf("E:ID_FS_LABEL=%s\n", fsLabel)), 0644)
+	label := diskFSLabel(paths, "sda", "sda1")
+	if label != fsLabel {
+		t.Fatalf("Got label %s but expected %s", label, fsLabel)
 	}
 
 	// Check empty label if not found
-	label = diskPartLabel(paths, "sda", "sda2")
+	label = diskFSLabel(paths, "sda", "sda2")
 	if label != util.UNKNOWN {
 		t.Fatalf("Got label %s, but expected %s label", label, util.UNKNOWN)
 	}


### PR DESCRIPTION
The label entry in the Partition struct should correspond to the
partition label, but we were getting the FS label instead.

This patch fixes that by getting the actual partition label for the
label value and adding an extra field on the Partition struct to add the
fs label, so they are separated and clear on which is which.

Signed-off-by: Itxaka <igarcia@suse.com>