### PR TITLE
marshal: replace `github.com/ghodss/yaml` with `gopkg.in/yaml.v2`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/jaypipes/pcidb v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.3
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	howett.net/plist v1.0.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.18
 
 require (
 	github.com/StackExchange/wmi v1.2.1
-	github.com/ghodss/yaml v1.0.0
 	github.com/jaypipes/pcidb v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.3
+	gopkg.in/yaml.v2 v2.4.0
 	howett.net/plist v1.0.0
 )
 
@@ -19,5 +19,4 @@ require (
 	github.com/spf13/pflag v1.0.2 // indirect
 	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
-github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=

--- a/go.sum
+++ b/go.sum
@@ -28,7 +28,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 howett.net/plist v1.0.0 h1:7CrbWYbPPO/PyNy38b2EB/+gYbjCe2DXBxgtOOZbSQM=
 howett.net/plist v1.0.0/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=

--- a/pkg/marshal/marshal.go
+++ b/pkg/marshal/marshal.go
@@ -9,28 +9,36 @@ package marshal
 import (
 	"encoding/json"
 
-	"github.com/ghodss/yaml"
 	"github.com/jaypipes/ghw/pkg/context"
+	"gopkg.in/yaml.v2"
 )
 
-// safeYAML returns a string after marshalling the supplied parameter into YAML
+// SafeYAML returns a string after marshalling the supplied parameter into YAML.
 func SafeYAML(ctx *context.Context, p interface{}) string {
 	b, err := json.Marshal(p)
 	if err != nil {
 		ctx.Warn("error marshalling JSON: %s", err)
 		return ""
 	}
-	yb, err := yaml.JSONToYAML(b)
-	if err != nil {
+
+	var jsonObj interface{}
+	if err := yaml.Unmarshal(b, &jsonObj); err != nil {
 		ctx.Warn("error converting JSON to YAML: %s", err)
 		return ""
 	}
+
+	yb, err := yaml.Marshal(jsonObj)
+	if err != nil {
+		ctx.Warn("error marshalling YAML: %s", err)
+		return ""
+	}
+
 	return string(yb)
 }
 
-// safeJSON returns a string after marshalling the supplied parameter into
+// SafeJSON returns a string after marshalling the supplied parameter into
 // JSON. Accepts an optional argument to trigger pretty/indented formatting of
-// the JSON string
+// the JSON string.
 func SafeJSON(ctx *context.Context, p interface{}, indent bool) string {
 	var b []byte
 	var err error

--- a/pkg/marshal/marshal.go
+++ b/pkg/marshal/marshal.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 
 	"github.com/jaypipes/ghw/pkg/context"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // SafeYAML returns a string after marshalling the supplied parameter into YAML.


### PR DESCRIPTION
Hi :wave: 

The `github.com/ghodss/yaml` package is no longer actively maintained. There are numerous inquiries about the project's status on its issue tracker: https://github.com/ghodss/yaml/issues.

Since we are only using the `JSONToYAML` from `github.com/ghodss/yaml`, we can implement the code ourselves [^1] and remove an extra dependency.

---

Alternatively, we can replace `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`, which is a permanent fork currently maintained by Kubernetes SIG. Please let me know if you prefer using a package for YAML unmarshalling, and I will gladly update this pull request.

[^1]: https://github.com/ghodss/yaml/blob/0ca9ea5df5451ffdf184b4428c902747c2c11cd7/yaml.go#L45-L61