### PR TITLE
inaccurate disk size on windows

### DIFF
--- a/pkg/block/block_windows.go
+++ b/pkg/block/block_windows.go
@@ -6,7 +6,10 @@
 package block
 
 import (
+	"os"
 	"strings"
+	"syscall"
+	"unsafe"
 
 	"github.com/StackExchange/wmi"
 
@@ -157,6 +160,26 @@ func getDiskDrives() ([]win32DiskDrive, error) {
 	var win3232DiskDriveDescriptions []win32DiskDrive
 	if err := wmi.Query(wqlDiskDrive, &win3232DiskDriveDescriptions); err != nil {
 		return nil, err
+	}
+	for _, disk := range win3232DiskDriveDescriptions {
+		if disk.DeviceID == nil {
+			continue
+		}
+		volume, err := os.OpenFile(*disk.DeviceID, os.O_RDWR, 0)
+		if err != nil {
+			continue
+		}
+		// Get the volume's underlying partition size in NTFS clusters.
+		var (
+			partitionSize int64
+			bytes         uint32
+		)
+		const _IOCTL_DISK_GET_LENGTH_INFO = 0x0007405C
+		err = syscall.DeviceIoControl(syscall.Handle(volume.Fd()), _IOCTL_DISK_GET_LENGTH_INFO, nil, 0, (*byte)(unsafe.Pointer(&partitionSize)), 8, &bytes, nil)
+		volume.Close()
+		if err == nil {
+			*disk.Size = uint64(partitionSize)
+		}
 	}
 	return win3232DiskDriveDescriptions, nil
 }


### PR DESCRIPTION
wmi report inaccurate disk size, refer : https://stackoverflow.com/questions/9901792/wmi-win32-diskdrive-to-get-total-sector-on-the-physical-disk-drive  
replace Win32_DiskDrive with DeviceIOControl.