### PR TITLE
Allow separating the WWN vendor extension

### DIFF
--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -233,9 +233,13 @@ type Disk struct {
 	Model string `json:"model"`
 	// SerialNumber is the serial number of the disk.
 	SerialNumber string `json:"serial_number"`
-	// WWN is the World-wide Number of the disk.
+	// WWN is the World-wide Name of the disk.
 	// See: https://en.wikipedia.org/wiki/World_Wide_Name
 	WWN string `json:"wwn"`
+	// WWNNoExtension is the World-wide Name of the disk with any vendor
+	// extensions excluded.
+	// See: https://en.wikipedia.org/wiki/World_Wide_Name
+	WWNNoExtension string `json:"wwnNoExtension"`
 	// Partitions contains an array of pointers to `Partition` structs, one for
 	// each partition on the disk.
 	Partitions []*Partition `json:"partitions"`

--- a/pkg/block/block_darwin.go
+++ b/pkg/block/block_darwin.go
@@ -258,6 +258,7 @@ func (info *Info) load() error {
 			Model:                  ioregPlist.ModelNumber,
 			SerialNumber:           ioregPlist.SerialNumber,
 			WWN:                    "",
+			WWNNoExtension:         "",
 			Partitions:             make([]*Partition, 0, len(disk.Partitions)+len(disk.APFSVolumes)),
 		}
 

--- a/pkg/block/block_linux.go
+++ b/pkg/block/block_linux.go
@@ -183,6 +183,18 @@ func diskBusPath(paths *linuxpath.Paths, disk string) string {
 	return util.UNKNOWN
 }
 
+func diskWWNNoExtension(paths *linuxpath.Paths, disk string) string {
+	info, err := udevInfoDisk(paths, disk)
+	if err != nil {
+		return util.UNKNOWN
+	}
+
+	if wwn, ok := info["ID_WWN"]; ok {
+		return wwn
+	}
+	return util.UNKNOWN
+}
+
 func diskWWN(paths *linuxpath.Paths, disk string) string {
 	info, err := udevInfoDisk(paths, disk)
 	if err != nil {
@@ -326,6 +338,7 @@ func disks(ctx *context.Context, paths *linuxpath.Paths) []*Disk {
 		model := diskModel(paths, dname)
 		serialNo := diskSerialNumber(paths, dname)
 		wwn := diskWWN(paths, dname)
+		wwnNoExtension := diskWWNNoExtension(paths, dname)
 		removable := diskIsRemovable(paths, dname)
 
 		if storageController == STORAGE_CONTROLLER_LOOP && size == 0 {
@@ -345,6 +358,7 @@ func disks(ctx *context.Context, paths *linuxpath.Paths) []*Disk {
 			Model:                  model,
 			SerialNumber:           serialNo,
 			WWN:                    wwn,
+			WWNNoExtension:         wwnNoExtension,
 		}
 
 		parts := diskPartitions(ctx, paths, dname)

--- a/pkg/block/block_windows.go
+++ b/pkg/block/block_windows.go
@@ -155,6 +155,7 @@ func (i *Info) load() error {
 			Model:                  strings.TrimSpace(*diskdrive.Caption),
 			SerialNumber:           strings.TrimSpace(*diskdrive.SerialNumber),
 			WWN:                    util.UNKNOWN, // TODO: add information
+			WWNNoExtension:         util.UNKNOWN, // TODO: add information
 			Partitions:             make([]*Partition, 0),
 		}
 		for _, diskpartition := range win32DiskPartitionDescriptions {


### PR DESCRIPTION
Provide a way to get the disk WWN without the vendor extension.

[Ironic root device hints](https://docs.openstack.org/ironic/latest/install/advanced.html#specifying-the-disk-for-deployment-root-device-hints) support matching separately on the WWN, vendor extension, and WWN+extension. This makes it useful to be able to separate the vendor extension from the base WWN.