### PR TITLE
remove deprecated fields/functions, clean up docs

### DIFF
--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -15,16 +15,9 @@ import (
 	"github.com/jaypipes/ghw/pkg/context"
 	"github.com/jaypipes/ghw/pkg/marshal"
 	"github.com/jaypipes/ghw/pkg/option"
-	pciaddr "github.com/jaypipes/ghw/pkg/pci/address"
 	"github.com/jaypipes/ghw/pkg/topology"
 	"github.com/jaypipes/ghw/pkg/util"
 )
-
-// backward compatibility, to be removed in 1.0.0
-type Address pciaddr.Address
-
-// backward compatibility, to be removed in 1.0.0
-var AddressFromString = pciaddr.FromString
 
 type Device struct {
 	// The PCI address of the device
@@ -123,22 +116,11 @@ func (d *Device) String() string {
 }
 
 type Info struct {
+	db   *pcidb.PCIDB
 	arch topology.Architecture
 	ctx  *context.Context
 	// All PCI devices on the host system
 	Devices []*Device
-	// hash of class ID -> class information
-	// DEPRECATED. Will be removed in v1.0. Please use
-	// github.com/jaypipes/pcidb to explore PCIDB information
-	Classes map[string]*pcidb.Class `json:"-"`
-	// hash of vendor ID -> vendor information
-	// DEPRECATED. Will be removed in v1.0. Please use
-	// github.com/jaypipes/pcidb to explore PCIDB information
-	Vendors map[string]*pcidb.Vendor `json:"-"`
-	// hash of vendor ID + product/device ID -> product information
-	// DEPRECATED. Will be removed in v1.0. Please use
-	// github.com/jaypipes/pcidb to explore PCIDB information
-	Products map[string]*pcidb.Product `json:"-"`
 }
 
 func (i *Info) String() string {

--- a/pkg/pci/pci_test.go
+++ b/pkg/pci/pci_test.go
@@ -27,9 +27,9 @@ func TestPCI(t *testing.T) {
 	// being tested (and we haven't built in fixtures/mocks for things yet)
 	// about all we can do is verify that the returned list of pointers to
 	// PCIDevice structs is non-empty
-	devs := info.ListDevices()
+	devs := info.Devices
 	if len(devs) == 0 {
-		t.Fatalf("Expected to find >0 PCI devices from PCIInfo.ListDevices() but got 0.")
+		t.Fatalf("Expected to find >0 PCI devices in PCIInfo.Devices but got 0.")
 	}
 
 	// Ensure that the data fields are at least populated, even if we don't yet


### PR DESCRIPTION
Mostly documentation cleanups, but this commit does remove a number of deprecated fields and functions:

* `ghw.PCIInfo.Classes` (deprecated for >1 year, use pcidb instead)
* `ghw.PCIInfo.Products` (deprecated for >1 year, use pcidb instead)
* `ghw.PCIInfo.Vendors` (deprecated for >1 year, use pcidb instead)
* `ghw.PCIInfo.ListDevices()` (deprecated for >1 year, use `ghw.PCIInfo.Devices`)
* `ghw.pkg/pci.Address` (deprecated for >1 year, just use pkg/pci/address package)
* `ghw.pkg/pci.AddressFromString()` (deprecated for >1 year, just use pkg/pci/address package)

Primary documentation changes were to move the configuration options, environment-setting instructions, serialization and snapshot stuff into an "Advanced Usage" section towards the bottom of the README and focus the main "Usage" part on the domain-specific functions like `CPU()`, `Memory()` etc.