### PR TITLE
Add more fields to NIC

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,6 +715,20 @@ Each `ghw.NIC` struct contains the following fields:
 * `ghw.NIC.PCIAddress` is the PCI device address of the device backing the NIC.
   this is not-nil only if the backing device is indeed a PCI device; more backing
   devices (e.g. USB) will be added in future versions.
+* `ghw.NIC.Speed` is a string showing the current link speed.  This 
+  field will be present even if ethtool is not available.
+* `ghw.NIC.Duplex` is a string showing the current link duplex.  This 
+  field will be present even if ethtool is not available.
+* `ghw.NIC.SupportedLinkModes` is a string slice containing a list of
+  supported link modes
+* `ghw.NIC.SupportedPorts` is a string slice containing the list of 
+  supported port types (MII, TP, FIBRE)
+* `ghw.NIC.SupportedFECModes` is a string slice containing a list of 
+  supported FEC Modes.
+* `ghw.NIC.AdvertisedLinkModes` is a string slice containing the
+  link modes being advertised during auto negotiation.
+* `ghw.NIC.AdvertisedFECModes` is a string slice containing the FEC
+  modes advertised during auto negotiation.
 
 The `ghw.NICCapability` struct contains the following fields:
 

--- a/README.md
+++ b/README.md
@@ -711,7 +711,8 @@ Each `ghw.NIC` struct contains the following fields:
   device
 * `ghw.NIC.Capabilities` is an array of pointers to `ghw.NICCapability` structs
   that can describe the things the NIC supports. These capabilities match the
-  returned values from the `ethtool -k <DEVICE>` call on Linux
+  returned values from the `ethtool -k <DEVICE>` call on Linux as well as the 
+  AutoNegotiation and PauseFrameUse capabilities from `ethtool`.
 * `ghw.NIC.PCIAddress` is the PCI device address of the device backing the NIC.
   this is not-nil only if the backing device is indeed a PCI device; more backing
   devices (e.g. USB) will be added in future versions.

--- a/README.md
+++ b/README.md
@@ -718,8 +718,8 @@ Each `ghw.NIC` struct contains the following fields:
   devices (e.g. USB) will be added in future versions.
 * `ghw.NIC.Speed` is a string showing the current link speed.  On Linux, this 
   field will be present even if `ethtool` is not available.
-* `ghw.NIC.Duplex` is a string showing the current link duplex.  This 
-  field will be present even if ethtool is not available.
+* `ghw.NIC.Duplex` is a string showing the current link duplex. On Linux, this 
+  field will be present even if `ethtool` is not available.
 * `ghw.NIC.SupportedLinkModes` is a string slice containing a list of
   supported link modes
 * `ghw.NIC.SupportedPorts` is a string slice containing the list of 

--- a/README.md
+++ b/README.md
@@ -716,8 +716,8 @@ Each `ghw.NIC` struct contains the following fields:
 * `ghw.NIC.PCIAddress` is the PCI device address of the device backing the NIC.
   this is not-nil only if the backing device is indeed a PCI device; more backing
   devices (e.g. USB) will be added in future versions.
-* `ghw.NIC.Speed` is a string showing the current link speed.  This 
-  field will be present even if ethtool is not available.
+* `ghw.NIC.Speed` is a string showing the current link speed.  On Linux, this 
+  field will be present even if `ethtool` is not available.
 * `ghw.NIC.Duplex` is a string showing the current link duplex.  This 
   field will be present even if ethtool is not available.
 * `ghw.NIC.SupportedLinkModes` is a string slice containing a list of

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -21,11 +21,20 @@ type NICCapability struct {
 }
 
 type NIC struct {
-	Name         string           `json:"name"`
-	MacAddress   string           `json:"mac_address"`
-	IsVirtual    bool             `json:"is_virtual"`
-	Capabilities []*NICCapability `json:"capabilities"`
-	PCIAddress   *string          `json:"pci_address,omitempty"`
+	Name                  string           `json:"name"`
+	MacAddress            string           `json:"mac_address"`
+	IsVirtual             bool             `json:"is_virtual"`
+	Capabilities          []*NICCapability `json:"capabilities"`
+	PCIAddress            *string          `json:"pci_address,omitempty"`
+	Speed                 string           `json:"speed"`
+	Duplex                string           `json:"duplex"`
+	SupportedLinkModes    []string         `json:"supported_link_modes,omitempty"`
+	SupportedPorts        []string         `json:"supported_ports,omitempty"`
+	SupportedFECModes     []string         `json:"supported_fec_modes,omitempty"`
+	AdvertisedLinkModes   []string         `json:"advertised_link_modes,omitempty"`
+	AdvertisedFECModes    []string         `json:"advertised_fec_modes,omitempty"`
+	SupportedWakeOnModes  []string         `json:"supported_wake_on_modes,omitempty"`
+	AdvertisedWakeOnModes []string         `json:"advertised_wake_on_modes,omitempty"`
 	// TODO(fromani): add other hw addresses (USB) when we support them
 }
 

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -21,20 +21,18 @@ type NICCapability struct {
 }
 
 type NIC struct {
-	Name                  string           `json:"name"`
-	MacAddress            string           `json:"mac_address"`
-	IsVirtual             bool             `json:"is_virtual"`
-	Capabilities          []*NICCapability `json:"capabilities"`
-	PCIAddress            *string          `json:"pci_address,omitempty"`
-	Speed                 string           `json:"speed"`
-	Duplex                string           `json:"duplex"`
-	SupportedLinkModes    []string         `json:"supported_link_modes,omitempty"`
-	SupportedPorts        []string         `json:"supported_ports,omitempty"`
-	SupportedFECModes     []string         `json:"supported_fec_modes,omitempty"`
-	AdvertisedLinkModes   []string         `json:"advertised_link_modes,omitempty"`
-	AdvertisedFECModes    []string         `json:"advertised_fec_modes,omitempty"`
-	SupportedWakeOnModes  []string         `json:"supported_wake_on_modes,omitempty"`
-	AdvertisedWakeOnModes []string         `json:"advertised_wake_on_modes,omitempty"`
+	Name                string           `json:"name"`
+	MacAddress          string           `json:"mac_address"`
+	IsVirtual           bool             `json:"is_virtual"`
+	Capabilities        []*NICCapability `json:"capabilities"`
+	PCIAddress          *string          `json:"pci_address,omitempty"`
+	Speed               string           `json:"speed"`
+	Duplex              string           `json:"duplex"`
+	SupportedLinkModes  []string         `json:"supported_link_modes,omitempty"`
+	SupportedPorts      []string         `json:"supported_ports,omitempty"`
+	SupportedFECModes   []string         `json:"supported_fec_modes,omitempty"`
+	AdvertisedLinkModes []string         `json:"advertised_link_modes,omitempty"`
+	AdvertisedFECModes  []string         `json:"advertised_fec_modes,omitempty"`
 	// TODO(fromani): add other hw addresses (USB) when we support them
 }
 

--- a/pkg/net/net_linux.go
+++ b/pkg/net/net_linux.go
@@ -68,7 +68,7 @@ func nics(ctx *context.Context) []*NIC {
 		mac := netDeviceMacAddress(paths, filename)
 		nic.MacAddress = mac
 		if etAvailable {
-			nic.Capabilities = netDeviceCapabilities(ctx, filename)
+			nic.netDeviceParseEthtool(ctx, filename)
 		} else {
 			nic.Capabilities = []*NICCapability{}
 		}
@@ -106,19 +106,29 @@ func ethtoolInstalled() bool {
 	return err == nil
 }
 
-func netDeviceCapabilities(ctx *context.Context, dev string) []*NICCapability {
-	caps := make([]*NICCapability, 0)
+func (n *NIC) netDeviceParseEthtool(ctx *context.Context, dev string) {
 	var out bytes.Buffer
 	path, _ := exec.LookPath("ethtool")
 
 	// Get auto-negotiation and pause-frame-use capabilities from "ethtool" (with no options)
+	// Populate Speed, Duplex, SupportedLinkModes, SupportedPorts, SupportedFECModes,
+	// AdvertisedLinkModes, and AdvertisedFECModes attributes from "ethtool" output.
 	cmd := exec.Command(path, dev)
 	cmd.Stdout = &out
 	err := cmd.Run()
 	if err == nil {
 		m := parseNicAttrEthtool(&out)
-		caps = append(caps, autoNegCap(m))
-		caps = append(caps, pauseFrameUseCap(m))
+		n.Capabilities = append(n.Capabilities, autoNegCap(m))
+		n.Capabilities = append(n.Capabilities, pauseFrameUseCap(m))
+
+		// Update NIC Attributes with ethtool output
+		n.Speed = strings.Join(m["Speed"], "")
+		n.Duplex = strings.Join(m["Duplex"], "")
+		n.SupportedLinkModes = m["Supported link modes"]
+		n.SupportedPorts = m["Supported ports"]
+		n.SupportedFECModes = m["Supported FEC modes"]
+		n.AdvertisedLinkModes = m["Advertised link modes"]
+		n.AdvertisedFECModes = m["Advertised FEC modes"]
 	} else {
 		msg := fmt.Sprintf("could not grab NIC link info for %s: %s", dev, err)
 		ctx.Warn(msg)
@@ -154,7 +164,7 @@ func netDeviceCapabilities(ctx *context.Context, dev string) []*NICCapability {
 		scanner.Scan()
 		for scanner.Scan() {
 			line := strings.TrimPrefix(scanner.Text(), "\t")
-			caps = append(caps, netParseEthtoolFeature(line))
+			n.Capabilities = append(n.Capabilities, netParseEthtoolFeature(line))
 		}
 
 	} else {
@@ -162,7 +172,6 @@ func netDeviceCapabilities(ctx *context.Context, dev string) []*NICCapability {
 		ctx.Warn(msg)
 	}
 
-	return caps
 
 }
 

--- a/pkg/net/net_linux.go
+++ b/pkg/net/net_linux.go
@@ -174,7 +174,6 @@ func (n *NIC) netDeviceParseEthtool(ctx *context.Context, dev string) {
 		ctx.Warn(msg)
 	}
 
-
 }
 
 // netParseEthtoolFeature parses a line from the ethtool -k output and returns
@@ -262,24 +261,6 @@ func readFile(path string) string {
 		return ""
 	}
 	return strings.TrimSpace(string(contents))
-}
-
-func (nic *NIC) setNicAttrEthtool(ctx *context.Context, dev string) error {
-	path, _ := exec.LookPath("ethtool")
-	cmd := exec.Command(path, dev)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err := cmd.Run()
-	if err != nil {
-		msg := fmt.Sprintf("could not grab NIC link info for %s: %s", dev, err)
-		ctx.Warn(msg)
-		return err
-	}
-
-	m := parseNicAttrEthtool(&out)
-	nic.updateNicAttrEthtool(m)
-
-	return nil
 }
 
 func autoNegCap(m map[string][]string) *NICCapability {

--- a/pkg/net/net_linux_test.go
+++ b/pkg/net/net_linux_test.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -143,7 +144,7 @@ func TestParseNicAttrEthtool(t *testing.T) {
 		actual.Capabilities = append(actual.Capabilities, autoNegCap(m))
 		actual.Capabilities = append(actual.Capabilities, pauseFrameUseCap(m))
 		if !reflect.DeepEqual(test.expected, actual) {
-			t.Fatalf("In test %d\nExpected:\n%+v\nActual:\n%+v\n", x, test.expected, actual)
+			t.Fatalf("In test %d\nExpected:\n%+v\nActual:\n%+v\n", x, *test.expected, *actual)
 		}
 	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -71,6 +71,9 @@ func ParseBool(str string) (bool, error) {
 			"off": false,
 			"yes": true,
 			"no":  false,
+			// Return false instead of an error on empty strings
+			// For example from empty files in SysClassNet/Device
+			"": false,
 		}
 		if b, ok := ExtraBools[strings.ToLower(str)]; ok {
 			return b, nil

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -76,6 +76,10 @@ func TestParseBool(t *testing.T) {
 			expected: true,
 		},
 		{
+			item:     "",
+			expected: false,
+		},
+		{
 			item:     "on",
 			expected: true,
 		},


### PR DESCRIPTION
Added the following to the `NIC` struct:
* `Speed`
* `Duplex`
* `SupportedLinkModes`
* `SupportedPorts`
* `SupportedFECModes`
* `AdvertisedLinkModes`
* `AdvertisedFECModes`

Refactoring PR #335 