### PR TITLE
go: chore: remove references to io/ioutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -1333,7 +1333,6 @@ package.
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/jaypipes/ghw/pkg/snapshot"
@@ -1341,7 +1340,7 @@ import (
 
 // ...
 
-scratchDir, err := ioutil.TempDir("", "ghw-snapshot-*")
+scratchDir, err := os.MkdirTemp("", "ghw-snapshot-*")
 if err != nil {
 	fmt.Printf("Error creating clone directory: %v", err)
 }

--- a/cmd/ghw-snapshot/main.go
+++ b/cmd/ghw-snapshot/main.go
@@ -13,7 +13,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -65,7 +64,7 @@ func defaultOutPath() (string, error) {
 }
 
 func execute(cmd *cobra.Command, args []string) error {
-	scratchDir, err := ioutil.TempDir("", "ghw-snapshot")
+	scratchDir, err := os.MkdirTemp("", "ghw-snapshot")
 	if err != nil {
 		return err
 	}

--- a/pkg/block/block_linux.go
+++ b/pkg/block/block_linux.go
@@ -8,7 +8,6 @@ package block
 import (
 	"bufio"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -38,7 +37,7 @@ func diskPhysicalBlockSizeBytes(paths *linuxpath.Paths, disk string) uint64 {
 	// We can find the sector size in Linux by looking at the
 	// /sys/block/$DEVICE/queue/physical_block_size file in sysfs
 	path := filepath.Join(paths.SysBlock, disk, "queue", "physical_block_size")
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return 0
 	}
@@ -53,7 +52,7 @@ func diskSizeBytes(paths *linuxpath.Paths, disk string) uint64 {
 	// We can find the number of 512-byte sectors by examining the contents of
 	// /sys/block/$DEVICE/size and calculate the physical bytes accordingly.
 	path := filepath.Join(paths.SysBlock, disk, "size")
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return 0
 	}
@@ -70,7 +69,7 @@ func diskNUMANodeID(paths *linuxpath.Paths, disk string) int {
 		return -1
 	}
 	for partial := link; strings.HasPrefix(partial, "../devices/"); partial = filepath.Base(partial) {
-		if nodeContents, err := ioutil.ReadFile(filepath.Join(paths.SysBlock, partial, "numa_node")); err != nil {
+		if nodeContents, err := os.ReadFile(filepath.Join(paths.SysBlock, partial, "numa_node")); err != nil {
 			if nodeInt, err := strconv.Atoi(string(nodeContents)); err != nil {
 				return nodeInt
 			}
@@ -83,7 +82,7 @@ func diskVendor(paths *linuxpath.Paths, disk string) string {
 	// In Linux, the vendor for a disk device is found in the
 	// /sys/block/$DEVICE/device/vendor file in sysfs
 	path := filepath.Join(paths.SysBlock, disk, "device", "vendor")
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return util.UNKNOWN
 	}
@@ -93,7 +92,7 @@ func diskVendor(paths *linuxpath.Paths, disk string) string {
 // udevInfoDisk gets the udev info for a disk
 func udevInfoDisk(paths *linuxpath.Paths, disk string) (map[string]string, error) {
 	// Get device major:minor numbers
-	devNo, err := ioutil.ReadFile(filepath.Join(paths.SysBlock, disk, "dev"))
+	devNo, err := os.ReadFile(filepath.Join(paths.SysBlock, disk, "dev"))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +102,7 @@ func udevInfoDisk(paths *linuxpath.Paths, disk string) (map[string]string, error
 // udevInfoPartition gets the udev info for a partition
 func udevInfoPartition(paths *linuxpath.Paths, disk string, partition string) (map[string]string, error) {
 	// Get device major:minor numbers
-	devNo, err := ioutil.ReadFile(filepath.Join(paths.SysBlock, disk, partition, "dev"))
+	devNo, err := os.ReadFile(filepath.Join(paths.SysBlock, disk, partition, "dev"))
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +112,7 @@ func udevInfoPartition(paths *linuxpath.Paths, disk string, partition string) (m
 func udevInfo(paths *linuxpath.Paths, devNo string) (map[string]string, error) {
 	// Look up block device in udev runtime database
 	udevID := "b" + strings.TrimSpace(devNo)
-	udevBytes, err := ioutil.ReadFile(filepath.Join(paths.RunUdevData, udevID))
+	udevBytes, err := os.ReadFile(filepath.Join(paths.RunUdevData, udevID))
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +195,7 @@ func diskWWN(paths *linuxpath.Paths, disk string) string {
 func diskPartitions(ctx *context.Context, paths *linuxpath.Paths, disk string) []*Partition {
 	out := make([]*Partition, 0)
 	path := filepath.Join(paths.SysBlock, disk)
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		ctx.Warn("failed to read disk partitions: %s\n", err)
 		return out
@@ -281,7 +280,7 @@ func diskPartUUID(paths *linuxpath.Paths, disk string, partition string) string 
 
 func diskIsRemovable(paths *linuxpath.Paths, disk string) bool {
 	path := filepath.Join(paths.SysBlock, disk, "removable")
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return false
 	}
@@ -295,7 +294,7 @@ func disks(ctx *context.Context, paths *linuxpath.Paths) []*Disk {
 	// run. We can get all of this information by examining the /sys/block
 	// and /sys/class/block files
 	disks := make([]*Disk, 0)
-	files, err := ioutil.ReadDir(paths.SysBlock)
+	files, err := os.ReadDir(paths.SysBlock)
 	if err != nil {
 		return nil
 	}
@@ -403,7 +402,7 @@ func diskIsRotational(ctx *context.Context, paths *linuxpath.Paths, devName stri
 // paths.
 func partitionSizeBytes(paths *linuxpath.Paths, disk string, part string) uint64 {
 	path := filepath.Join(paths.SysBlock, disk, part, "size")
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return 0
 	}

--- a/pkg/block/block_linux_test.go
+++ b/pkg/block/block_linux_test.go
@@ -11,7 +11,6 @@ package block
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -199,7 +198,7 @@ func TestDiskPartLabel(t *testing.T) {
 	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_BLOCK"); ok {
 		t.Skip("Skipping block tests.")
 	}
-	baseDir, _ := ioutil.TempDir("", "test")
+	baseDir, _ := os.MkdirTemp("", "test")
 	defer os.RemoveAll(baseDir)
 	ctx := context.New()
 	ctx.Chroot = baseDir
@@ -212,8 +211,8 @@ func TestDiskPartLabel(t *testing.T) {
 	// Emulate a disk with one partition with label TEST_LABEL_GHW
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda"), 0755)
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda", "sda1"), 0755)
-	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, "sda", "sda1", "dev"), []byte("259:0\n"), 0644)
-	_ = ioutil.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(fmt.Sprintf("E:ID_PART_ENTRY_NAME=%s\n", partLabel)), 0644)
+	_ = os.WriteFile(filepath.Join(paths.SysBlock, "sda", "sda1", "dev"), []byte("259:0\n"), 0644)
+	_ = os.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(fmt.Sprintf("E:ID_PART_ENTRY_NAME=%s\n", partLabel)), 0644)
 	label := diskPartLabel(paths, "sda", "sda1")
 	if label != partLabel {
 		t.Fatalf("Got label %s but expected %s", label, partLabel)
@@ -230,7 +229,7 @@ func TestDiskFSLabel(t *testing.T) {
 	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_BLOCK"); ok {
 		t.Skip("Skipping block tests.")
 	}
-	baseDir, _ := ioutil.TempDir("", "test")
+	baseDir, _ := os.MkdirTemp("", "test")
 	defer os.RemoveAll(baseDir)
 	ctx := context.New()
 	ctx.Chroot = baseDir
@@ -243,8 +242,8 @@ func TestDiskFSLabel(t *testing.T) {
 	// Emulate a disk with one partition with label TEST_LABEL_GHW
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda"), 0755)
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda", "sda1"), 0755)
-	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, "sda", "sda1", "dev"), []byte("259:0\n"), 0644)
-	_ = ioutil.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(fmt.Sprintf("E:ID_FS_LABEL=%s\n", fsLabel)), 0644)
+	_ = os.WriteFile(filepath.Join(paths.SysBlock, "sda", "sda1", "dev"), []byte("259:0\n"), 0644)
+	_ = os.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(fmt.Sprintf("E:ID_FS_LABEL=%s\n", fsLabel)), 0644)
 	label := diskFSLabel(paths, "sda", "sda1")
 	if label != fsLabel {
 		t.Fatalf("Got label %s but expected %s", label, fsLabel)
@@ -261,7 +260,7 @@ func TestDiskTypeUdev(t *testing.T) {
 	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_BLOCK"); ok {
 		t.Skip("Skipping block tests.")
 	}
-	baseDir, _ := ioutil.TempDir("", "test")
+	baseDir, _ := os.MkdirTemp("", "test")
 	defer os.RemoveAll(baseDir)
 	ctx := context.New()
 	ctx.Chroot = baseDir
@@ -274,8 +273,8 @@ func TestDiskTypeUdev(t *testing.T) {
 	// Emulate a disk with one partition with label TEST_LABEL_GHW
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda"), 0755)
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda", "sda1"), 0755)
-	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, "sda", "sda1", "dev"), []byte("259:0\n"), 0644)
-	_ = ioutil.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(fmt.Sprintf("E:ID_FS_TYPE=%s\n", expectedPartType)), 0644)
+	_ = os.WriteFile(filepath.Join(paths.SysBlock, "sda", "sda1", "dev"), []byte("259:0\n"), 0644)
+	_ = os.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(fmt.Sprintf("E:ID_FS_TYPE=%s\n", expectedPartType)), 0644)
 	pt := diskPartTypeUdev(paths, "sda", "sda1")
 	if pt != expectedPartType {
 		t.Fatalf("Got partition type %s but expected %s", pt, expectedPartType)
@@ -292,7 +291,7 @@ func TestDiskPartUUID(t *testing.T) {
 	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_BLOCK"); ok {
 		t.Skip("Skipping block tests.")
 	}
-	baseDir, _ := ioutil.TempDir("", "test")
+	baseDir, _ := os.MkdirTemp("", "test")
 	defer os.RemoveAll(baseDir)
 	ctx := context.New()
 	ctx.Chroot = baseDir
@@ -305,8 +304,8 @@ func TestDiskPartUUID(t *testing.T) {
 	// Emulate a disk with one partition with uuid
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda"), 0755)
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, "sda", "sda1"), 0755)
-	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, "sda", "sda1", "dev"), []byte("259:0\n"), 0644)
-	_ = ioutil.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(fmt.Sprintf("E:ID_PART_ENTRY_UUID=%s\n", partUUID)), 0644)
+	_ = os.WriteFile(filepath.Join(paths.SysBlock, "sda", "sda1", "dev"), []byte("259:0\n"), 0644)
+	_ = os.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(fmt.Sprintf("E:ID_PART_ENTRY_UUID=%s\n", partUUID)), 0644)
 	uuid := diskPartUUID(paths, "sda", "sda1")
 	if uuid != partUUID {
 		t.Fatalf("Got uuid %s but expected %s", uuid, partUUID)
@@ -324,7 +323,7 @@ func TestLoopDevicesWithOption(t *testing.T) {
 	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_BLOCK"); ok {
 		t.Skip("Skipping block tests.")
 	}
-	baseDir, _ := ioutil.TempDir("", "test")
+	baseDir, _ := os.MkdirTemp("", "test")
 	defer os.RemoveAll(baseDir)
 	ctx := context.New(option.WithNullAlerter(), option.WithDisableTools())
 	ctx.Chroot = baseDir
@@ -342,13 +341,13 @@ func TestLoopDevicesWithOption(t *testing.T) {
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, loopNotUsed), 0755)
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, expectedLoopName, "queue"), 0755)
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, loopNotUsed, "queue"), 0755)
-	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, expectedLoopName, "queue", "rotational"), []byte("1\n"), 0644)
-	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, expectedLoopName, "size"), []byte("62810112\n"), 0644)
-	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, loopNotUsed, "size"), []byte("0\n"), 0644)
+	_ = os.WriteFile(filepath.Join(paths.SysBlock, expectedLoopName, "queue", "rotational"), []byte("1\n"), 0644)
+	_ = os.WriteFile(filepath.Join(paths.SysBlock, expectedLoopName, "size"), []byte("62810112\n"), 0644)
+	_ = os.WriteFile(filepath.Join(paths.SysBlock, loopNotUsed, "size"), []byte("0\n"), 0644)
 	_ = os.Mkdir(filepath.Join(paths.SysBlock, expectedLoopName, loopPartitionName), 0755)
-	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, expectedLoopName, loopPartitionName, "dev"), []byte("259:0\n"), 0644)
-	_ = ioutil.WriteFile(filepath.Join(paths.SysBlock, expectedLoopName, loopPartitionName, "size"), []byte("102400\n"), 0644)
-	_ = ioutil.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(fmt.Sprintf("E:ID_FS_TYPE=%s\n", fsType)), 0644)
+	_ = os.WriteFile(filepath.Join(paths.SysBlock, expectedLoopName, loopPartitionName, "dev"), []byte("259:0\n"), 0644)
+	_ = os.WriteFile(filepath.Join(paths.SysBlock, expectedLoopName, loopPartitionName, "size"), []byte("102400\n"), 0644)
+	_ = os.WriteFile(filepath.Join(paths.RunUdevData, "b259:0"), []byte(fmt.Sprintf("E:ID_FS_TYPE=%s\n", fsType)), 0644)
 	d := disks(ctx, paths)
 	// There should be one disk, the other should be ignored due to 0 size
 	if len(d) != 1 {

--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -8,7 +8,6 @@ package block_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -112,7 +111,7 @@ func TestBlockUnmarshal(t *testing.T) {
 		t.Fatalf("Expected nil err when detecting the samples directory, but got %v", err)
 	}
 
-	data, err := ioutil.ReadFile(filepath.Join(testdataPath, "dell-r610-block.json"))
+	data, err := os.ReadFile(filepath.Join(testdataPath, "dell-r610-block.json"))
 	if err != nil {
 		t.Fatalf("Expected nil err when reading the sample data, but got %v", err)
 	}

--- a/pkg/cpu/cpu_linux.go
+++ b/pkg/cpu/cpu_linux.go
@@ -8,7 +8,6 @@ package cpu
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -47,7 +46,7 @@ func processorsGet(ctx *context.Context) []*Processor {
 	// /sys/devices/system/cpu pseudodir contains N number of pseudodirs with
 	// information about the logical processors on the host. These logical
 	// processor pseudodirs are of the pattern /sys/devices/system/cpu/cpu{N}
-	fnames, err := ioutil.ReadDir(paths.SysDevicesSystemCPU)
+	fnames, err := os.ReadDir(paths.SysDevicesSystemCPU)
 	if err != nil {
 		ctx.Warn("failed to read /sys/devices/system/cpu: %s", err)
 		return []*Processor{}
@@ -172,7 +171,7 @@ func CoresForNode(ctx *context.Context, nodeID int) ([]*ProcessorCore, error) {
 		return c
 	}
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gpu/gpu_linux.go
+++ b/pkg/gpu/gpu_linux.go
@@ -6,7 +6,6 @@
 package gpu
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -55,7 +54,7 @@ func (i *Info) load() error {
 	// subsystem (we query the modalias file of the PCI device's sysfs
 	// directory using the `ghw.PCIInfo.GetDevice()` function.
 	paths := linuxpath.New(i.ctx)
-	links, err := ioutil.ReadDir(paths.SysClassDRM)
+	links, err := os.ReadDir(paths.SysClassDRM)
 	if err != nil {
 		i.ctx.Warn(_WARN_NO_SYS_CLASS_DRM)
 		return nil

--- a/pkg/gpu/gpu_linux_test.go
+++ b/pkg/gpu/gpu_linux_test.go
@@ -8,7 +8,6 @@ package gpu_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +38,7 @@ func TestGPUWithoutNUMANodeInfo(t *testing.T) {
 	// snapshot to fully understand this test. Inspect it using
 	// GHW_SNAPSHOT_PATH="/path/to/linux-amd64-amd-ryzen-1600.tar.gz" ghwc gpu
 
-	tmpRoot, err := ioutil.TempDir("", "ghw-gpu-testing-*")
+	tmpRoot, err := os.MkdirTemp("", "ghw-gpu-testing-*")
 	if err != nil {
 		t.Fatalf("Unable to create temporary directory: %v", err)
 	}

--- a/pkg/linuxdmi/dmi_linux.go
+++ b/pkg/linuxdmi/dmi_linux.go
@@ -6,7 +6,7 @@
 package linuxdmi
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -19,7 +19,7 @@ func Item(ctx *context.Context, value string) string {
 	paths := linuxpath.New(ctx)
 	path := filepath.Join(paths.SysClassDMI, "id", value)
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		ctx.Warn("Unable to read %s: %s\n", value, err)
 		return util.UNKNOWN

--- a/pkg/memory/memory_cache_linux.go
+++ b/pkg/memory/memory_cache_linux.go
@@ -8,7 +8,6 @@ package memory
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -35,7 +34,7 @@ func CachesForNode(ctx *context.Context, nodeID int) ([]*Cache, error) {
 	)
 	caches := make(map[string]*Cache)
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +65,7 @@ func CachesForNode(ctx *context.Context, nodeID int) ([]*Cache, error) {
 		if _, err = os.Stat(cachePath); errors.Is(err, os.ErrNotExist) {
 			continue
 		}
-		cacheDirFiles, err := ioutil.ReadDir(cachePath)
+		cacheDirFiles, err := os.ReadDir(cachePath)
 		if err != nil {
 			return nil, err
 		}
@@ -120,7 +119,7 @@ func memoryCacheLevel(ctx *context.Context, paths *linuxpath.Paths, nodeID int, 
 		paths.NodeCPUCacheIndex(nodeID, lpID, cacheIndex),
 		"level",
 	)
-	levelContents, err := ioutil.ReadFile(levelPath)
+	levelContents, err := os.ReadFile(levelPath)
 	if err != nil {
 		ctx.Warn("%s", err)
 		return -1
@@ -140,7 +139,7 @@ func memoryCacheSize(ctx *context.Context, paths *linuxpath.Paths, nodeID int, l
 		paths.NodeCPUCacheIndex(nodeID, lpID, cacheIndex),
 		"size",
 	)
-	sizeContents, err := ioutil.ReadFile(sizePath)
+	sizeContents, err := os.ReadFile(sizePath)
 	if err != nil {
 		ctx.Warn("%s", err)
 		return -1
@@ -159,7 +158,7 @@ func memoryCacheType(ctx *context.Context, paths *linuxpath.Paths, nodeID int, l
 		paths.NodeCPUCacheIndex(nodeID, lpID, cacheIndex),
 		"type",
 	)
-	cacheTypeContents, err := ioutil.ReadFile(typePath)
+	cacheTypeContents, err := os.ReadFile(typePath)
 	if err != nil {
 		ctx.Warn("%s", err)
 		return CACHE_TYPE_UNIFIED
@@ -179,7 +178,7 @@ func memoryCacheSharedCPUMap(ctx *context.Context, paths *linuxpath.Paths, nodeI
 		paths.NodeCPUCacheIndex(nodeID, lpID, cacheIndex),
 		"shared_cpu_map",
 	)
-	sharedCpuMap, err := ioutil.ReadFile(scpuPath)
+	sharedCpuMap, err := os.ReadFile(scpuPath)
 	if err != nil {
 		ctx.Warn("%s", err)
 		return ""

--- a/pkg/memory/memory_linux.go
+++ b/pkg/memory/memory_linux.go
@@ -10,7 +10,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -111,7 +110,7 @@ func memoryBlockSizeBytes(dir string) (uint64, error) {
 	// get the memory block size in byte in hexadecimal notation
 	blockSize := filepath.Join(dir, "block_size_bytes")
 
-	d, err := ioutil.ReadFile(blockSize)
+	d, err := os.ReadFile(blockSize)
 	if err != nil {
 		return 0, err
 	}
@@ -149,7 +148,7 @@ func memTotalPhysicalBytes(paths *linuxpath.Paths) (total int64) {
 // size in bytes
 func memoryTotalPhysicalBytesFromPath(dir string, blockSizeBytes uint64) (int64, error) {
 	var total int64
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return -1, err
 	}
@@ -165,7 +164,7 @@ func memoryTotalPhysicalBytesFromPath(dir string, blockSizeBytes uint64) (int64,
 		if !regexMemoryBlockDirname.MatchString(fname) {
 			continue
 		}
-		s, err := ioutil.ReadFile(filepath.Join(dir, fname, "state"))
+		s, err := os.ReadFile(filepath.Join(dir, fname, "state"))
 		if err != nil {
 			return -1, err
 		}
@@ -202,7 +201,7 @@ func memTotalPhysicalBytesFromSyslog(paths *linuxpath.Paths) int64 {
 	// search each, stopping when we match a system log record line that
 	// contains physical memory information.
 	logDir := paths.VarLog
-	logFiles, err := ioutil.ReadDir(logDir)
+	logFiles, err := os.ReadDir(logDir)
 	if err != nil {
 		return -1
 	}
@@ -304,7 +303,7 @@ func memorySupportedPageSizes(hpDir string) ([]uint64, error) {
 	// 'hugepages-{pagesize}kb'
 	out := make([]uint64, 0)
 
-	files, err := ioutil.ReadDir(hpDir)
+	files, err := os.ReadDir(hpDir)
 	if err != nil {
 		return out, err
 	}

--- a/pkg/net/net_linux.go
+++ b/pkg/net/net_linux.go
@@ -9,7 +9,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,7 +32,7 @@ func nics(ctx *context.Context) []*NIC {
 	nics := make([]*NIC, 0)
 
 	paths := linuxpath.New(ctx)
-	files, err := ioutil.ReadDir(paths.SysClassNet)
+	files, err := os.ReadDir(paths.SysClassNet)
 	if err != nil {
 		return nics
 	}
@@ -88,7 +87,7 @@ func netDeviceMacAddress(paths *linuxpath.Paths, dev string) string {
 	// that have addr_assign_type != 0, return None since the MAC address is
 	// random.
 	aatPath := filepath.Join(paths.SysClassNet, dev, "addr_assign_type")
-	contents, err := ioutil.ReadFile(aatPath)
+	contents, err := os.ReadFile(aatPath)
 	if err != nil {
 		return ""
 	}
@@ -96,7 +95,7 @@ func netDeviceMacAddress(paths *linuxpath.Paths, dev string) string {
 		return ""
 	}
 	addrPath := filepath.Join(paths.SysClassNet, dev, "address")
-	contents, err = ioutil.ReadFile(addrPath)
+	contents, err = os.ReadFile(addrPath)
 	if err != nil {
 		return ""
 	}
@@ -256,7 +255,7 @@ func (nic *NIC) setNicAttrSysFs(paths *linuxpath.Paths, dev string) {
 }
 
 func readFile(path string) string {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return ""
 	}

--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -8,7 +8,6 @@ package option
 
 import (
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 )
@@ -35,7 +34,7 @@ type Alerter interface {
 }
 
 var (
-	NullAlerter = log.New(ioutil.Discard, "", 0)
+	NullAlerter = log.New(io.Discard, "", 0)
 )
 
 // EnvOrDefaultAlerter returns the default instance ghw will use to emit
@@ -45,7 +44,7 @@ var (
 func EnvOrDefaultAlerter() Alerter {
 	var dest io.Writer
 	if _, exists := os.LookupEnv(envKeyDisableWarnings); exists {
-		dest = ioutil.Discard
+		dest = io.Discard
 	} else {
 		// default
 		dest = os.Stderr

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -6,7 +6,6 @@
 package pci
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,7 +68,7 @@ func getDeviceRevision(ctx *context.Context, pciAddr *pciaddr.Address) string {
 	if _, err := os.Stat(revisionPath); err != nil {
 		return ""
 	}
-	revision, err := ioutil.ReadFile(revisionPath)
+	revision, err := os.ReadFile(revisionPath)
 	if err != nil {
 		return ""
 	}
@@ -123,7 +122,7 @@ func parseModaliasFile(fp string) *deviceModaliasInfo {
 	if _, err := os.Stat(fp); err != nil {
 		return nil
 	}
-	data, err := ioutil.ReadFile(fp)
+	data, err := os.ReadFile(fp)
 	if err != nil {
 		return nil
 	}
@@ -394,7 +393,7 @@ func (info *Info) getDevices() []*Device {
 	// of symlinks. The names of the symlinks are all the known PCI addresses
 	// for the host. For each address, we grab a *Device matching the
 	// address and append to the returned array.
-	links, err := ioutil.ReadDir(paths.SysBusPciDevices)
+	links, err := os.ReadDir(paths.SysBusPciDevices)
 	if err != nil {
 		info.ctx.Warn("failed to read /sys/bus/pci/devices")
 		return nil

--- a/pkg/snapshot/clonetree.go
+++ b/pkg/snapshot/clonetree.go
@@ -8,7 +8,6 @@ package snapshot
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -182,7 +181,7 @@ func copyLink(path, targetPath string) error {
 }
 
 func copyPseudoFile(path, targetPath string) error {
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/pkg/snapshot/clonetree_block_linux.go
+++ b/pkg/snapshot/clonetree_block_linux.go
@@ -8,7 +8,6 @@ package snapshot
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,7 +17,7 @@ func createBlockDevices(buildDir string) error {
 	// Grab all the block device pseudo-directories from /sys/block symlinks
 	// (excluding loopback devices) and inject them into our build filesystem
 	// with all but the circular symlink'd subsystem directories
-	devLinks, err := ioutil.ReadDir("/sys/block")
+	devLinks, err := os.ReadDir("/sys/block")
 	if err != nil {
 		return err
 	}
@@ -78,7 +77,7 @@ func createBlockDeviceDir(buildDeviceDir string, srcDeviceDir string) error {
 	// Populate the supplied directory (in our build filesystem) with all the
 	// appropriate information pseudofile contents for the block device.
 	devName := filepath.Base(srcDeviceDir)
-	devFiles, err := ioutil.ReadDir(srcDeviceDir)
+	devFiles, err := os.ReadDir(srcDeviceDir)
 	if err != nil {
 		return err
 	}
@@ -119,7 +118,7 @@ func createBlockDeviceDir(buildDeviceDir string, srcDeviceDir string) error {
 			// Regular files in the block device directory are both regular and
 			// pseudofiles containing information such as the size (in sectors)
 			// and whether the device is read-only
-			buf, err := ioutil.ReadFile(fp)
+			buf, err := os.ReadFile(fp)
 			if err != nil {
 				if errors.Is(err, os.ErrPermission) {
 					// example: /sys/devices/virtual/block/zram0/compact is 0400
@@ -156,7 +155,7 @@ func createBlockDeviceDir(buildDeviceDir string, srcDeviceDir string) error {
 		return err
 	}
 	fp := filepath.Join(srcQueueDir, "rotational")
-	buf, err := ioutil.ReadFile(fp)
+	buf, err := os.ReadFile(fp)
 	if err != nil {
 		return err
 	}
@@ -177,7 +176,7 @@ func createBlockDeviceDir(buildDeviceDir string, srcDeviceDir string) error {
 func createPartitionDir(buildPartitionDir string, srcPartitionDir string) error {
 	// Populate the supplied directory (in our build filesystem) with all the
 	// appropriate information pseudofile contents for the partition.
-	partFiles, err := ioutil.ReadDir(srcPartitionDir)
+	partFiles, err := os.ReadDir(srcPartitionDir)
 	if err != nil {
 		return err
 	}
@@ -201,7 +200,7 @@ func createPartitionDir(buildPartitionDir string, srcPartitionDir string) error 
 			// Regular files in the block device directory are both regular and
 			// pseudofiles containing information such as the size (in sectors)
 			// and whether the device is read-only
-			buf, err := ioutil.ReadFile(fp)
+			buf, err := os.ReadFile(fp)
 			if err != nil {
 				return err
 			}

--- a/pkg/snapshot/clonetree_linux.go
+++ b/pkg/snapshot/clonetree_linux.go
@@ -7,7 +7,6 @@
 package snapshot
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -67,7 +66,7 @@ func cloneContentByClass(devClass string, subEntries []string, filterName filter
 	// warning: don't use the context package here, this means not even the linuxpath package.
 	// TODO(fromani) remove the path duplication
 	sysClass := filepath.Join("sys", "class", devClass)
-	entries, err := ioutil.ReadDir(sysClass)
+	entries, err := os.ReadDir(sysClass)
 	if err != nil {
 		// we should not import context, hence we can't Warn()
 		return fileSpecs

--- a/pkg/snapshot/clonetree_linux_test.go
+++ b/pkg/snapshot/clonetree_linux_test.go
@@ -7,7 +7,6 @@
 package snapshot_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -30,7 +29,7 @@ func TestCloneTree(t *testing.T) {
 	}
 	defer os.RemoveAll(root)
 
-	cloneRoot, err := ioutil.TempDir("", "ghw-test-clonetree-*")
+	cloneRoot, err := os.MkdirTemp("", "ghw-test-clonetree-*")
 	if err != nil {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}
@@ -74,7 +73,7 @@ func TestCloneSystemTree(t *testing.T) {
 	// sensible. To really do a meaningful test we need a more advanced functional test, starting with from
 	// a ghw snapshot.
 
-	cloneRoot, err := ioutil.TempDir("", "ghw-test-clonetree-*")
+	cloneRoot, err := os.MkdirTemp("", "ghw-test-clonetree-*")
 	if err != nil {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}

--- a/pkg/snapshot/clonetree_pci_linux.go
+++ b/pkg/snapshot/clonetree_pci_linux.go
@@ -8,7 +8,6 @@ package snapshot
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -70,7 +69,7 @@ func scanPCIDeviceRoot(root string) (fileSpecs []string, pciRoots []string) {
 		"revision",
 		"vendor",
 	}
-	entries, err := ioutil.ReadDir(root)
+	entries, err := os.ReadDir(root)
 	if err != nil {
 		return []string{}, []string{}
 	}
@@ -124,7 +123,7 @@ func findPCIEntryFromPath(root, entryName string) (string, error) {
 }
 
 func isPCIBridge(entryPath string) bool {
-	subNodes, err := ioutil.ReadDir(entryPath)
+	subNodes, err := os.ReadDir(entryPath)
 	if err != nil {
 		// this is so unlikely we don't even return error. But we trace just in case.
 		trace("error scanning device entry path %q: %v", entryPath, err)

--- a/pkg/snapshot/pack_test.go
+++ b/pkg/snapshot/pack_test.go
@@ -7,7 +7,6 @@
 package snapshot_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -26,7 +25,7 @@ func TestPackUnpack(t *testing.T) {
 	}
 	defer os.RemoveAll(root)
 
-	tmpfile, err := ioutil.TempFile("", "ght-test-snapshot-*.tgz")
+	tmpfile, err := os.CreateTemp("", "ght-test-snapshot-*.tgz")
 	if err != nil {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}

--- a/pkg/snapshot/unpack.go
+++ b/pkg/snapshot/unpack.go
@@ -10,7 +10,6 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -39,7 +38,7 @@ func Cleanup(targetRoot string) error {
 
 // Unpack expands the given snapshot in a temporary directory managed by `ghw`. Returns the path of that directory.
 func Unpack(snapshotName string) (string, error) {
-	targetRoot, err := ioutil.TempDir("", TargetRoot)
+	targetRoot, err := os.MkdirTemp("", TargetRoot)
 	if err != nil {
 		return "", err
 	}
@@ -121,7 +120,7 @@ func Untar(root string, r io.Reader) error {
 }
 
 func isEmptyDir(name string) bool {
-	entries, err := ioutil.ReadDir(name)
+	entries, err := os.ReadDir(name)
 	if err != nil {
 		return false
 	}

--- a/pkg/snapshot/unpack_test.go
+++ b/pkg/snapshot/unpack_test.go
@@ -8,7 +8,6 @@ package snapshot_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,7 +40,7 @@ func TestUnpack(t *testing.T) {
 
 // nolint: gocyclo
 func TestUnpackInto(t *testing.T) {
-	testRoot, err := ioutil.TempDir("", "ghw-test-snapshot-*")
+	testRoot, err := os.MkdirTemp("", "ghw-test-snapshot-*")
 	if err != nil {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}
@@ -68,12 +67,12 @@ func TestUnpackInto(t *testing.T) {
 
 // nolint: gocyclo
 func TestUnpackIntoPresrving(t *testing.T) {
-	testRoot, err := ioutil.TempDir("", "ghw-test-snapshot-*")
+	testRoot, err := os.MkdirTemp("", "ghw-test-snapshot-*")
 	if err != nil {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}
 
-	err = ioutil.WriteFile(filepath.Join(testRoot, "canary"), []byte(""), 0644)
+	err = os.WriteFile(filepath.Join(testRoot, "canary"), []byte(""), 0644)
 	if err != nil {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}
@@ -83,7 +82,7 @@ func TestUnpackIntoPresrving(t *testing.T) {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}
 
-	entries, err := ioutil.ReadDir(testRoot)
+	entries, err := os.ReadDir(testRoot)
 	if err != nil {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}
@@ -117,7 +116,7 @@ func verifyTestData(t *testing.T, root string) {
 }
 
 func verifyFileContent(t *testing.T, path, expected string) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}

--- a/pkg/topology/topology_linux.go
+++ b/pkg/topology/topology_linux.go
@@ -7,7 +7,7 @@ package topology
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -32,7 +32,7 @@ func topologyNodes(ctx *context.Context) []*Node {
 	paths := linuxpath.New(ctx)
 	nodes := make([]*Node, 0)
 
-	files, err := ioutil.ReadDir(paths.SysDevicesSystemNode)
+	files, err := os.ReadDir(paths.SysDevicesSystemNode)
 	if err != nil {
 		ctx.Warn("failed to determine nodes: %s\n", err)
 		return nodes
@@ -89,7 +89,7 @@ func distancesForNode(ctx *context.Context, nodeID int) ([]int, error) {
 		"distance",
 	)
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -8,7 +8,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -37,7 +36,7 @@ func SafeClose(c closer) {
 // message is printed to STDERR and -1 is returned.
 func SafeIntFromFile(ctx *context.Context, path string) int {
 	msg := "failed to read int from file: %s\n"
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		ctx.Warn(msg, err)
 		return -1


### PR DESCRIPTION
Don't use anymore long-reprecated functions,
switching to recommended alternatives.
No intended changes in behavior.

Fixes lint issues post merging of #350 : https://github.com/jaypipes/ghw/actions/runs/5619500764