### PR TITLE
Fix parsing of PCI domains longer than 4 digits

### DIFF
--- a/pkg/pci/address/address.go
+++ b/pkg/pci/address/address.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	regexAddress *regexp.Regexp = regexp.MustCompile(
-		`^(([0-9a-f]{0,4}):)?([0-9a-f]{2}):([0-9a-f]{2})\.([0-9a-f]{1})$`,
+		`^(([0-9a-f]{0,8}):)?([0-9a-f]{2}):([0-9a-f]{2})\.([0-9a-f]{1})$`,
 	)
 )
 
@@ -30,12 +30,11 @@ func (addr *Address) String() string {
 	return addr.Domain + ":" + addr.Bus + ":" + addr.Device + "." + addr.Function
 }
 
-// FromString returns an Address struct from an ddress string in either
-// $BUS:$DEVICE.$FUNCTION (BDF) format or it can be a full PCI address that
-// includes the 4-digit $DOMAIN information as well:
-// $DOMAIN:$BUS:$DEVICE.$FUNCTION.
+// FromString returns [Address] from an address string in either
+// $BUS:$DEVICE.$FUNCTION (BDF) format or a full PCI address that
+// includes the $DOMAIN: $DOMAIN:$BUS:$DEVICE.$FUNCTION.
 //
-// Returns "" if the address string wasn't a valid PCI address.
+// If the address string isn't a valid PCI address, then nil is returned.
 func FromString(address string) *Address {
 	addrLowered := strings.ToLower(address)
 	matches := regexAddress.FindStringSubmatch(addrLowered)

--- a/pkg/pci/address/address.go
+++ b/pkg/pci/address/address.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	regexAddress *regexp.Regexp = regexp.MustCompile(
-		`^(([0-9a-f]{0,8}):)?([0-9a-f]{2}):([0-9a-f]{2})\.([0-9a-f]{1})$`,
+		`^((1?[0-9a-f]{0,4}):)?([0-9a-f]{2}):([0-9a-f]{2})\.([0-9a-f]{1})$`,
 	)
 )
 
@@ -32,7 +32,7 @@ func (addr *Address) String() string {
 
 // FromString returns [Address] from an address string in either
 // $BUS:$DEVICE.$FUNCTION (BDF) format or a full PCI address that
-// includes the $DOMAIN: $DOMAIN:$BUS:$DEVICE.$FUNCTION.
+// includes the domain: $DOMAIN:$BUS:$DEVICE.$FUNCTION.
 //
 // If the address string isn't a valid PCI address, then nil is returned.
 func FromString(address string) *Address {

--- a/pkg/pci/address/address_test.go
+++ b/pkg/pci/address/address_test.go
@@ -62,6 +62,16 @@ func TestPCIAddressFromString(t *testing.T) {
 				Function: "a",
 			},
 		},
+		{
+			// PCI-X / PCI Express extensions may use 5-digit domain
+			addrStr: "10000:03:00.A",
+			expected: &pciaddr.Address{
+				Domain:   "10000",
+				Bus:      "03",
+				Device:   "00",
+				Function: "a",
+			},
+		},
 	}
 	for x, test := range tests {
 		got := pciaddr.FromString(test.addrStr)


### PR DESCRIPTION
Allow parsing of PCI addresses like `10001:80:05.0` where the domain component is longer than 4 digits.

The domain component should be able to handle values up to 32 bits - see: https://patches.dpdk.org/project/dpdk/patch/20200512133057.106374-1-dariusz.stojaczyk@intel.com/

Fixes #372 