### PR TITLE
deps: declare go 1.18 in go.mod

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
 
     - name: format
       run: ./hack/check-format.sh
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.15', '1.16', '1.17' ]
+        go: [ '1.18', '1.19']
     steps:
     - uses: actions/checkout@v2
 
@@ -63,7 +63,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        go: [ '1.16' ]
+        go: [ '1.18' ]
     steps:
     - uses: actions/checkout@v2
 
@@ -91,7 +91,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        go: [ '1.16' ]
+        go: [ '1.18' ]
     steps:
     - uses: actions/checkout@v2
 

--- a/go.mod
+++ b/go.mod
@@ -1,20 +1,23 @@
 module github.com/jaypipes/ghw
 
-go 1.15
+go 1.18
 
 require (
 	github.com/StackExchange/wmi v1.2.1
 	github.com/ghodss/yaml v1.0.0
-	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jaypipes/pcidb v1.0.0
-	github.com/kr/pretty v0.1.0 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.3
+	howett.net/plist v1.0.0
+)
+
+require (
+	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.2 // indirect
 	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	howett.net/plist v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -15,7 +15,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
This updates the go.{mod,sum} files to declare a version of Go that supports module graph pruning. The change allows consuming projects to avoid picking up dependencies on modules that ghw only uses for testing or for its CLI.

Fixes #328

Signed-off-by: Chris Waldon <christopher.waldon.dev@gmail.com>