### PR TITLE
added gpu driver query for windows

### DIFF
--- a/pkg/gpu/gpu_windows.go
+++ b/pkg/gpu/gpu_windows.go
@@ -15,13 +15,14 @@ import (
 	"github.com/jaypipes/ghw/pkg/util"
 )
 
-const wqlVideoController = "SELECT Caption, CreationClassName, Description, DeviceID, Name, PNPDeviceID, SystemCreationClassName, SystemName, VideoArchitecture, VideoMemoryType, VideoModeDescription, VideoProcessor FROM Win32_VideoController"
+const wqlVideoController = "SELECT Caption, CreationClassName, Description, DeviceID, DriverVersion, Name, PNPDeviceID, SystemCreationClassName, SystemName, VideoArchitecture, VideoMemoryType, VideoModeDescription, VideoProcessor FROM Win32_VideoController"
 
 type win32VideoController struct {
 	Caption                 string
 	CreationClassName       string
 	Description             string
 	DeviceID                string
+	DriverVersion           string
 	Name                    string
 	PNPDeviceID             string
 	SystemCreationClassName string
@@ -75,6 +76,7 @@ func (i *Info) load() error {
 			Index:      0,
 			DeviceInfo: GetDevice(description.PNPDeviceID, win32PnPDescriptions),
 		}
+		card.DeviceInfo.Driver = description.DriverVersion
 		cards = append(cards, card)
 	}
 	i.GraphicsCards = cards


### PR DESCRIPTION
## Description
GPU does not currently return driver version for Windows. Adding these 3 lines reliably returns driver version

## Test
```
package main

import (
	"fmt"

	"github.com/jaypipes/ghw"
)

type gpuInfo struct {
	Vendor        string
	Name          string
	OfflineDriver string
}

func GetGpuData() []gpuInfo {
	gpus := []gpuInfo{}

	cards, err := ghw.GPU()
	if err != nil {
		fmt.Printf("Error getting GPU info: %v", err)
	}

	for _, card := range cards.GraphicsCards {
		gpu := gpuInfo{
			Name:          card.DeviceInfo.Product.Name,
			Vendor:        card.DeviceInfo.Vendor.Name,
			OfflineDriver: card.DeviceInfo.Driver,
		}

		gpus = append(gpus, gpu)
	}

	return gpus
}

func main() {
	gpus := GetGpuData()

	for _, gpu := range gpus {
		println("GPU Vendor: ", gpu.Vendor)
		println("GPU Name: ", gpu.Name)
		println("Driver: ", gpu.OfflineDriver)
	}
}
```

### Returns before update
```
GPU Vendor:  NVIDIA
GPU Name:  NVIDIA GeForce RTX 3060 Ti
Driver:
```

### Return after update
```
GPU Vendor:  NVIDIA
GPU Name:  NVIDIA GeForce RTX 3060 Ti
Driver:  31.0.15.3118
```