### PR TITLE
update Step Security hardener action

### DIFF
--- a/.github/workflows/fmtcheck.yml
+++ b/.github/workflows/fmtcheck.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - name: harden runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
        with:
          egress-policy: block
          disable-sudo: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - name: harden runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
        with:
          egress-policy: block
          disable-sudo: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         go: [ '1.19', '1.20', '1.21']
     steps:
      - name: harden runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
        with:
          egress-policy: block
          disable-sudo: true
@@ -51,7 +51,7 @@ jobs:
         go: [ '1.18', '1.19']
     steps:
      - name: harden runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
        with:
          egress-policy: block
          disable-sudo: true
@@ -82,7 +82,7 @@ jobs:
         go: [ '1.20', '1.21' ]
     steps:
      - name: harden runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
        with:
          egress-policy: block
          disable-sudo: true
@@ -119,7 +119,7 @@ jobs:
         go: [ '1.19' ]
     steps:
      - name: harden runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
        with:
          egress-policy: block
          disable-sudo: true
@@ -163,7 +163,7 @@ jobs:
         go: [ '1.18' ]
     steps:
      - name: harden runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+       uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
        with:
          egress-policy: block
          disable-sudo: true


### PR DESCRIPTION
The step security Github Action step was stuck and not letting the
workflow proceed. Step Security advised updating to the latest
harden-runner version.
    
Issue step-security/harden-runner#466