### PR TITLE
Use udev for partition UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ Each `ghw.Partition` struct contains these fields:
   the partition. This will be `nil` if the `ghw.Partition` struct was returned
   by the `ghw.DiskPartitions()` library function.
 * `ghw.Partition.UUID` is a string containing the partition UUID on Linux, the
-  partition UUID on MacOS and nothing on Windows.On Linux
+  partition UUID on MacOS and nothing on Windows. On Linux
   systems, this is derived from the `ID_PART_ENTRY_UUID` udev entry for the
   partition.
 

--- a/README.md
+++ b/README.md
@@ -546,8 +546,10 @@ Each `ghw.Partition` struct contains these fields:
 * `ghw.Partition.Disk` is a pointer to the `ghw.Disk` object associated with
   the partition. This will be `nil` if the `ghw.Partition` struct was returned
   by the `ghw.DiskPartitions()` library function.
-* `ghw.Partition.UUID` is a string containing the volume UUID on Linux, the
-  partition UUID on MacOS and nothing on Windows.
+* `ghw.Partition.UUID` is a string containing the partition UUID on Linux, the
+  partition UUID on MacOS and nothing on Windows.On Linux
+  systems, this is derived from the `ID_PART_ENTRY_UUID` udev entry for the
+  partition.
 
 ```go
 package main

--- a/pkg/block/block_linux.go
+++ b/pkg/block/block_linux.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -209,7 +208,7 @@ func diskPartitions(ctx *context.Context, paths *linuxpath.Paths, disk string) [
 		}
 		size := partitionSizeBytes(paths, disk, fname)
 		mp, pt, ro := partitionInfo(paths, fname)
-		du := diskPartUUID(ctx, fname)
+		du := diskPartUUID(paths, disk, fname)
 		label := diskPartLabel(paths, disk, fname)
 		if pt == "" {
 			pt = diskPartTypeUdev(paths, disk, fname)
@@ -268,37 +267,16 @@ func diskPartTypeUdev(paths *linuxpath.Paths, disk string, partition string) str
 	return util.UNKNOWN
 }
 
-func diskPartUUID(ctx *context.Context, part string) string {
-	if !ctx.EnableTools {
-		ctx.Warn("EnableTools=false disables partition UUID detection.")
-		return ""
-	}
-	if !strings.HasPrefix(part, "/dev") {
-		part = "/dev/" + part
-	}
-	args := []string{
-		"blkid",
-		"-s",
-		"PARTUUID",
-		part,
-	}
-	out, err := exec.Command(args[0], args[1:]...).Output()
+func diskPartUUID(paths *linuxpath.Paths, disk string, partition string) string {
+	info, err := udevInfoPartition(paths, disk, partition)
 	if err != nil {
-		ctx.Warn("failed to read disk partuuid of %s : %s\n", part, err.Error())
-		return ""
+		return util.UNKNOWN
 	}
 
-	if len(out) == 0 {
-		return ""
+	if pType, ok := info["ID_PART_ENTRY_UUID"]; ok {
+		return pType
 	}
-
-	parts := strings.Split(string(out), "PARTUUID=")
-	if len(parts) != 2 {
-		ctx.Warn("failed to parse the partuuid of %s\n", part)
-		return ""
-	}
-
-	return strings.ReplaceAll(strings.TrimSpace(parts[1]), `"`, "")
+	return util.UNKNOWN
 }
 
 func diskIsRemovable(paths *linuxpath.Paths, disk string) bool {


### PR DESCRIPTION
This allows us to drop the use of blkid completely and on linux fully
report all the data rootless.

Closes #319 

Signed-off-by: Itxaka <igarcia@suse.com>