### PR TITLE
Add NICLinkInfo to each NIC

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,7 +718,7 @@ Each `ghw.NIC` struct contains the following fields:
 * `ghw.NIC.LinkInfo` is a pointer to a `ghw.NICLinkInfo` struct, which describes 
   parameters of the NIC's link information and status.  This will contain the 
   fields returned by `ethtool <DEVICE>` call on Linux, but will fall back to 
-  returning link information available in the /sys/class/net/<DEVICE>/ directory
+  returning link information available in the `/sys/class/net/<DEVICE>/` directory
   if ethtool is not available.
 
 The `ghw.NICCapability` struct contains the following fields:
@@ -762,7 +762,7 @@ The `gwh.NICLinkInfo` struct contains the following fields:
 * `ghw.NICLinkInfo.AdvertisedLinkModes` is a string slice containing the
   link modes being advertised during auto negotiation.
 * `ghw.NICLinkInfo.AdvertisedPauseFrameUse` is a boolean indicating if pause
-  frame use is being advertised durinig auto negotiation.
+  frame use is being advertised during auto negotiation.
 * `ghw.NICLinkInfo.AdvertisedAutoNegotiation` is a boolean indicating if 
   auto negotiation is advertised.
 * `ghw.NICLinkInfo.AdvertisedFECModes` is a string slice containing the FEC

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -20,12 +20,36 @@ type NICCapability struct {
 	CanEnable bool   `json:"can_enable"`
 }
 
+type NICLinkInfo struct {
+	Speed						string		`json:"speed"`
+	Duplex						string		`json:"duplex"`
+	AutoNegotiation				*bool		`json:"auto-negotiation,omitempty"`
+	Port						string		`json:"port,omitempty"`
+	PHYAD						string		`json:"phyad,omitempty"`
+	Transceiver					string		`json:"transceiver,omitempty"`
+	MDIX						[]string	`json:"mdi-x,omitempty"`
+	SupportsWakeOn				string		`json:"supports_wake-on,omitempty"`
+	WakeOn						string		`json:"wake-on,omitempty"`
+	LinkDetected				*bool		`json:"link_detected"`
+	SupportedPorts				[]string	`json:"supported_ports,omitempty"`
+	SupportedLinkModes			[]string	`json:"supported_link_modes,omitempty"`
+	SupportedPauseFrameUse		*bool		`json:"supported_pause_frame_use,omitempty"`
+	SupportsAutoNegotiation		*bool		`json:"supports_auto-negotiation,omitempty"`
+	SupportedFECModes			[]string	`json:"supported_fec_modes,omitempty"`
+	AdvertisedLinkModes			[]string	`json:"advertised_link_modes,omitempty"`
+	AdvertisedPauseFrameUse		*bool		`json:"advertised_pause_frame_use,omitempty"`
+	AdvertisedAutoNegotiation	*bool		`json:"advertised_auto-negotiation,omitempty"`
+	AdvertisedFECModes			[]string	`json:"advertised_fec_modes,omitempty"`
+	NETIFMsgLevel				[]string	`json:"netif_msg_level,omitempty"`
+}
+
 type NIC struct {
 	Name         string           `json:"name"`
 	MacAddress   string           `json:"mac_address"`
 	IsVirtual    bool             `json:"is_virtual"`
 	Capabilities []*NICCapability `json:"capabilities"`
 	PCIAddress   *string          `json:"pci_address,omitempty"`
+	LinkInfo     *NICLinkInfo     `json:"link_info"`
 	// TODO(fromani): add other hw addresses (USB) when we support them
 }
 

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -7,8 +7,8 @@
 package net
 
 import (
-	"fmt"
 	"encoding/json"
+	"fmt"
 
 	"github.com/jaypipes/ghw/pkg/context"
 	"github.com/jaypipes/ghw/pkg/marshal"
@@ -34,7 +34,7 @@ type NICLinkInfo struct {
 	LinkDetected              *bool    `json:"link_detected"`
 	SupportedPorts            []string `json:"supported_ports,omitempty"`
 	SupportedLinkModes        []string `json:"supported_link_modes,omitempty"`
-	SupportedPauseFrameUse    *bool     `json:"supported_pause_frame_use,omitempty"`
+	SupportedPauseFrameUse    *bool    `json:"supported_pause_frame_use,omitempty"`
 	SupportsAutoNegotiation   *bool    `json:"supports_auto-negotiation,omitempty"`
 	SupportedFECModes         []string `json:"supported_fec_modes,omitempty"`
 	AdvertisedLinkModes       []string `json:"advertised_link_modes,omitempty"`
@@ -45,8 +45,8 @@ type NICLinkInfo struct {
 }
 
 func (h *NICLinkInfo) String() string {
-    s, _ := json.Marshal(h)
-    return string(s)
+	s, _ := json.Marshal(h)
+	return string(s)
 }
 
 type NIC struct {

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -8,6 +8,7 @@ package net
 
 import (
 	"fmt"
+	"encoding/json"
 
 	"github.com/jaypipes/ghw/pkg/context"
 	"github.com/jaypipes/ghw/pkg/marshal"
@@ -21,26 +22,31 @@ type NICCapability struct {
 }
 
 type NICLinkInfo struct {
-	Speed						string		`json:"speed"`
-	Duplex						string		`json:"duplex"`
-	AutoNegotiation				*bool		`json:"auto-negotiation,omitempty"`
-	Port						string		`json:"port,omitempty"`
-	PHYAD						string		`json:"phyad,omitempty"`
-	Transceiver					string		`json:"transceiver,omitempty"`
-	MDIX						[]string	`json:"mdi-x,omitempty"`
-	SupportsWakeOn				string		`json:"supports_wake-on,omitempty"`
-	WakeOn						string		`json:"wake-on,omitempty"`
-	LinkDetected				*bool		`json:"link_detected"`
-	SupportedPorts				[]string	`json:"supported_ports,omitempty"`
-	SupportedLinkModes			[]string	`json:"supported_link_modes,omitempty"`
-	SupportedPauseFrameUse		*bool		`json:"supported_pause_frame_use,omitempty"`
-	SupportsAutoNegotiation		*bool		`json:"supports_auto-negotiation,omitempty"`
-	SupportedFECModes			[]string	`json:"supported_fec_modes,omitempty"`
-	AdvertisedLinkModes			[]string	`json:"advertised_link_modes,omitempty"`
-	AdvertisedPauseFrameUse		*bool		`json:"advertised_pause_frame_use,omitempty"`
-	AdvertisedAutoNegotiation	*bool		`json:"advertised_auto-negotiation,omitempty"`
-	AdvertisedFECModes			[]string	`json:"advertised_fec_modes,omitempty"`
-	NETIFMsgLevel				[]string	`json:"netif_msg_level,omitempty"`
+	Speed                     string   `json:"speed"`
+	Duplex                    string   `json:"duplex"`
+	AutoNegotiation           *bool    `json:"auto-negotiation,omitempty"`
+	Port                      string   `json:"port,omitempty"`
+	PHYAD                     string   `json:"phyad,omitempty"`
+	Transceiver               string   `json:"transceiver,omitempty"`
+	MDIX                      []string `json:"mdi-x,omitempty"`
+	SupportsWakeOn            string   `json:"supports_wake-on,omitempty"`
+	WakeOn                    string   `json:"wake-on,omitempty"`
+	LinkDetected              *bool    `json:"link_detected"`
+	SupportedPorts            []string `json:"supported_ports,omitempty"`
+	SupportedLinkModes        []string `json:"supported_link_modes,omitempty"`
+	SupportedPauseFrameUse    *bool     `json:"supported_pause_frame_use,omitempty"`
+	SupportsAutoNegotiation   *bool    `json:"supports_auto-negotiation,omitempty"`
+	SupportedFECModes         []string `json:"supported_fec_modes,omitempty"`
+	AdvertisedLinkModes       []string `json:"advertised_link_modes,omitempty"`
+	AdvertisedPauseFrameUse   *bool    `json:"advertised_pause_frame_use,omitempty"`
+	AdvertisedAutoNegotiation *bool    `json:"advertised_auto-negotiation,omitempty"`
+	AdvertisedFECModes        []string `json:"advertised_fec_modes,omitempty"`
+	NETIFMsgLevel             []string `json:"netif_msg_level,omitempty"`
+}
+
+func (h *NICLinkInfo) String() string {
+    s, _ := json.Marshal(h)
+    return string(s)
 }
 
 type NIC struct {

--- a/pkg/net/net_linux.go
+++ b/pkg/net/net_linux.go
@@ -226,9 +226,9 @@ func netDevicePCIAddress(netDevDir, netDevName string) *string {
 
 func netDeviceLimittedLinkInfo(paths *linuxpath.Paths, dev string) *NICLinkInfo {
 	// Get speed, duplex, and link detected from /sys/class/net/$DEVICE/ directory
-	speed     := readFile(filepath.Join(paths.SysClassNet, dev, "speed"))
-	duplex    := readFile(filepath.Join(paths.SysClassNet, dev, "duplex"))
-	carrier   := readFile(filepath.Join(paths.SysClassNet, dev, "carrier"))
+	speed := readFile(filepath.Join(paths.SysClassNet, dev, "speed"))
+	duplex := readFile(filepath.Join(paths.SysClassNet, dev, "duplex"))
+	carrier := readFile(filepath.Join(paths.SysClassNet, dev, "carrier"))
 	link, err := util.ParseBool(carrier)
 	if err == nil {
 		return &NICLinkInfo{
@@ -238,8 +238,8 @@ func netDeviceLimittedLinkInfo(paths *linuxpath.Paths, dev string) *NICLinkInfo 
 		}
 	} else {
 		return &NICLinkInfo{
-			Speed:        speed,
-			Duplex:       duplex,
+			Speed:  speed,
+			Duplex: duplex,
 		}
 	}
 }
@@ -307,10 +307,10 @@ func netParseEthtoolLinkInfo(out *bytes.Buffer) *NICLinkInfo {
 		var fields []string
 		if strings.Contains(scanner.Text(), ":") {
 			line := strings.Split(scanner.Text(), ":")
-			name  = strings.TrimSpace(line[0])
-			str  := strings.Trim(strings.TrimSpace(line[1]), "[]")
+			name = strings.TrimSpace(line[0])
+			str := strings.Trim(strings.TrimSpace(line[1]), "[]")
 			switch str {
-				case
+			case
 				"Not reported",
 				"Unknown":
 				continue
@@ -328,7 +328,7 @@ func netParseEthtoolLinkInfo(out *bytes.Buffer) *NICLinkInfo {
 	var nilBool *bool
 
 	var autoNegotiation *bool
-	an, err	:=	util.ParseBool(strings.Join(m["Auto-negotiation"],""))
+	an, err	:= util.ParseBool(strings.Join(m["Auto-negotiation"], ""))
 	if err != nil {
 		autoNegotiation	= nilBool
 	} else {
@@ -336,7 +336,7 @@ func netParseEthtoolLinkInfo(out *bytes.Buffer) *NICLinkInfo {
 	}
 
 	var linkDetected *bool
-	ld, err	:=	util.ParseBool(strings.Join(m["Link detected"],""))
+	ld, err	:= util.ParseBool(strings.Join(m["Link detected"], ""))
 	if err != nil {
 		linkDetected = nilBool
 	} else {
@@ -344,7 +344,7 @@ func netParseEthtoolLinkInfo(out *bytes.Buffer) *NICLinkInfo {
 	}
 
 	var supportedPauseFrameUse *bool
-	spfu, err := util.ParseBool(strings.Join(m["Supported pause frame use"],""))
+	spfu, err := util.ParseBool(strings.Join(m["Supported pause frame use"], ""))
 	if err != nil {
 		supportedPauseFrameUse = nilBool
 	} else {
@@ -352,7 +352,7 @@ func netParseEthtoolLinkInfo(out *bytes.Buffer) *NICLinkInfo {
 	}
 
 	var supportsAutoNegotiation *bool
-	san, err := util.ParseBool(strings.Join(m["Supports auto-negotiation"],""))
+	san, err := util.ParseBool(strings.Join(m["Supports auto-negotiation"], ""))
 	if err != nil {
 		supportsAutoNegotiation = nilBool
 	} else {
@@ -360,7 +360,7 @@ func netParseEthtoolLinkInfo(out *bytes.Buffer) *NICLinkInfo {
 	}
 
 	var advertisedPauseFrameUse *bool
-	apfu, err := util.ParseBool(strings.Join(m["Advertised pause frame use"],""))
+	apfu, err := util.ParseBool(strings.Join(m["Advertised pause frame use"], ""))
 	if err != nil {
 		advertisedPauseFrameUse = nilBool
 	} else {
@@ -368,7 +368,7 @@ func netParseEthtoolLinkInfo(out *bytes.Buffer) *NICLinkInfo {
 	}
 
 	var advertisedAutoNegotiation *bool
-	aan, err := util.ParseBool(strings.Join(m["Advertised auto-negotiation"],""))
+	aan, err := util.ParseBool(strings.Join(m["Advertised auto-negotiation"], ""))
 	if err != nil {
 		advertisedAutoNegotiation = nilBool
 	} else {
@@ -376,15 +376,15 @@ func netParseEthtoolLinkInfo(out *bytes.Buffer) *NICLinkInfo {
 	}
 
 	return &NICLinkInfo {
-		Speed:                     strings.Join(m["Speed"],""),
-		Duplex:                    strings.Join(m["Duplex"],""),
+		Speed:                     strings.Join(m["Speed"], ""),
+		Duplex:                    strings.Join(m["Duplex"], ""),
 		AutoNegotiation:           autoNegotiation,
-		Port:                      strings.Join(m["Port"],""),
-		PHYAD:                     strings.Join(m["PHYAD"],""),
-		Transceiver:               strings.Join(m["Transceiver"],""),
+		Port:                      strings.Join(m["Port"], ""),
+		PHYAD:                     strings.Join(m["PHYAD"], ""),
+		Transceiver:               strings.Join(m["Transceiver"], ""),
 		MDIX:                      m["MDI-X"],
-		SupportsWakeOn:            strings.Join(m["Supports Wake-on"],""),
-		WakeOn:                    strings.Join(m["Wake-on"],""),
+		SupportsWakeOn:            strings.Join(m["Supports Wake-on"], ""),
+		WakeOn:                    strings.Join(m["Wake-on"], ""),
 		LinkDetected:              linkDetected,
 		SupportedPorts:            m["Supported ports"],
 		SupportedLinkModes:        m["Supported link modes"],

--- a/pkg/net/net_linux.go
+++ b/pkg/net/net_linux.go
@@ -72,7 +72,7 @@ func nics(ctx *context.Context) []*NIC {
 			nic.LinkInfo = netDeviceLinkInfo(ctx, filename)
 		} else {
 			nic.Capabilities = []*NICCapability{}
-			nic.LinkInfo = netDeviceLimittedLinkInfo(paths, filename)
+			nic.LinkInfo = netDeviceLimitedLinkInfo(paths, filename)
 		}
 
 		nic.PCIAddress = netDevicePCIAddress(paths.SysClassNet, filename)
@@ -224,7 +224,7 @@ func netDevicePCIAddress(netDevDir, netDevName string) *string {
 	return &pciAddr
 }
 
-func netDeviceLimittedLinkInfo(paths *linuxpath.Paths, dev string) *NICLinkInfo {
+func netDeviceLimitedLinkInfo(paths *linuxpath.Paths, dev string) *NICLinkInfo {
 	// Get speed, duplex, and link detected from /sys/class/net/$DEVICE/ directory
 	speed := readFile(filepath.Join(paths.SysClassNet, dev, "speed"))
 	duplex := readFile(filepath.Join(paths.SysClassNet, dev, "duplex"))

--- a/pkg/net/net_linux_test.go
+++ b/pkg/net/net_linux_test.go
@@ -64,9 +64,9 @@ func TestParseEthtoolLinkInfo(t *testing.T) {
 		t.Skip("Skipping network tests.")
 	}
 
-	truePtr  := true
+	truePtr := true
 	falsePtr := false
-	tests    := []struct {
+	tests := []struct {
 		input    string
 		expected *NICLinkInfo
 	}{
@@ -99,41 +99,41 @@ func TestParseEthtoolLinkInfo(t *testing.T) {
 	Link detected: yes
 `,
 			expected: &NICLinkInfo{
-				Speed:                     "1000Mb/s",
-				Duplex:                    "Full",
+				AdvertisedAutoNegotiation: &truePtr,
+				AdvertisedPauseFrameUse:   &falsePtr,
 				AutoNegotiation:           &truePtr,
+				Duplex:                    "Full",
+				LinkDetected:              &truePtr,
+				MDIX:                      []string{"off", "(auto)"},
 				Port:                      "TwistedPair",
 				PHYAD:                     "1",
-				Transceiver:               "internal",
-				MDIX:                      []string{"off", "(auto)"},
-				SupportsWakeOn:            "pumbg",
-				WakeOn:                    "d",
-				LinkDetected:              &truePtr,
-				SupportedPorts:            []string{"TP"},
-				SupportedLinkModes:        []string{
-					"10baseT/Half",
-					"10baseT/Full",
-					"100baseT/Half",
-					"100baseT/Full",
-					"1000baseT/Full",
-				},
+				Speed:                     "1000Mb/s",
 				SupportedPauseFrameUse:    &falsePtr,
+				SupportedPorts:            []string{"TP"},
 				SupportsAutoNegotiation:   &truePtr,
-				AdvertisedLinkModes:       []string{
+				SupportsWakeOn:            "pumbg",
+				Transceiver:               "internal",
+				WakeOn:                    "d",
+				AdvertisedLinkModes: []string{
 					"10baseT/Half",
 					"10baseT/Full",
 					"100baseT/Half",
 					"100baseT/Full",
 					"1000baseT/Full",
 				},
-				AdvertisedPauseFrameUse:   &falsePtr,
-				AdvertisedAutoNegotiation: &truePtr,
-				NETIFMsgLevel:             []string{
+				NETIFMsgLevel: []string{
 					"0x00000007",
 					"(7)",
 					"drv",
 					"probe",
 					"link",
+				},
+				SupportedLinkModes: []string{
+					"10baseT/Half",
+					"10baseT/Full",
+					"100baseT/Half",
+					"100baseT/Full",
+					"1000baseT/Full",
 				},
 			},
 		},

--- a/pkg/net/net_linux_test.go
+++ b/pkg/net/net_linux_test.go
@@ -10,6 +10,7 @@
 package net
 
 import (
+	"bytes"
 	"os"
 	"reflect"
 	"testing"
@@ -63,11 +64,11 @@ func TestParseEthtoolLinkInfo(t *testing.T) {
 		t.Skip("Skipping network tests.")
 	}
 
-	truePtr		:= true
-	falsePtr	:= false
-	tests := []struct {
-		input		string
-		expected	*NICLinkInfo
+	truePtr  := true
+	falsePtr := false
+	tests    := []struct {
+		input    string
+		expected *NICLinkInfo
 	}{
 		{
 			input: `Settings for eth0:
@@ -98,46 +99,50 @@ func TestParseEthtoolLinkInfo(t *testing.T) {
 	Link detected: yes
 `,
 			expected: &NICLinkInfo{
-				Speed:						"1000Mb/s",
-				Duplex:						"Full",
-				AutoNegotiation:			&truePtr,
-				Port:						"Twisted Pair",
-				PHYAD:						"1",
-				Transceiver:				"internal",
-				MDIX:						[]string{"off", "(auto)"},
-				SupportsWakeOn:				"pumbg",
-				WakeOn:						"d",
-				LinkDetected:				&truePtr,
-				SupportedPorts:				[]string{"[", "TP", "]"},
-				SupportedLinkModes:			[]string{
-												"10baseT/Half",
-												"10baseT/Full",
-												"100baseT/Half",
-												"100baseT/Full",
-												"1000baseT/Full",
-											},
-				SupportedPauseFrameUse:		&falsePtr,
-				SupportsAutoNegotiation:	&truePtr,
-				SupportedFECModes:			[]string{"Not", "reported"},
-				AdvertisedLinkModes:		[]string{
-												"10baseT/Half",
-												"10baseT/Full",
-												"100baseT/Half",
-												"100baseT/Full",
-												"1000baseT/Full",
-											},
-				AdvertisedPauseFrameUse:	&falsePtr,
-				AdvertisedAutoNegotiation:	&truePtr,
-				AdvertisedFECModes:			[]string{"Not", "reported"},
-				NETIFMsgLevel:				[]string{"0x00000007", "(7)", "drv", "probe", "link"},
+				Speed:                     "1000Mb/s",
+				Duplex:                    "Full",
+				AutoNegotiation:           &truePtr,
+				Port:                      "TwistedPair",
+				PHYAD:                     "1",
+				Transceiver:               "internal",
+				MDIX:                      []string{"off", "(auto)"},
+				SupportsWakeOn:            "pumbg",
+				WakeOn:                    "d",
+				LinkDetected:              &truePtr,
+				SupportedPorts:            []string{"TP"},
+				SupportedLinkModes:        []string{
+					"10baseT/Half",
+					"10baseT/Full",
+					"100baseT/Half",
+					"100baseT/Full",
+					"1000baseT/Full",
+				},
+				SupportedPauseFrameUse:    &falsePtr,
+				SupportsAutoNegotiation:   &truePtr,
+				AdvertisedLinkModes:       []string{
+					"10baseT/Half",
+					"10baseT/Full",
+					"100baseT/Half",
+					"100baseT/Full",
+					"1000baseT/Full",
+				},
+				AdvertisedPauseFrameUse:   &falsePtr,
+				AdvertisedAutoNegotiation: &truePtr,
+				NETIFMsgLevel:             []string{
+					"0x00000007",
+					"(7)",
+					"drv",
+					"probe",
+					"link",
+				},
 			},
 		},
 	}
 
 	for x, test := range tests {
-		actual := netParseEthtoolLinkInfo(test.input)
+		actual := netParseEthtoolLinkInfo(bytes.NewBufferString(test.input))
 		if !reflect.DeepEqual(test.expected, actual) {
-			t.Fatalf("In test %d, expected %v == %v", x, test.expected, actual)
+			t.Fatalf("In test %d\nExpected:\n%v\nActual:\n%v\n", x, test.expected, actual)
 		}
 	}
 }

--- a/pkg/net/net_linux_test.go
+++ b/pkg/net/net_linux_test.go
@@ -57,3 +57,87 @@ func TestParseEthtoolFeature(t *testing.T) {
 		}
 	}
 }
+
+func TestParseEthtoolLinkInfo(t *testing.T) {
+	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_NET"); ok {
+		t.Skip("Skipping network tests.")
+	}
+
+	truePtr		:= true
+	falsePtr	:= false
+	tests := []struct {
+		input		string
+		expected	*NICLinkInfo
+	}{
+		{
+			input: `Settings for eth0:
+	Supported ports: [ TP ]
+	Supported link modes:   10baseT/Half 10baseT/Full
+	                        100baseT/Half 100baseT/Full
+	                        1000baseT/Full
+	Supported pause frame use: No
+	Supports auto-negotiation: Yes
+	Supported FEC modes: Not reported
+	Advertised link modes:  10baseT/Half 10baseT/Full
+	                        100baseT/Half 100baseT/Full
+	                        1000baseT/Full
+	Advertised pause frame use: No
+	Advertised auto-negotiation: Yes
+	Advertised FEC modes: Not reported
+	Speed: 1000Mb/s
+	Duplex: Full
+	Auto-negotiation: on
+	Port: Twisted Pair
+	PHYAD: 1
+	Transceiver: internal
+	MDI-X: off (auto)
+	Supports Wake-on: pumbg
+	Wake-on: d
+        Current message level: 0x00000007 (7)
+                               drv probe link
+	Link detected: yes
+`,
+			expected: &NICLinkInfo{
+				Speed:						"1000Mb/s",
+				Duplex:						"Full",
+				AutoNegotiation:			&truePtr,
+				Port:						"Twisted Pair",
+				PHYAD:						"1",
+				Transceiver:				"internal",
+				MDIX:						[]string{"off", "(auto)"},
+				SupportsWakeOn:				"pumbg",
+				WakeOn:						"d",
+				LinkDetected:				&truePtr,
+				SupportedPorts:				[]string{"[", "TP", "]"},
+				SupportedLinkModes:			[]string{
+												"10baseT/Half",
+												"10baseT/Full",
+												"100baseT/Half",
+												"100baseT/Full",
+												"1000baseT/Full",
+											},
+				SupportedPauseFrameUse:		&falsePtr,
+				SupportsAutoNegotiation:	&truePtr,
+				SupportedFECModes:			[]string{"Not", "reported"},
+				AdvertisedLinkModes:		[]string{
+												"10baseT/Half",
+												"10baseT/Full",
+												"100baseT/Half",
+												"100baseT/Full",
+												"1000baseT/Full",
+											},
+				AdvertisedPauseFrameUse:	&falsePtr,
+				AdvertisedAutoNegotiation:	&truePtr,
+				AdvertisedFECModes:			[]string{"Not", "reported"},
+				NETIFMsgLevel:				[]string{"0x00000007", "(7)", "drv", "probe", "link"},
+			},
+		},
+	}
+
+	for x, test := range tests {
+		actual := netParseEthtoolLinkInfo(test.input)
+		if !reflect.DeepEqual(test.expected, actual) {
+			t.Fatalf("In test %d, expected %v == %v", x, test.expected, actual)
+		}
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -57,3 +57,29 @@ func SafeIntFromFile(ctx *context.Context, path string) int {
 func ConcatStrings(items ...string) string {
 	return strings.Join(items, "")
 }
+
+// Convert strings to bool using strconv.ParseBool() when recognized, otherwise
+// use map lookup to convert strings like "Yes" "No" "On" "Off" to bool
+// `ethtool` uses on, off, yes, no (upper and lower case) rather than true and
+// false.
+func ParseBool(str string) (bool, error) {
+	if b, err := strconv.ParseBool(str); err == nil {
+		return b, err
+	} else {
+		ExtraBools := map[string]bool{
+			"on":	true,
+			"off":	false,
+			"yes":	true,
+			"no":	false,
+			// Return false instead of an error on empty strings
+			// For example from empty files in SysClassNet/Device
+			"":		false,
+		}
+		if b, ok := ExtraBools[strings.ToLower(str)]; ok {
+			return b, nil
+		} else {
+			// Return strconv.ParseBool's error here
+			return b, err
+		}
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -73,7 +73,7 @@ func ParseBool(str string) (bool, error) {
 			"no":  false,
 			// Return false instead of an error on empty strings
 			// For example from empty files in SysClassNet/Device
-			"":    false,
+			"": false,
 		}
 		if b, ok := ExtraBools[strings.ToLower(str)]; ok {
 			return b, nil

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -67,13 +67,13 @@ func ParseBool(str string) (bool, error) {
 		return b, err
 	} else {
 		ExtraBools := map[string]bool{
-			"on":	true,
-			"off":	false,
-			"yes":	true,
-			"no":	false,
+			"on":  true,
+			"off": false,
+			"yes": true,
+			"no":  false,
 			// Return false instead of an error on empty strings
 			// For example from empty files in SysClassNet/Device
-			"":		false,
+			"":    false,
 		}
 		if b, ok := ExtraBools[strings.ToLower(str)]; ok {
 			return b, nil

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -64,36 +64,36 @@ func TestParseBool(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			item:		"False",
-			expected:	false,
+			item:     "False",
+			expected: false,
 		},
 		{
-			item:		"F",
-			expected:	false,
+			item:     "F",
+			expected: false,
 		},
 		{
-			item:		"1",
-			expected:	true,
+			item:     "1",
+			expected: true,
 		},
 		{
-			item:		"",
-			expected:	false,
+			item:     "",
+			expected: false,
 		},
 		{
-			item:		"on",
-			expected:	true,
+			item:     "on",
+			expected: true,
 		},
 		{
-			item:		"Off",
-			expected:	false,
+			item:     "Off",
+			expected: false,
 		},
 		{
-			item:		"Yes",
-			expected:	true,
+			item:     "Yes",
+			expected: true,
 		},
 		{
-			item:		"no",
-			expected:	false,
+			item:     "no",
+			expected: false,
 		},
 	}
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -55,3 +55,57 @@ func TestConcatStrings(t *testing.T) {
 		})
 	}
 }
+
+func TestParseBool(t *testing.T) {
+	type testCase struct {
+		item		string
+		expected	bool
+	}
+
+	testCases := []testCase{
+		{
+			item:		"False",
+			expected:	false,
+		},
+		{
+			item:		"F",
+			expected:	false,
+		},
+		{
+			item:		"1",
+			expected:	true,
+		},
+		{
+			item:		"",
+			expected:	false,
+		},
+		{
+			item:		"on",
+			expected:	true,
+		},
+		{
+			item:		"Off",
+			expected:	false,
+		},
+		{
+			item:		"Yes",
+			expected:	true,
+		},
+		{
+			item:		"no",
+			expected:	false,
+		},
+	}
+
+	for _, tCase := range testCases {
+		t.Run(tCase.item, func(t *testing.T) {
+			got, err := util.ParseBool(tCase.item)
+			if got != tCase.expected {
+				t.Errorf("expected %t got %t", tCase.expected, got)
+			}
+			if err != nil {
+				t.Errorf("util.ParseBool threw error %s", err)
+			}
+		})
+	}
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -58,8 +58,8 @@ func TestConcatStrings(t *testing.T) {
 
 func TestParseBool(t *testing.T) {
 	type testCase struct {
-		item		string
-		expected	bool
+		item     string
+		expected bool
 	}
 
 	testCases := []testCase{


### PR DESCRIPTION
Default to parsing the output of `ethtool`, but fall back to reading a few parameters from the /sys/class/net/<int>/ directory.  Information such as interface Speed, Duplex, Link Detected, and Auto Negotiation will be available for each NIC.

* `ghw.NIC.LinkInfo` is a pointer to a `ghw.NICLinkInfo` struct, which describes 
  parameters of the NIC's link information and status.  This will contain the 
  fields returned by `ethtool <DEVICE>` call on Linux, but will fall back to 
  returning link information available in the /sys/class/net/<DEVICE>/ directory
  if ethtool is not available.

The `gwh.NICLinkInfo` struct contains the following fields:
* `ghw.NICLinkInfo.Speed` is a string showing the current link speed.  This 
  field will be present even if ethtool is not available.
* `ghw.NICLinkInfo.Duplex` is a string showing the current link duplex.  This 
  field will be present even if ethtool is not available.
* `ghw.NICLinkInfo.AutoNegotiation` is a boolean indicating whether 
  Auto-Negotiation is enabled
* `ghw.NICLinkInfo.Port` is a string showing the current link port type
* `ghw.NICLinkInfo.PHYAD` is a string showing the device driver's setting
* `ghw.NICLinkInfo.Transceiver` is a string showing the transceiver's state
* `ghw.NICLinkInfo.MDIX` is a string slice indicating the state of MDI-X capability
  of the interface.
* `ghw.NICLinkInfo.SupportsWakeOn` is a string containing a list of supported 
  WakeOnLAN events.
* `ghw.NICLinkInfo.WakeOn` is a string indicating which WakeOnLAN events are 
  will trigger wake up.
* `ghw.NICLinkInfo.LinkDetected` is a boolean indicating whether there is an active
  link detected on this interface.  This field will be present even if ethtool is
  not available.
* `ghw.NICLinkInfo.SupportedPorts` is a string slice containing the list of 
  supported port types (MII, TP, FIBRE)
* `ghw.NICLinkInfo.SupportedLinkModes` is a string slice containing a list of
  supported link modes
* `ghw.NICLinkInfo.SupportedPauseFrameUse` is a boolean indicating if pause
  frame use is enabled.
* `ghw.NICLinkInfo.SupportsAutoNegotiation` is a boolean indicating if the 
  network device supports Auto Negotiation.
* `ghw.NICLinkInfo.SupportedFECModes` is a string slice containing a list of 
  supported FEC Modes.
* `ghw.NICLinkInfo.AdvertisedLinkModes` is a string slice containing the
  link modes being advertised during auto negotiation.
* `ghw.NICLinkInfo.AdvertisedPauseFrameUse` is a boolean indicating if pause
  frame use is being advertised durinig auto negotiation.
* `ghw.NICLinkInfo.AdvertisedAutoNegotiation` is a boolean indicating if 
  auto negotiation is advertised.
* `ghw.NICLinkInfo.AdvertisedFECModes` is a string slice containing the FEC
  modes advertised during auto negotiation.
* `ghw.NICLinkInfo.NETIFMsgLevel` is a string slice containing the network
  driver's debug level and other misc driver information from the kernel.