### PR TITLE
doc and const cleanup for cpu, block, memory, and net packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ Each `ghw.Processor` struct contains a number of fields:
   package
 * `ghw.Processor.Vendor` is a string containing the vendor name
 * `ghw.Processor.Model` is a string containing the vendor's model name
-* `ghw.Processor.Capabilities` is an array of strings indicating the features
-  the processor has enabled
-* `ghw.Processor.Cores` is an array of `ghw.ProcessorCore` structs that are
-  packed onto this physical processor
+* `ghw.Processor.Capabilities` (Linux only) is an array of strings indicating
+  the features the processor has enabled
+* `ghw.Processor.Cores` (Linux only) is an array of `ghw.ProcessorCore` structs
+  that are packed onto this physical processor
 
 A `ghw.ProcessorCore` has the following fields:
 

--- a/README.md
+++ b/README.md
@@ -524,30 +524,32 @@ The `ghw.NetworkInfo` struct contains one field:
 Each `ghw.NIC` struct contains the following fields:
 
 * `ghw.NIC.Name` is the system's identifier for the NIC
-* `ghw.NIC.MacAddress` is the MAC address for the NIC, if any
+* `ghw.NIC.MACAddress` is the Media Access Control (MAC) address for the NIC,
+  if any
 * `ghw.NIC.IsVirtual` is a boolean indicating if the NIC is a virtualized
   device
-* `ghw.NIC.Capabilities` is an array of pointers to `ghw.NICCapability` structs
-  that can describe the things the NIC supports. These capabilities match the
-  returned values from the `ethtool -k <DEVICE>` call on Linux as well as the 
-  AutoNegotiation and PauseFrameUse capabilities from `ethtool`.
-* `ghw.NIC.PCIAddress` is the PCI device address of the device backing the NIC.
-  this is not-nil only if the backing device is indeed a PCI device; more backing
-  devices (e.g. USB) will be added in future versions.
-* `ghw.NIC.Speed` is a string showing the current link speed.  On Linux, this 
-  field will be present even if `ethtool` is not available.
-* `ghw.NIC.Duplex` is a string showing the current link duplex. On Linux, this 
-  field will be present even if `ethtool` is not available.
-* `ghw.NIC.SupportedLinkModes` is a string slice containing a list of
-  supported link modes
-* `ghw.NIC.SupportedPorts` is a string slice containing the list of 
-  supported port types (MII, TP, FIBRE)
-* `ghw.NIC.SupportedFECModes` is a string slice containing a list of 
-  supported FEC Modes.
-* `ghw.NIC.AdvertisedLinkModes` is a string slice containing the
+* `ghw.NIC.Capabilities` (Linux only) is an array of pointers to
+  `ghw.NICCapability` structs that can describe the things the NIC supports.
+  These capabilities match the returned values from the `ethtool -k <DEVICE>`
+  call on Linux as well as the AutoNegotiation and PauseFrameUse capabilities
+  from `ethtool`.
+* `ghw.NIC.PCIAddress` (Linux only) is the PCI device address of the device
+  backing the NIC.  this is not-nil only if the backing device is indeed a PCI
+  device; more backing devices (e.g. USB) will be added in future versions.
+* `ghw.NIC.Speed` (Linux only) is a string showing the current link speed.  On
+  Linux, this field will be present even if `ethtool` is not available.
+* `ghw.NIC.Duplex` (Linux only) is a string showing the current link duplex. On
+  Linux, this field will be present even if `ethtool` is not available.
+* `ghw.NIC.SupportedLinkModes` (Linux only) is a string slice containing a list
+  of supported link modes, e.g. "10baseT/Half", "1000baseT/Full".
+* `ghw.NIC.SupportedPorts` (Linux only) is a string slice containing the list
+  of supported port types, e.g. "MII", "TP", "FIBRE", "Twisted Pair".
+* `ghw.NIC.SupportedFECModes` (Linux only) is a string slice containing a list
+  of supported Forward Error Correction (FEC) Modes.
+* `ghw.NIC.AdvertisedLinkModes` (Linux only) is a string slice containing the
   link modes being advertised during auto negotiation.
-* `ghw.NIC.AdvertisedFECModes` is a string slice containing the FEC
-  modes advertised during auto negotiation.
+* `ghw.NIC.AdvertisedFECModes` (Linux only) is a string slice containing the
+  Forward Error Correction (FEC) modes advertised during auto negotiation.
 
 The `ghw.NICCapability` struct contains the following fields:
 

--- a/README.md
+++ b/README.md
@@ -288,8 +288,8 @@ information about the block storage on the host system.
 
 `ghw.BlockInfo` contains the following fields:
 
-* `ghw.BlockInfo.TotalPhysicalBytes` contains the amount of physical block
-  storage on the host
+* `ghw.BlockInfo.TotalSizeBytes` contains the amount of physical block storage
+  on the host.
 * `ghw.BlockInfo.Disks` is an array of pointers to `ghw.Disk` structs, one for
   each disk found by the system
 
@@ -298,7 +298,8 @@ Each `ghw.Disk` struct contains the following fields:
 * `ghw.Disk.Name` contains a string with the short name of the disk, e.g. "sda"
 * `ghw.Disk.SizeBytes` contains the amount of storage the disk provides
 * `ghw.Disk.PhysicalBlockSizeBytes` contains the size of the physical blocks
-  used on the disk, in bytes
+  used on the disk, in bytes. This is typically the minimum amount of data that
+  will be written in a single write operation for the disk.
 * `ghw.Disk.IsRemovable` contains a boolean indicating if the disk drive is
   removable
 * `ghw.Disk.DriveType` is the type of drive. It is of type `ghw.DriveType`
@@ -310,8 +311,11 @@ Each `ghw.Disk` struct contains the following fields:
   `ghw.StorageController` which has a `ghw.StorageController.String()` method
   that can be called to return a string representation of the bus. This string
   will be `SCSI`, `IDE`, `virtio`, `MMC`, or `NVMe`
-* `ghw.Disk.NUMANodeID` is the numeric index of the NUMA node this disk is
-  local to, or -1 if the host system is not a NUMA system.
+* `ghw.Disk.BusPath` (Linux, Darwin only) is the filepath to the bus used by
+  the disk.
+* `ghw.Disk.NUMANodeID` (Linux only) is the numeric index of the NUMA node this
+  disk is local to, or -1 if the host system is not a NUMA system or is not
+  Linux.
 * `ghw.Disk.Vendor` contains a string with the name of the hardware vendor for
   the disk
 * `ghw.Disk.Model` contains a string with the vendor-assigned disk model name

--- a/alias.go
+++ b/alias.go
@@ -47,13 +47,20 @@ var (
 
 type MemoryArea = memory.Area
 type MemoryInfo = memory.Info
+type MemoryCache = memory.Cache
 type MemoryCacheType = memory.CacheType
 type MemoryModule = memory.Module
 
 const (
-	MEMORY_CACHE_TYPE_UNIFIED     = memory.CACHE_TYPE_UNIFIED
+	MemoryCacheTypeUnified = memory.CacheTypeUnified
+	// DEPRECATED: Please use MemoryCacheTypeUnified
+	MEMORY_CACHE_TYPE_UNIFIED  = memory.CACHE_TYPE_UNIFIED
+	MemoryCacheTypeInstruction = memory.CacheTypeInstruction
+	// DEPRECATED: Please use MemoryCacheTypeInstruction
 	MEMORY_CACHE_TYPE_INSTRUCTION = memory.CACHE_TYPE_INSTRUCTION
-	MEMORY_CACHE_TYPE_DATA        = memory.CACHE_TYPE_DATA
+	MemoryCacheTypeData           = memory.CacheTypeData
+	// DEPRECATED: Please use MemoryCacheTypeData
+	MEMORY_CACHE_TYPE_DATA = memory.CACHE_TYPE_DATA
 )
 
 var (

--- a/alias.go
+++ b/alias.go
@@ -78,22 +78,44 @@ var (
 type DriveType = block.DriveType
 
 const (
+	DriveTypeUnknown = block.DriveTypeUnknown
+	// DEPRECATED: Please use DriveTypeUnknown
 	DRIVE_TYPE_UNKNOWN = block.DRIVE_TYPE_UNKNOWN
-	DRIVE_TYPE_HDD     = block.DRIVE_TYPE_HDD
-	DRIVE_TYPE_FDD     = block.DRIVE_TYPE_FDD
-	DRIVE_TYPE_ODD     = block.DRIVE_TYPE_ODD
-	DRIVE_TYPE_SSD     = block.DRIVE_TYPE_SSD
+	DriveTypeHDD       = block.DriveTypeHDD
+	// DEPRECATED: Please use DriveTypeHDD
+	DRIVE_TYPE_HDD = block.DRIVE_TYPE_HDD
+	DriveTypeFDD   = block.DriveTypeFDD
+	// DEPRECATED: Please use DriveTypeFDD
+	DRIVE_TYPE_FDD = block.DRIVE_TYPE_FDD
+	DriveTypeODD   = block.DriveTypeODD
+	// DEPRECATED: Please use DriveTypeODD
+	DRIVE_TYPE_ODD = block.DRIVE_TYPE_ODD
+	DriveTypeSSD   = block.DriveTypeSSD
+	// DEPRECATED: Please use DriveTypeSSD
+	DRIVE_TYPE_SSD = block.DRIVE_TYPE_SSD
 )
 
 type StorageController = block.StorageController
 
 const (
+	StorageControllerUnknown = block.StorageControllerUnknown
+	// DEPRECATED: Please use StorageControllerUnknown
 	STORAGE_CONTROLLER_UNKNOWN = block.STORAGE_CONTROLLER_UNKNOWN
-	STORAGE_CONTROLLER_IDE     = block.STORAGE_CONTROLLER_IDE
-	STORAGE_CONTROLLER_SCSI    = block.STORAGE_CONTROLLER_SCSI
-	STORAGE_CONTROLLER_NVME    = block.STORAGE_CONTROLLER_NVME
-	STORAGE_CONTROLLER_VIRTIO  = block.STORAGE_CONTROLLER_VIRTIO
-	STORAGE_CONTROLLER_MMC     = block.STORAGE_CONTROLLER_MMC
+	StorageControllerIDE       = block.StorageControllerIDE
+	// DEPRECATED: Please use StorageControllerIDE
+	STORAGE_CONTROLLER_IDE = block.STORAGE_CONTROLLER_IDE
+	StorageControllerSCSI  = block.StorageControllerSCSI
+	// DEPRECATED: Please use StorageControllerSCSI
+	STORAGE_CONTROLLER_SCSI = block.STORAGE_CONTROLLER_SCSI
+	StorageControllerNVMe   = block.StorageControllerNVMe
+	// DEPRECATED: Please use StorageControllerNVMe
+	STORAGE_CONTROLLER_NVME = block.STORAGE_CONTROLLER_NVME
+	StorageControllerVirtIO = block.StorageControllerVirtIO
+	// DEPRECATED: Please use StorageControllerVirtIO
+	STORAGE_CONTROLLER_VIRTIO = block.STORAGE_CONTROLLER_VIRTIO
+	StorageControllerMMC      = block.StorageControllerMMC
+	// DEPRECATED: Please use StorageControllerMMC
+	STORAGE_CONTROLLER_MMC = block.STORAGE_CONTROLLER_MMC
 )
 
 type NetworkInfo = net.Info

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -24,22 +24,43 @@ import (
 type DriveType int
 
 const (
-	DRIVE_TYPE_UNKNOWN DriveType = iota
-	DRIVE_TYPE_HDD               // Hard disk drive
-	DRIVE_TYPE_FDD               // Floppy disk drive
-	DRIVE_TYPE_ODD               // Optical disk drive
-	DRIVE_TYPE_SSD               // Solid-state drive
-	DRIVE_TYPE_VIRTUAL           // virtual drive i.e. loop devices
+	// DriveTypeUnknown means we could not determine the drive type of the disk
+	DriveTypeUnknown DriveType = iota
+	// DriveTypeHDD indicates a hard disk drive
+	DriveTypeHDD
+	// DriveTypeFDD indicates a floppy disk drive
+	DriveTypeFDD
+	// DriveTypeODD indicates an optical disk drive
+	DriveTypeODD
+	// DriveTypeSSD indicates a solid-state drive
+	DriveTypeSSD
+	// DriveTypeVirtual indicates a virtual drive i.e. loop devices
+	DriveTypeVirtual
+)
+
+const (
+	// DEPRECATED: Please use DriveTypeUnknown
+	DRIVE_TYPE_UNKNOWN = DriveTypeUnknown
+	// DEPRECATED: Please use DriveTypeHDD
+	DRIVE_TYPE_HDD = DriveTypeHDD
+	// DEPRECATED: Please use DriveTypeFDD
+	DRIVE_TYPE_FDD = DriveTypeFDD
+	// DEPRECATED: Please use DriveTypeODD
+	DRIVE_TYPE_ODD = DriveTypeODD
+	// DEPRECATED: Please use DriveTypeSSD
+	DRIVE_TYPE_SSD = DriveTypeSSD
+	// DEPRECATED: Please use DriveTypeVirtual
+	DRIVE_TYPE_VIRTUAL = DriveTypeVirtual
 )
 
 var (
 	driveTypeString = map[DriveType]string{
-		DRIVE_TYPE_UNKNOWN: "Unknown",
-		DRIVE_TYPE_HDD:     "HDD",
-		DRIVE_TYPE_FDD:     "FDD",
-		DRIVE_TYPE_ODD:     "ODD",
-		DRIVE_TYPE_SSD:     "SSD",
-		DRIVE_TYPE_VIRTUAL: "virtual",
+		DriveTypeUnknown: "Unknown",
+		DriveTypeHDD:     "HDD",
+		DriveTypeFDD:     "FDD",
+		DriveTypeODD:     "ODD",
+		DriveTypeSSD:     "SSD",
+		DriveTypeVirtual: "virtual",
 	}
 
 	// NOTE(fromani): the keys are all lowercase and do not match
@@ -48,12 +69,12 @@ var (
 	// DriveType::MarshalJSON.
 	// We use this table only in UnmarshalJSON, so it should be OK.
 	stringDriveType = map[string]DriveType{
-		"unknown": DRIVE_TYPE_UNKNOWN,
-		"hdd":     DRIVE_TYPE_HDD,
-		"fdd":     DRIVE_TYPE_FDD,
-		"odd":     DRIVE_TYPE_ODD,
-		"ssd":     DRIVE_TYPE_SSD,
-		"virtual": DRIVE_TYPE_VIRTUAL,
+		"unknown": DriveTypeUnknown,
+		"hdd":     DriveTypeHDD,
+		"fdd":     DriveTypeFDD,
+		"odd":     DriveTypeODD,
+		"ssd":     DriveTypeSSD,
+		"virtual": DriveTypeVirtual,
 	}
 )
 
@@ -90,24 +111,54 @@ func (dt *DriveType) UnmarshalJSON(b []byte) error {
 type StorageController int
 
 const (
-	STORAGE_CONTROLLER_UNKNOWN StorageController = iota
-	STORAGE_CONTROLLER_IDE                       // Integrated Drive Electronics
-	STORAGE_CONTROLLER_SCSI                      // Small computer system interface
-	STORAGE_CONTROLLER_NVME                      // Non-volatile Memory Express
-	STORAGE_CONTROLLER_VIRTIO                    // Virtualized storage controller/driver
-	STORAGE_CONTROLLER_MMC                       // Multi-media controller (used for mobile phone storage devices)
-	STORAGE_CONTROLLER_LOOP                      // loop device
+	// StorageControllerUnknown indicates we could not determine the storage
+	// controller for the disk
+	StorageControllerUnknown StorageController = iota
+	// StorageControllerIDE indicates a Integrated Drive Electronics (IDE)
+	// controller
+	StorageControllerIDE
+	// StorageControllerSCSI indicates a  Small computer system interface
+	// (SCSI) controller
+	StorageControllerSCSI
+	// StorageControllerNVMe indicates a Non-volatile Memory Express (NVMe)
+	// controller
+	StorageControllerNVMe
+	// StorageControllerVirtIO indicates a virtualized storage
+	// controller/driver
+	StorageControllerVirtIO
+	// StorageControllerMMC indicates a Multi-media controller (used for mobile
+	// phone storage devices)
+	StorageControllerMMC
+	// StorageControllerLoop indicates a loopback storage controller
+	StorageControllerLoop
+)
+
+const (
+	// DEPRECATED: Please use StorageControllerUnknown
+	STORAGE_CONTROLLER_UNKNOWN = StorageControllerUnknown
+	// DEPRECATED: Please use StorageControllerIDE
+	STORAGE_CONTROLLER_IDE = StorageControllerIDE
+	// DEPRECATED: Please use StorageControllerSCSI
+	STORAGE_CONTROLLER_SCSI = StorageControllerSCSI
+	// DEPRECATED: Please use StorageControllerNVMe
+	STORAGE_CONTROLLER_NVME = StorageControllerNVMe
+	// DEPRECATED: Please use StorageControllerVirtIO
+	STORAGE_CONTROLLER_VIRTIO = StorageControllerVirtIO
+	// DEPRECATED: Please use StorageControllerMMC
+	STORAGE_CONTROLLER_MMC = StorageControllerMMC
+	// DEPRECATED: Please use StorageControllerLoop
+	STORAGE_CONTROLLER_LOOP = StorageControllerLoop
 )
 
 var (
 	storageControllerString = map[StorageController]string{
-		STORAGE_CONTROLLER_UNKNOWN: "Unknown",
-		STORAGE_CONTROLLER_IDE:     "IDE",
-		STORAGE_CONTROLLER_SCSI:    "SCSI",
-		STORAGE_CONTROLLER_NVME:    "NVMe",
-		STORAGE_CONTROLLER_VIRTIO:  "virtio",
-		STORAGE_CONTROLLER_MMC:     "MMC",
-		STORAGE_CONTROLLER_LOOP:    "loop",
+		StorageControllerUnknown: "Unknown",
+		StorageControllerIDE:     "IDE",
+		StorageControllerSCSI:    "SCSI",
+		StorageControllerNVMe:    "NVMe",
+		StorageControllerVirtIO:  "virtio",
+		StorageControllerMMC:     "MMC",
+		StorageControllerLoop:    "loop",
 	}
 
 	// NOTE(fromani): the keys are all lowercase and do not match
@@ -116,13 +167,13 @@ var (
 	// StorageController::MarshalJSON.
 	// We use this table only in UnmarshalJSON, so it should be OK.
 	stringStorageController = map[string]StorageController{
-		"unknown": STORAGE_CONTROLLER_UNKNOWN,
-		"ide":     STORAGE_CONTROLLER_IDE,
-		"scsi":    STORAGE_CONTROLLER_SCSI,
-		"nvme":    STORAGE_CONTROLLER_NVME,
-		"virtio":  STORAGE_CONTROLLER_VIRTIO,
-		"mmc":     STORAGE_CONTROLLER_MMC,
-		"loop":    STORAGE_CONTROLLER_LOOP,
+		"unknown": StorageControllerUnknown,
+		"ide":     StorageControllerIDE,
+		"scsi":    StorageControllerSCSI,
+		"nvme":    StorageControllerNVMe,
+		"virtio":  StorageControllerVirtIO,
+		"mmc":     StorageControllerMMC,
+		"loop":    StorageControllerLoop,
 	}
 )
 
@@ -154,45 +205,84 @@ func (sc StorageController) MarshalJSON() ([]byte, error) {
 // Disk describes a single disk drive on the host system. Disk drives provide
 // raw block storage resources.
 type Disk struct {
-	Name                   string            `json:"name"`
-	SizeBytes              uint64            `json:"size_bytes"`
-	PhysicalBlockSizeBytes uint64            `json:"physical_block_size_bytes"`
-	DriveType              DriveType         `json:"drive_type"`
-	IsRemovable            bool              `json:"removable"`
-	StorageController      StorageController `json:"storage_controller"`
-	BusPath                string            `json:"bus_path"`
+	// Name contains a short name for the disk, e.g. `sda`
+	Name string `json:"name"`
+	// SizeBytes contains the total amount of storage, in bytes, for this disk
+	SizeBytes uint64 `json:"size_bytes"`
+	// PhysicalBlockSizeBytes is the size, in bytes, of the physical blocks in
+	// this disk. This is typically the minimum amount of data that can be
+	// written to a disk in a single write operation.
+	PhysicalBlockSizeBytes uint64 `json:"physical_block_size_bytes"`
+	// DriveType is the category of disk drive for this disk.
+	DriveType DriveType `json:"drive_type"`
+	// IsRemovable indicates if the disk drive is removable.
+	IsRemovable bool `json:"removable"`
+	// StorageController is the category of storage controller used by the
+	// disk.
+	StorageController StorageController `json:"storage_controller"`
+	// BusPath is the filepath to the bus for this disk.
+	BusPath string `json:"bus_path"`
+	// NUMANodeID contains the numeric index (0-based) of the NUMA Node this
+	// disk is affined to, or -1 if the host system is non-NUMA.
 	// TODO(jaypipes): Convert this to a TopologyNode struct pointer and then
 	// add to serialized output as "numa_node,omitempty"
-	NUMANodeID   int          `json:"-"`
-	Vendor       string       `json:"vendor"`
-	Model        string       `json:"model"`
-	SerialNumber string       `json:"serial_number"`
-	WWN          string       `json:"wwn"`
-	Partitions   []*Partition `json:"partitions"`
+	NUMANodeID int `json:"-"`
+	// Vendor is the manufacturer of the disk.
+	Vendor string `json:"vendor"`
+	// Model is the model number of the disk.
+	Model string `json:"model"`
+	// SerialNumber is the serial number of the disk.
+	SerialNumber string `json:"serial_number"`
+	// WWN is the World-wide Number of the disk.
+	// See: https://en.wikipedia.org/wiki/World_Wide_Name
+	WWN string `json:"wwn"`
+	// Partitions contains an array of pointers to `Partition` structs, one for
+	// each partition on the disk.
+	Partitions []*Partition `json:"partitions"`
 	// TODO(jaypipes): Add PCI field for accessing PCI device information
 	// PCI *PCIDevice `json:"pci"`
 }
 
 // Partition describes a logical division of a Disk.
 type Partition struct {
-	Disk            *Disk  `json:"-"`
-	Name            string `json:"name"`
-	Label           string `json:"label"`
-	MountPoint      string `json:"mount_point"`
-	SizeBytes       uint64 `json:"size_bytes"`
-	Type            string `json:"type"`
-	IsReadOnly      bool   `json:"read_only"`
-	UUID            string `json:"uuid"` // This would be volume UUID on macOS, PartUUID on linux, empty on Windows
+	// Disk is a pointer to the `Disk` struct that houses this partition.
+	Disk *Disk `json:"-"`
+	// Name is the system name given to the partition, e.g. "sda1".
+	Name string `json:"name"`
+	// Label is the human-readable label given to the partition. On Linux, this
+	// is derived from the `ID_PART_ENTRY_NAME` udev entry.
+	Label string `json:"label"`
+	// MountPoint is the path where this partition is mounted.
+	MountPoint string `json:"mount_point"`
+	// SizeBytes contains the total amount of storage, in bytes, this partition
+	// can consume.
+	SizeBytes uint64 `json:"size_bytes"`
+	// Type contains the type of the partition.
+	Type string `json:"type"`
+	// IsReadOnly indicates if the partition is marked read-only.
+	IsReadOnly bool `json:"read_only"`
+	// UUID is the universally-unique identifier (UUID) for the partition.
+	// This will be volume UUID on Darwin, PartUUID on linux, empty on Windows.
+	UUID string `json:"uuid"`
+	// FilesystemLabel is the label of the filesystem contained on the
+	// partition. On Linux, this is derived from the `ID_FS_NAME` udev entry.
 	FilesystemLabel string `json:"filesystem_label"`
 }
 
 // Info describes all disk drives and partitions in the host system.
 type Info struct {
 	ctx *context.Context
-	// TODO(jaypipes): Deprecate this field and replace with TotalSizeBytes
-	TotalPhysicalBytes uint64       `json:"total_size_bytes"`
-	Disks              []*Disk      `json:"disks"`
-	Partitions         []*Partition `json:"-"`
+	// TotalSizeBytes contains the total amount of storage, in bytes, on the
+	// host system.
+	TotalSizeBytes uint64 `json:"total_size_bytes"`
+	// DEPRECATED: Please use TotalSizeBytes
+	TotalPhysicalBytes uint64 `json:"-"`
+	// Disks contains an array of pointers to `Disk` structs, one for each disk
+	// drive on the host system.
+	Disks []*Disk `json:"disks"`
+	// Partitions contains an array of pointers to `Partition` structs, one for
+	// each partition on any disk drive on the host system.
+	Partitions []*Partition `json:"-"`
 }
 
 // New returns a pointer to an Info struct that describes the block storage
@@ -206,6 +296,8 @@ func New(opts ...*option.Option) (*Info, error) {
 	return info, nil
 }
 
+// String returns a short string indicating important information about the
+// block storage on the host system.
 func (i *Info) String() string {
 	tpbs := util.UNKNOWN
 	if i.TotalPhysicalBytes > 0 {
@@ -222,6 +314,8 @@ func (i *Info) String() string {
 		len(i.Disks), dplural, tpbs)
 }
 
+// String returns a short string indicating important information about the
+// disk.
 func (d *Disk) String() string {
 	sizeStr := util.UNKNOWN
 	if d.SizeBytes > 0 {
@@ -272,6 +366,8 @@ func (d *Disk) String() string {
 	)
 }
 
+// String returns a short string indicating important information about the
+// partition.
 func (p *Partition) String() string {
 	typeStr := ""
 	if p.Type != "" {

--- a/pkg/block/block_darwin.go
+++ b/pkg/block/block_darwin.go
@@ -185,9 +185,9 @@ func makePartition(disk, s diskOrPartitionPlistNode, isAPFS bool) (*Partition, e
 // driveTypeFromPlist looks at the supplied property list struct and attempts to
 // determine the disk type
 func driveTypeFromPlist(infoPlist *diskUtilInfoPlist) DriveType {
-	dt := DRIVE_TYPE_HDD
+	dt := DriveTypeHDD
 	if infoPlist.SolidState {
-		dt = DRIVE_TYPE_SSD
+		dt = DriveTypeSSD
 	}
 	// TODO(jaypipes): Figure out how to determine floppy and/or CD/optical
 	// drive type on Mac
@@ -197,9 +197,9 @@ func driveTypeFromPlist(infoPlist *diskUtilInfoPlist) DriveType {
 // storageControllerFromPlist looks at the supplied property list struct and
 // attempts to determine the storage controller in use for the device
 func storageControllerFromPlist(infoPlist *diskUtilInfoPlist) StorageController {
-	sc := STORAGE_CONTROLLER_SCSI
+	sc := StorageControllerSCSI
 	if strings.HasSuffix(infoPlist.DeviceTreePath, "IONVMeController") {
-		sc = STORAGE_CONTROLLER_NVME
+		sc = StorageControllerNVMe
 	}
 	// TODO(jaypipes): I don't know if Mac even supports IDE controllers and
 	// the "virtio" controller is libvirt-specific
@@ -217,7 +217,7 @@ func (info *Info) load() error {
 		return err
 	}
 
-	info.TotalPhysicalBytes = 0
+	var tsb uint64
 	info.Disks = make([]*Disk, 0, len(listPlist.AllDisksAndPartitions))
 	info.Partitions = []*Partition{}
 
@@ -278,10 +278,12 @@ func (info *Info) load() error {
 			diskReport.Partitions = append(diskReport.Partitions, part)
 		}
 
-		info.TotalPhysicalBytes += uint64(disk.Size)
+		tsb += uint64(disk.Size)
 		info.Disks = append(info.Disks, diskReport)
 		info.Partitions = append(info.Partitions, diskReport.Partitions...)
 	}
+	info.TotalSizeBytes = tsb
+	info.TotalPhysicalBytes = tsb
 
 	return nil
 }

--- a/pkg/block/block_linux.go
+++ b/pkg/block/block_linux.go
@@ -25,11 +25,12 @@ const (
 func (i *Info) load() error {
 	paths := linuxpath.New(i.ctx)
 	i.Disks = disks(i.ctx, paths)
-	var tpb uint64
+	var tsb uint64
 	for _, d := range i.Disks {
-		tpb += d.SizeBytes
+		tsb += d.SizeBytes
 	}
-	i.TotalPhysicalBytes = tpb
+	i.TotalSizeBytes = tsb
+	i.TotalPhysicalBytes = tsb
 	return nil
 }
 
@@ -357,34 +358,34 @@ func diskTypes(dname string) (
 	// The conditionals below which set the controller and drive type are
 	// based on information listed here:
 	// https://en.wikipedia.org/wiki/Device_file
-	driveType := DRIVE_TYPE_UNKNOWN
-	storageController := STORAGE_CONTROLLER_UNKNOWN
+	driveType := DriveTypeUnknown
+	storageController := StorageControllerUnknown
 	if strings.HasPrefix(dname, "fd") {
-		driveType = DRIVE_TYPE_FDD
+		driveType = DriveTypeFDD
 	} else if strings.HasPrefix(dname, "sd") {
-		driveType = DRIVE_TYPE_HDD
-		storageController = STORAGE_CONTROLLER_SCSI
+		driveType = DriveTypeHDD
+		storageController = StorageControllerSCSI
 	} else if strings.HasPrefix(dname, "hd") {
-		driveType = DRIVE_TYPE_HDD
-		storageController = STORAGE_CONTROLLER_IDE
+		driveType = DriveTypeHDD
+		storageController = StorageControllerIDE
 	} else if strings.HasPrefix(dname, "vd") {
-		driveType = DRIVE_TYPE_HDD
-		storageController = STORAGE_CONTROLLER_VIRTIO
+		driveType = DriveTypeHDD
+		storageController = StorageControllerVirtIO
 	} else if strings.HasPrefix(dname, "nvme") {
-		driveType = DRIVE_TYPE_SSD
-		storageController = STORAGE_CONTROLLER_NVME
+		driveType = DriveTypeSSD
+		storageController = StorageControllerNVMe
 	} else if strings.HasPrefix(dname, "sr") {
-		driveType = DRIVE_TYPE_ODD
-		storageController = STORAGE_CONTROLLER_SCSI
+		driveType = DriveTypeODD
+		storageController = StorageControllerSCSI
 	} else if strings.HasPrefix(dname, "xvd") {
-		driveType = DRIVE_TYPE_HDD
-		storageController = STORAGE_CONTROLLER_SCSI
+		driveType = DriveTypeHDD
+		storageController = StorageControllerSCSI
 	} else if strings.HasPrefix(dname, "mmc") {
-		driveType = DRIVE_TYPE_SSD
-		storageController = STORAGE_CONTROLLER_MMC
+		driveType = DriveTypeSSD
+		storageController = StorageControllerMMC
 	} else if strings.HasPrefix(dname, "loop") {
-		driveType = DRIVE_TYPE_VIRTUAL
-		storageController = STORAGE_CONTROLLER_LOOP
+		driveType = DriveTypeVirtual
+		storageController = StorageControllerLoop
 	}
 
 	return driveType, storageController

--- a/pkg/block/block_windows.go
+++ b/pkg/block/block_windows.go
@@ -17,24 +17,24 @@ import (
 type physicalDiskMediaType int
 
 const (
-	PHYSICAL_DISK_MEDIA_TYPE_UNSPECIFIED physicalDiskMediaType = 0
-	PHYSICAL_DISK_MEDIA_TYPE_HDD         physicalDiskMediaType = 3
-	PHYSICAL_DISK_MEDIA_TYPE_SSD         physicalDiskMediaType = 4
-	PHYSICAL_DISK_MEDIA_TYPE_SCM         physicalDiskMediaType = 5
+	physicalDiskMediaTypeUnspecified physicalDiskMediaType = 0
+	physicalDiskMediaTypeHDD         physicalDiskMediaType = 3
+	physicalDiskMediaTypeSSD         physicalDiskMediaType = 4
+	physicalDiskMediaTypeSCM         physicalDiskMediaType = 5
 )
 
 func (dt physicalDiskMediaType) ToDriveType() DriveType {
 	switch dt {
-	case PHYSICAL_DISK_MEDIA_TYPE_UNSPECIFIED:
-		return DRIVE_TYPE_UNKNOWN
-	case PHYSICAL_DISK_MEDIA_TYPE_HDD:
-		return DRIVE_TYPE_HDD
-	case PHYSICAL_DISK_MEDIA_TYPE_SSD:
-		return DRIVE_TYPE_SSD
-	case PHYSICAL_DISK_MEDIA_TYPE_SCM:
-		return DRIVE_TYPE_UNKNOWN
+	case physicalDiskMediaTypeUnspecified:
+		return DriveTypeUnknown
+	case physicalDiskMediaTypeHDD:
+		return DriveTypeHDD
+	case physicalDiskMediaTypeSSD:
+		return DriveTypeSSD
+	case physicalDiskMediaTypeSCM:
+		return DriveTypeUnknown
 	}
-	return DRIVE_TYPE_UNKNOWN
+	return DriveTypeUnknown
 }
 
 const wqlDiskDrive = "SELECT Caption, CreationClassName, DefaultBlockSize, Description, DeviceID, Index, InterfaceType, Manufacturer, MediaType, Model, Name, Partitions, SerialNumber, Size, TotalCylinders, TotalHeads, TotalSectors, TotalTracks, TracksPerCylinder FROM Win32_DiskDrive"
@@ -191,11 +191,12 @@ func (i *Info) load() error {
 	}
 
 	i.Disks = disks
-	var tpb uint64
+	var tsb uint64
 	for _, d := range i.Disks {
-		tpb += d.SizeBytes
+		tsb += d.SizeBytes
 	}
-	i.TotalPhysicalBytes = tpb
+	i.TotalSizeBytes = tsb
+	i.TotalPhysicalBytes = tsb
 	return nil
 }
 
@@ -245,18 +246,18 @@ func getPhysicalDisks() ([]win32PhysicalDisk, error) {
 }
 
 func toDriveType(physicalDiskMediaType physicalDiskMediaType, mediaType string, caption string) DriveType {
-	if driveType := physicalDiskMediaType.ToDriveType(); driveType != DRIVE_TYPE_UNKNOWN {
+	if driveType := physicalDiskMediaType.ToDriveType(); driveType != DriveTypeUnknown {
 		return driveType
 	}
 
 	mediaType = strings.ToLower(mediaType)
 	caption = strings.ToLower(caption)
 	if strings.Contains(mediaType, "fixed") || strings.Contains(mediaType, "ssd") || strings.Contains(caption, "ssd") {
-		return DRIVE_TYPE_SSD
+		return DriveTypeSSD
 	} else if strings.ContainsAny(mediaType, "hdd") {
-		return DRIVE_TYPE_HDD
+		return DriveTypeHDD
 	}
-	return DRIVE_TYPE_UNKNOWN
+	return DriveTypeUnknown
 }
 
 // TODO: improve
@@ -264,11 +265,11 @@ func toStorageController(interfaceType string) StorageController {
 	var storageController StorageController
 	switch interfaceType {
 	case "SCSI":
-		storageController = STORAGE_CONTROLLER_SCSI
+		storageController = StorageControllerSCSI
 	case "IDE":
-		storageController = STORAGE_CONTROLLER_IDE
+		storageController = StorageControllerIDE
 	default:
-		storageController = STORAGE_CONTROLLER_UNKNOWN
+		storageController = StorageControllerUnknown
 	}
 	return storageController
 }

--- a/pkg/cpu/cpu_linux.go
+++ b/pkg/cpu/cpu_linux.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -112,6 +113,9 @@ func processorsGet(ctx *context.Context) []*Processor {
 	}
 	res := []*Processor{}
 	for _, p := range procs {
+		for _, c := range p.Cores {
+			sort.Ints(c.LogicalProcessors)
+		}
 		res = append(res, p)
 	}
 	return res

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -17,6 +17,10 @@ import (
 	"github.com/jaypipes/ghw/pkg/util"
 )
 
+// Module describes a single physical memory module for a host system. Pretty
+// much all modern systems contain dual in-line memory modules (DIMMs).
+//
+// See https://en.wikipedia.org/wiki/DIMM
 type Module struct {
 	Label        string `json:"label"`
 	Location     string `json:"location"`
@@ -25,6 +29,10 @@ type Module struct {
 	Vendor       string `json:"vendor"`
 }
 
+// Area describes a set of physical memory on a host system. Non-NUMA systems
+// will almost always have a single memory area containing all memory the
+// system can use. NUMA systems will have multiple memory areas, one or more
+// for each NUMA node/cell in the system.
 type Area struct {
 	TotalPhysicalBytes int64 `json:"total_physical_bytes"`
 	TotalUsableBytes   int64 `json:"total_usable_bytes"`
@@ -33,6 +41,8 @@ type Area struct {
 	Modules            []*Module `json:"modules"`
 }
 
+// String returns a short string with a summary of information for this memory
+// area
 func (a *Area) String() string {
 	tpbs := util.UNKNOWN
 	if a.TotalPhysicalBytes > 0 {
@@ -51,11 +61,13 @@ func (a *Area) String() string {
 	return fmt.Sprintf("memory (%s physical, %s usable)", tpbs, tubs)
 }
 
+// Info contains information about the memory on a host system.
 type Info struct {
 	ctx *context.Context
 	Area
 }
 
+// New returns an Info struct that describes the memory on a host system.
 func New(opts ...*option.Option) (*Info, error) {
 	ctx := context.New(opts...)
 	info := &Info{ctx: ctx}
@@ -65,6 +77,7 @@ func New(opts ...*option.Option) (*Info, error) {
 	return info, nil
 }
 
+// String returns a short string with a summary of memory information
 func (i *Info) String() string {
 	return i.Area.String()
 }

--- a/pkg/memory/memory_cache_linux.go
+++ b/pkg/memory/memory_cache_linux.go
@@ -161,15 +161,15 @@ func memoryCacheType(ctx *context.Context, paths *linuxpath.Paths, nodeID int, l
 	cacheTypeContents, err := os.ReadFile(typePath)
 	if err != nil {
 		ctx.Warn("%s", err)
-		return CACHE_TYPE_UNIFIED
+		return CacheTypeUnified
 	}
 	switch string(cacheTypeContents[:len(cacheTypeContents)-1]) {
 	case "Data":
-		return CACHE_TYPE_DATA
+		return CacheTypeData
 	case "Instruction":
-		return CACHE_TYPE_INSTRUCTION
+		return CacheTypeInstruction
 	default:
-		return CACHE_TYPE_UNIFIED
+		return CacheTypeUnified
 	}
 }
 

--- a/pkg/memory/memory_linux.go
+++ b/pkg/memory/memory_linux.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	_WARN_CANNOT_DETERMINE_PHYSICAL_MEMORY = `
+	warnCannotDeterminePhysicalMemory = `
 Could not determine total physical bytes of memory. This may
 be due to the host being a virtual machine or container with no
 /var/log/syslog file or /sys/devices/system/memory directory, or
@@ -36,7 +36,7 @@ the total usable amount of memory
 var (
 	// System log lines will look similar to the following:
 	// ... kernel: [0.000000] Memory: 24633272K/25155024K ...
-	_REGEX_SYSLOG_MEMLINE = regexp.MustCompile(`Memory:\s+\d+K\/(\d+)K`)
+	regexSyslogMemline = regexp.MustCompile(`Memory:\s+\d+K\/(\d+)K`)
 	// regexMemoryBlockDirname matches a subdirectory in either
 	// /sys/devices/system/memory or /sys/devices/system/node/nodeX that
 	// represents information on a specific memory cell/block
@@ -53,7 +53,7 @@ func (i *Info) load() error {
 	tpb := memTotalPhysicalBytes(paths)
 	i.TotalPhysicalBytes = tpb
 	if tpb < 1 {
-		i.ctx.Warn(_WARN_CANNOT_DETERMINE_PHYSICAL_MEMORY)
+		i.ctx.Warn(warnCannotDeterminePhysicalMemory)
 		i.TotalPhysicalBytes = tub
 	}
 	i.SupportedPageSizes, _ = memorySupportedPageSizes(paths.SysKernelMMHugepages)
@@ -185,7 +185,7 @@ func memTotalPhysicalBytesFromSyslog(paths *linuxpath.Paths) int64 {
 	// so instead we examine the system logs for startup information containing
 	// total physical memory and cache the results of this.
 	findPhysicalKb := func(line string) int64 {
-		matches := _REGEX_SYSLOG_MEMLINE.FindStringSubmatch(line)
+		matches := regexSyslogMemline.FindStringSubmatch(line)
 		if len(matches) == 2 {
 			i, err := strconv.Atoi(matches[1])
 			if err != nil {

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -14,28 +14,63 @@ import (
 	"github.com/jaypipes/ghw/pkg/option"
 )
 
+// NICCapability is a feature/capability of a Network Interface Controller
+// (NIC)
 type NICCapability struct {
-	Name      string `json:"name"`
-	IsEnabled bool   `json:"is_enabled"`
-	CanEnable bool   `json:"can_enable"`
+	// Name is the string name for the capability, e.g.
+	// "tcp-segmentation-offload"
+	Name string `json:"name"`
+	// IsEnabled is true if the capability is currently enabled on the NIC,
+	// false otherwise.
+	IsEnabled bool `json:"is_enabled"`
+	// CanEnable is true if the capability can be enabled on the NIC, false
+	// otherwise.
+	CanEnable bool `json:"can_enable"`
 }
 
+// NIC contains information about a single Network Interface Controller (NIC).
 type NIC struct {
-	Name                string           `json:"name"`
-	MacAddress          string           `json:"mac_address"`
-	IsVirtual           bool             `json:"is_virtual"`
-	Capabilities        []*NICCapability `json:"capabilities"`
-	PCIAddress          *string          `json:"pci_address,omitempty"`
-	Speed               string           `json:"speed"`
-	Duplex              string           `json:"duplex"`
-	SupportedLinkModes  []string         `json:"supported_link_modes,omitempty"`
-	SupportedPorts      []string         `json:"supported_ports,omitempty"`
-	SupportedFECModes   []string         `json:"supported_fec_modes,omitempty"`
-	AdvertisedLinkModes []string         `json:"advertised_link_modes,omitempty"`
-	AdvertisedFECModes  []string         `json:"advertised_fec_modes,omitempty"`
+	// Name is the string identifier the system gave this NIC.
+	Name string `json:"name"`
+	// MACAddress is the Media Access Control (MAC) address of this NIC.
+	MACAddress string `json:"mac_address"`
+	// DEPRECATED: Please use MACAddress instead.
+	MacAddress string `json:"-"`
+	// IsVirtual is true if the NIC is entirely virtual/emulated, false
+	// otherwise.
+	IsVirtual bool `json:"is_virtual"`
+	// Capabilities is a slice of pointers to `NICCapability` structs
+	// describing a feature/capability of this NIC.
+	Capabilities []*NICCapability `json:"capabilities"`
+	// PCIAddress is a pointer to the PCI address for this NIC, or nil if there
+	// is no PCI address for this NIC.
+	PCIAddress *string `json:"pci_address,omitempty"`
+	// Speed is a string describing the link speed of this NIC, e.g. "1000Mb/s"
+	Speed string `json:"speed"`
+	// Duplex is a string indicating the current duplex setting of this NIC,
+	// e.g. "Full"
+	Duplex string `json:"duplex"`
+	// SupportedLinkModes is a slice of strings containing the supported link
+	// modes of this NIC, e.g. "10baseT/Half", "1000baseT/Full", etc.
+	SupportedLinkModes []string `json:"supported_link_modes,omitempty"`
+	// SupportedPorts is a slice of strings containing the supported physical
+	// ports on this NIC, e.g. "Twisted Pair"
+	SupportedPorts []string `json:"supported_ports,omitempty"`
+	// SupportedFECModes is a slice of strings containing the supported Forward
+	// Error Correction (FEC) modes for this NIC.
+	SupportedFECModes []string `json:"supported_fec_modes,omitempty"`
+	// AdvertiseLinkModes is a slice of strings containing the advertised
+	// (during auto-negotiation) link modes of this NIC, e.g. "10baseT/Half",
+	// "1000baseT/Full", etc.
+	AdvertisedLinkModes []string `json:"advertised_link_modes,omitempty"`
+	// AvertisedFECModes is a slice of strings containing the advertised
+	// (during auto-negotiation) Forward Error Correction (FEC) modes for this
+	// NIC.
+	AdvertisedFECModes []string `json:"advertised_fec_modes,omitempty"`
 	// TODO(fromani): add other hw addresses (USB) when we support them
 }
 
+// String returns a short string with information about the NIC capability.
 func (nc *NICCapability) String() string {
 	return fmt.Sprintf(
 		"{Name:%s IsEnabled:%t CanEnable:%t}",
@@ -45,6 +80,7 @@ func (nc *NICCapability) String() string {
 	)
 }
 
+// String returns a short string with information about the NIC.
 func (n *NIC) String() string {
 	isVirtualStr := ""
 	if n.IsVirtual {
@@ -57,8 +93,11 @@ func (n *NIC) String() string {
 	)
 }
 
+// Info describes all network interface controllers (NICs) in the host system.
 type Info struct {
-	ctx  *context.Context
+	ctx *context.Context
+	// NICs is a slice of pointers to `NIC` structs describing the network
+	// interface controllers (NICs) on the host system.
 	NICs []*NIC `json:"nics"`
 }
 
@@ -73,6 +112,8 @@ func New(opts ...*option.Option) (*Info, error) {
 	return info, nil
 }
 
+// String returns a short string with information about the networking on the
+// host system.
 func (i *Info) String() string {
 	return fmt.Sprintf(
 		"net (%d NICs)",

--- a/pkg/net/net_linux.go
+++ b/pkg/net/net_linux.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	_WARN_ETHTOOL_NOT_INSTALLED = `ethtool not installed. Cannot grab NIC capabilities`
+	warnEthtoolNotInstalled = `ethtool not installed. Cannot grab NIC capabilities`
 )
 
 func (i *Info) load() error {
@@ -40,7 +40,7 @@ func nics(ctx *context.Context) []*NIC {
 	etAvailable := ctx.EnableTools
 	if etAvailable {
 		if etInstalled := ethtoolInstalled(); !etInstalled {
-			ctx.Warn(_WARN_ETHTOOL_NOT_INSTALLED)
+			ctx.Warn(warnEthtoolNotInstalled)
 			etAvailable = false
 		}
 	}
@@ -66,6 +66,7 @@ func nics(ctx *context.Context) []*NIC {
 
 		mac := netDeviceMacAddress(paths, filename)
 		nic.MacAddress = mac
+		nic.MACAddress = mac
 		if etAvailable {
 			nic.netDeviceParseEthtool(ctx, filename)
 		} else {

--- a/pkg/net/net_windows.go
+++ b/pkg/net/net_windows.go
@@ -45,10 +45,10 @@ func nics(win32NetDescriptions []win32NetworkAdapter) []*NIC {
 		nic := &NIC{
 			Name:         netDeviceName(nicDescription),
 			MacAddress:   *nicDescription.MACAddress,
+			MACAddress:   *nicDescription.MACAddress,
 			IsVirtual:    netIsVirtual(nicDescription),
 			Capabilities: []*NICCapability{},
 		}
-		// Appenging NIC to NICs
 		nics = append(nics, nic)
 	}
 


### PR DESCRIPTION
doc and const cleanup for net package
    
    Ensures proper docstrings for all exported things in the `net`
    package and deprecates the (non-Go-idiomatic) ALL_CAPS constants in
    favour of CamelCase constants.
    
doc and const cleanup for block package
    
    Ensures proper docstrings for all exported things in the `block`
    package and deprecates the (non-Go-idiomatic) ALL_CAPS constants in
    favour of CamelCase constants.
    
    Also officially deprecates the `pkg/block.Info.TotalPhysicalBytes` field
    in favour of a `pkg/block.Info.TotalSizeBytes` field (had a TODO in
    there a while to do this...).
    
ensure ProcessorCore.LogicalProcessors sorted
    
    Ensures that we sort the `ProcessorCore.LogicalProcessors` slice of ints
    for each processor core in Linux.
    
    Also update the documentation for the CPU package to mark the
    `Processor.Cores` and `Processor.Capabilities` fields as Linux-only.
    
doc and const cleanup for memory package
    
    Ensures proper docstrings for all exported things in the `memory`
    package and deprecates the (non-Go-idiomatic) ALL_CAPS constants in
    favour of CamelCase constants.