### PR TITLE
fix Windows disk drive index comparison

### DIFF
--- a/pkg/block/block_windows.go
+++ b/pkg/block/block_windows.go
@@ -115,7 +115,10 @@ func (i *Info) load() error {
 		}
 		for _, diskpartition := range win32DiskPartitionDescriptions {
 			// Finding disk partition linked to current disk drive
-			if diskdrive.Index == diskpartition.DiskIndex {
+			if diskdrive.Index == nil || diskpartition.DiskIndex == nil {
+				continue
+			}
+			if *diskdrive.Index == *diskpartition.DiskIndex {
 				disk.PhysicalBlockSizeBytes = *diskpartition.BlockSize
 				// Finding logical partition linked to current disk partition
 				for _, logicaldisk := range win32LogicalDiskDescriptions {


### PR DESCRIPTION
Ensures that we are comparing indexes and not pointers to indexes.

Fixes #267

Signed-off-by: Jay Pipes <jaypipes@gmail.com>