### PR TITLE
Change udev properties for Linux disk serial

### DIFF
--- a/pkg/block/block_linux.go
+++ b/pkg/block/block_linux.go
@@ -147,6 +147,16 @@ func diskSerialNumber(paths *linuxpath.Paths, disk string) string {
 		return util.UNKNOWN
 	}
 
+	// First try to use the serial from sg3_utils
+	if serial, ok := info["SCSI_IDENT_SERIAL"]; ok {
+		return serial
+	}
+
+	// Fall back to ID_SCSI_SERIAL
+	if serial, ok := info["ID_SCSI_SERIAL"]; ok {
+		return serial
+	}
+
 	// There are two serial number keys, ID_SERIAL and ID_SERIAL_SHORT The
 	// non-_SHORT version often duplicates vendor information collected
 	// elsewhere, so use _SHORT and fall back to ID_SERIAL if missing...


### PR DESCRIPTION
The properties that are currently used are not always accurate, for example we have seen that they sometimes contain the WWN and not the serial. This change uses SCSI_IDENT_SERIAL and ID_SCSI_SERIAL first. This behavior aligns with what lsblk does:
https://github.com/util-linux/util-linux/blob/36c52fd14b83e6f7eff9a565c426a1e21812403b/misc-utils/lsblk-properties.c#L122-L128