### PR TITLE
Fix class name lookups

### DIFF
--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -160,9 +160,9 @@ func parseModaliasData(data string) *deviceModaliasInfo {
 	productID := strings.ToLower(data[18:22])
 	subvendorID := strings.ToLower(data[28:32])
 	subproductID := strings.ToLower(data[38:42])
-	classID := data[44:46]
-	subclassID := data[48:50]
-	progIfaceID := data[51:53]
+	classID := strings.ToLower(data[44:46])
+	subclassID := strings.ToLower(data[48:50])
+	progIfaceID := strings.ToLower(data[51:53])
 	return &deviceModaliasInfo{
 		vendorID:     vendorID,
 		productID:    productID,

--- a/pkg/pci/pci_linux_test.go
+++ b/pkg/pci/pci_linux_test.go
@@ -133,7 +133,10 @@ func TestPCIMarshalJSON(t *testing.T) {
 		t.Fatalf("Expected no error creating PciInfo, but got %v", err)
 	}
 
-	dev := info.ParseDevice("0000:3c:00.0", "pci:v0000144Dd0000A804sv0000144Dsd0000A801bc01sc08i02")
+	dev := info.ParseDevice("0000:3c:00.0", "pci:v0000144Dd0000A804sv0000144Dsd0000A801bc01sc08i02\n")
+	if dev == nil {
+		t.Fatalf("Failed to parse valid modalias")
+	}
 	s := marshal.SafeJSON(context.FromEnv(), dev, true)
 	if s == "" {
 		t.Fatalf("Error marshalling device: %v", dev)

--- a/pkg/pci/pci_linux_test.go
+++ b/pkg/pci/pci_linux_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jaypipes/ghw/pkg/marshal"
 	"github.com/jaypipes/ghw/pkg/option"
 	"github.com/jaypipes/ghw/pkg/pci"
+	"github.com/jaypipes/ghw/pkg/util"
 
 	"github.com/jaypipes/ghw/testdata"
 )
@@ -228,7 +229,7 @@ func TestPCIModaliasWithUpperCaseClassID(t *testing.T) {
 	if dev == nil {
 		t.Fatalf("Failed to parse valid modalias")
 	}
-	if dev.Class.Name == "unknown" {
+	if dev.Class.Name == util.UNKNOWN {
 		t.Fatalf("Failed to lookup class name")
 	}
 }

--- a/pkg/pci/pci_linux_test.go
+++ b/pkg/pci/pci_linux_test.go
@@ -214,3 +214,21 @@ func TestPCIMarshalUnmarshal(t *testing.T) {
 		t.Fatalf("Expected no error unmarshaling pci.Info, but got %v", err)
 	}
 }
+
+func TestPCIModaliasWithUpperCaseClassID(t *testing.T) {
+	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_PCI"); ok {
+		t.Skip("Skipping PCI tests.")
+	}
+	info, err := pci.New()
+	if err != nil {
+		t.Fatalf("Expected no error creating PciInfo, but got %v", err)
+	}
+
+	dev := info.ParseDevice("0000:00:1f.4", "pci:v00008086d00009D23sv00001028sd000007EAbc0Csc05i00\n")
+	if dev == nil {
+		t.Fatalf("Failed to parse valid modalias")
+	}
+	if dev.Class.Name == "unknown" {
+		t.Fatalf("Failed to lookup class name")
+	}
+}


### PR DESCRIPTION
All class IDs in https://pci-ids.ucw.cz/v2.2/pci.ids are stored as lowercase hex. The `modalias` file is used to extract the class IDs for a given device. The class IDs in that file can be uppercase HEX, e.g. pci:v00008086d00009D23sv00001028sd000007EAbc**0C**sc05i00. PCI DB lookup fails in that case.

**- What I did**

* Made sure that class-related IDs (class, subclass, programming interface) are parsed as lowercase hex.

**- How I did it**

* Using the `strings.ToLower` function on raw data
