### PR TITLE
use Go idiomatic naming for Architecture consts

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -154,8 +154,12 @@ var (
 type Architecture = topology.Architecture
 
 const (
-	ARCHITECTURE_SMP  = topology.ARCHITECTURE_SMP
-	ARCHITECTURE_NUMA = topology.ARCHITECTURE_NUMA
+	ArchitectureSMP = topology.ArchitectureSMP
+	// DEPRECATED: Please use ArchitectureSMP
+	ARCHITECTURE_SMP = topology.ArchitectureSMP
+	ArchitectureNUMA = topology.ArchitectureNUMA
+	// DEPRECATED: Please use ArchitectureNUMA
+	ARCHITECTURE_NUMA = topology.ArchitectureNUMA
 )
 
 type PCIInfo = pci.Info

--- a/pkg/gpu/gpu_linux.go
+++ b/pkg/gpu/gpu_linux.go
@@ -137,7 +137,7 @@ func gpuFillNUMANodes(ctx *context.Context, cards []*GraphicsCard) {
 		// Problem getting topology information so just set the graphics card's
 		// node to nil
 		for _, card := range cards {
-			if topo.Architecture != topology.ARCHITECTURE_NUMA {
+			if topo.Architecture != topology.ArchitectureNUMA {
 				card.Node = nil
 			}
 		}

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -135,7 +135,7 @@ func New(opts ...*option.Option) (*Info, error) {
 	// by default we don't report NUMA information;
 	// we will only if are sure we are running on NUMA architecture
 	info := &Info{
-		arch: topology.ARCHITECTURE_SMP,
+		arch: topology.ArchitectureSMP,
 		ctx:  ctx,
 	}
 

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -325,7 +325,7 @@ func (info *Info) GetDevice(address string) *Device {
 
 	device := info.getDeviceFromModaliasInfo(address, modaliasInfo)
 	device.Revision = getDeviceRevision(info.ctx, pciAddr)
-	if info.arch == topology.ARCHITECTURE_NUMA {
+	if info.arch == topology.ArchitectureNUMA {
 		device.Node = getDeviceNUMANode(info.ctx, pciAddr)
 	}
 	device.Driver = getDeviceDriver(info.ctx, pciAddr)

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -26,15 +26,24 @@ type Architecture int
 
 const (
 	// SMP is a Symmetric Multi-Processor system
-	ARCHITECTURE_SMP Architecture = iota
+	ArchitectureSMP Architecture = iota
 	// NUMA is a Non-Uniform Memory Access system
-	ARCHITECTURE_NUMA
+	ArchitectureNUMA
+)
+
+const (
+	// DEPRECATED: please use ArchitectureSMP.
+	// TODO(jaypipes): Remove before v1.0
+	ARCHITECTURE_SMP = ArchitectureSMP
+	// DEPRECATED: please use ArchitectureNUMA.
+	// TODO(jaypipes): Remove before v1.0
+	ARCHITECTURE_NUMA = ArchitectureNUMA
 )
 
 var (
 	architectureString = map[Architecture]string{
-		ARCHITECTURE_SMP:  "SMP",
-		ARCHITECTURE_NUMA: "NUMA",
+		ArchitectureSMP:  "SMP",
+		ArchitectureNUMA: "NUMA",
 	}
 
 	// NOTE(fromani): the keys are all lowercase and do not match
@@ -43,8 +52,8 @@ var (
 	// Architecture:MarshalJSON.
 	// We use this table only in UnmarshalJSON, so it should be OK.
 	stringArchitecture = map[string]Architecture{
-		"smp":  ARCHITECTURE_SMP,
-		"numa": ARCHITECTURE_NUMA,
+		"smp":  ArchitectureSMP,
+		"numa": ArchitectureNUMA,
 	}
 )
 
@@ -126,7 +135,7 @@ func New(opts ...*option.Option) (*Info, error) {
 
 func (i *Info) String() string {
 	archStr := "SMP"
-	if i.Architecture == ARCHITECTURE_NUMA {
+	if i.Architecture == ArchitectureNUMA {
 		archStr = "NUMA"
 	}
 	res := fmt.Sprintf(

--- a/pkg/topology/topology_linux.go
+++ b/pkg/topology/topology_linux.go
@@ -21,9 +21,9 @@ import (
 func (i *Info) load() error {
 	i.Nodes = topologyNodes(i.ctx)
 	if len(i.Nodes) == 1 {
-		i.Architecture = ARCHITECTURE_SMP
+		i.Architecture = ArchitectureSMP
 	} else {
-		i.Architecture = ARCHITECTURE_NUMA
+		i.Architecture = ArchitectureNUMA
 	}
 	return nil
 }

--- a/pkg/topology/topology_test.go
+++ b/pkg/topology/topology_test.go
@@ -32,7 +32,7 @@ func TestTopology(t *testing.T) {
 		t.Fatalf("Expected >0 nodes but got 0.")
 	}
 
-	if info.Architecture == topology.ARCHITECTURE_NUMA && len(info.Nodes) == 1 {
+	if info.Architecture == topology.ArchitectureNUMA && len(info.Nodes) == 1 {
 		t.Fatalf("Got NUMA architecture but only 1 node.")
 	}
 

--- a/pkg/topology/topology_windows.go
+++ b/pkg/topology/topology_windows.go
@@ -31,9 +31,9 @@ func (i *Info) load() error {
 	}
 	i.Nodes = nodes
 	if len(nodes) == 1 {
-		i.Architecture = ARCHITECTURE_SMP
+		i.Architecture = ArchitectureSMP
 	} else {
-		i.Architecture = ARCHITECTURE_NUMA
+		i.Architecture = ArchitectureNUMA
 	}
 	return nil
 }


### PR DESCRIPTION
Updates the `ARCHITECTURE_SMP` and `ARCHITECTURE_NUMA` constants to `ArchitectureSMP` and `ArchitectureNUMA`, respectively, to align with idiomatic Go naming conventions.

For backwards-compat, keeps `ARCHITECTURE_SMP` and `ARCHITECTURE_NUMA` in the aliased variables for a few releases. These will be discarded when we cut a v1.0 series.