### PR TITLE
use TotalXXX instead of NumXXX

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ information about the CPUs on the host system.
 
 * `ghw.CPUInfo.TotalCores` has the total number of physical cores the host
   system contains
-* `ghw.CPUInfo.TotalThreads` has the total number of hardware threads the
-  host system contains
+* `ghw.CPUInfo.TotalHardwareThreads` has the total number of hardware threads
+  the host system contains
 * `ghw.CPUInfo.Processors` is an array of `ghw.Processor` structs, one for each
   physical processor package contained in the host
 
@@ -85,10 +85,10 @@ Each `ghw.Processor` struct contains a number of fields:
 
 * `ghw.Processor.ID` is the physical processor `uint32` ID according to the
   system
-* `ghw.Processor.NumCores` is the number of physical cores in the processor
+* `ghw.Processor.TotalCores` is the number of physical cores in the processor
   package
-* `ghw.Processor.NumThreads` is the number of hardware threads in the processor
-  package
+* `ghw.Processor.TotalHardwareThreads` is the number of hardware threads in the
+  processor package
 * `ghw.Processor.Vendor` is a string containing the vendor name
 * `ghw.Processor.Model` is a string containing the vendor's model name
 * `ghw.Processor.Capabilities` (Linux only) is an array of strings indicating
@@ -102,8 +102,8 @@ A `ghw.ProcessorCore` has the following fields:
   core. Note that this does *not* necessarily equate to a zero-based index of
   the core within a physical package. For example, the core IDs for an Intel Core
   i7 are 0, 1, 2, 8, 9, and 10
-* `ghw.ProcessorCore.NumThreads` is the number of hardware threads associated
-  with the core
+* `ghw.ProcessorCore.TotalHardwareThreads` is the number of hardware threads
+  associated with the core
 * `ghw.ProcessorCore.LogicalProcessors` is an array of ints representing the
   logical processor IDs assigned to any processing unit for the core. These are
   sometimes called the "thread siblings". Logical processor IDs are the

--- a/pkg/cpu/cpu.go
+++ b/pkg/cpu/cpu.go
@@ -23,7 +23,11 @@ type ProcessorCore struct {
 	// within a physical package. For example, the core IDs for an Intel Core
 	// i7 are 0, 1, 2, 8, 9, and 10
 	ID int `json:"id"`
-	// NumThreads is the number of hardware threads associated with the core
+	// TotalHardwareThreads is the number of hardware threads associated with
+	// the core
+	TotalHardwareThreads uint32 `json:"total_hardware_threads"`
+	// NumThreads is the number of hardware threads associated with the core.
+	// DEPRECATED: Use `TotalHardwareThreads` instead.
 	NumThreads uint32 `json:"total_threads"`
 	// LogicalProcessors is a slice of ints representing the logical processor
 	// IDs assigned to any processing unit for the core. These are sometimes
@@ -38,7 +42,7 @@ func (c *ProcessorCore) String() string {
 	return fmt.Sprintf(
 		"processor core #%d (%d threads), logical processors %v",
 		c.ID,
-		c.NumThreads,
+		c.TotalHardwareThreads,
 		c.LogicalProcessors,
 	)
 }
@@ -47,9 +51,16 @@ func (c *ProcessorCore) String() string {
 type Processor struct {
 	// ID is the physical processor `uint32` ID according to the system
 	ID int `json:"id"`
+	// TotalCores is the number of physical cores in the processor package
+	TotalCores uint32 `json:"total_cores"`
 	// NumCores is the number of physical cores in the processor package
-	NumCores uint32 `json:"total_cores"`
+	// DEPRECATED: Use `TotalCores` instead.
+	NumCores uint32 `json:"-"`
+	// TotalHardwareThreads is the number of hardware threads associated with
+	// the processor package
+	TotalHardwareThreads uint32 `json:"total_hardware_threads"`
 	// NumThreads is the number of hardware threads in the processor package
+	// DEPRECATED: Use `TotalHardwareThreads` instead.
 	NumThreads uint32 `json:"total_threads"`
 	// Vendor is a string containing the vendor name
 	Vendor string `json:"vendor"`
@@ -91,19 +102,19 @@ func (p *Processor) HasCapability(find string) bool {
 // String returns a short string describing the Processor
 func (p *Processor) String() string {
 	ncs := "cores"
-	if p.NumCores == 1 {
+	if p.TotalCores == 1 {
 		ncs = "core"
 	}
 	nts := "threads"
-	if p.NumThreads == 1 {
+	if p.TotalHardwareThreads == 1 {
 		nts = "thread"
 	}
 	return fmt.Sprintf(
 		"physical package #%d (%d %s, %d hardware %s)",
 		p.ID,
-		p.NumCores,
+		p.TotalCores,
 		ncs,
-		p.NumThreads,
+		p.TotalHardwareThreads,
 		nts,
 	)
 }
@@ -117,6 +128,10 @@ type Info struct {
 	TotalCores uint32 `json:"total_cores"`
 	// TotalThreads is the total number of hardware threads the host system
 	// contains
+	TotalHardwareThreads uint32 `json:"total_hardware_threads"`
+	// TotalThreads is the total number of hardware threads the host system
+	// contains
+	// DEPRECATED: Use `TotalHardwareThreads` instead
 	TotalThreads uint32 `json:"total_threads"`
 	// Processors is a slice of Processor struct pointers, one for each
 	// physical processor package contained in the host

--- a/pkg/cpu/cpu_linux_test.go
+++ b/pkg/cpu/cpu_linux_test.go
@@ -49,10 +49,10 @@ func TestArmCPU(t *testing.T) {
 	}
 
 	for _, p := range info.Processors {
-		if p.NumCores == 0 {
+		if p.TotalCores == 0 {
 			t.Fatalf("Expected >0 cores but got 0.")
 		}
-		if p.NumThreads == 0 {
+		if p.TotalHardwareThreads == 0 {
 			t.Fatalf("Expected >0 threads but got 0.")
 		}
 		if len(p.Capabilities) == 0 {
@@ -66,7 +66,7 @@ func TestArmCPU(t *testing.T) {
 			t.Fatalf("Expected >0 cores in processor, but got 0.")
 		}
 		for _, c := range p.Cores {
-			if c.NumThreads == 0 {
+			if c.TotalHardwareThreads == 0 {
 				t.Fatalf("Expected >0 threads but got 0.")
 			}
 			if len(c.LogicalProcessors) == 0 {
@@ -118,6 +118,7 @@ func TestCheckCPUTopologyFilesForOfflineCPU(t *testing.T) {
 		t.Fatalf("Unexpected warning related to missing files under topology directory was reported")
 	}
 }
+
 func TestNumCoresAmongOfflineCPUs(t *testing.T) {
 	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_CPU"); ok {
 		t.Skip("Skipping CPU tests.")

--- a/pkg/cpu/cpu_test.go
+++ b/pkg/cpu/cpu_test.go
@@ -33,10 +33,10 @@ func TestCPU(t *testing.T) {
 	}
 
 	for _, p := range info.Processors {
-		if p.NumCores == 0 {
+		if p.TotalCores == 0 {
 			t.Fatalf("Expected >0 cores but got 0.")
 		}
-		if p.NumThreads == 0 {
+		if p.TotalHardwareThreads == 0 {
 			t.Fatalf("Expected >0 threads but got 0.")
 		}
 		if len(p.Capabilities) == 0 {
@@ -50,7 +50,7 @@ func TestCPU(t *testing.T) {
 			t.Fatalf("Expected >0 cores in processor, but got 0.")
 		}
 		for _, c := range p.Cores {
-			if c.NumThreads == 0 {
+			if c.TotalHardwareThreads == 0 {
 				t.Fatalf("Expected >0 threads but got 0.")
 			}
 			if len(c.LogicalProcessors) == 0 {

--- a/pkg/cpu/cpu_windows.go
+++ b/pkg/cpu/cpu_windows.go
@@ -32,10 +32,12 @@ func (i *Info) load() error {
 	var totCores uint32
 	var totThreads uint32
 	for _, p := range i.Processors {
-		totCores += p.NumCores
-		totThreads += p.NumThreads
+		totCores += p.TotalCores
+		totThreads += p.TotalHardwareThreads
 	}
 	i.TotalCores = totCores
+	i.TotalHardwareThreads = totThreads
+	// TODO(jaypipes): Remove TotalThreads by v1.0
 	i.TotalThreads = totThreads
 	return nil
 }
@@ -48,7 +50,11 @@ func processorsGet(win32descriptions []win32Processor) []*Processor {
 			ID:         index,
 			Model:      *description.Name,
 			Vendor:     *description.Manufacturer,
-			NumCores:   description.NumberOfCores,
+			TotalCores: description.NumberOfCores,
+			// TODO(jaypipes): Remove NumCores before v1.0
+			NumCores:             description.NumberOfCores,
+			TotalHardwareThreads: description.NumberOfLogicalProcessors,
+			// TODO(jaypipes): Remove NumThreads before v1.0
 			NumThreads: description.NumberOfLogicalProcessors,
 		}
 		procs = append(procs, p)

--- a/pkg/topology/topology_test.go
+++ b/pkg/topology/topology_test.go
@@ -44,10 +44,10 @@ func TestTopology(t *testing.T) {
 			if len(c.LogicalProcessors) == 0 {
 				t.Fatalf("Expected >0 logical processors but got 0.")
 			}
-			if uint32(len(c.LogicalProcessors)) != c.NumThreads {
+			if uint32(len(c.LogicalProcessors)) != c.TotalHardwareThreads {
 				t.Fatalf(
-					"Expected NumThreads == len(logical procs) but %d != %d",
-					c.NumThreads,
+					"Expected TotalHardwareThreads == len(logical procs) but %d != %d",
+					c.TotalHardwareThreads,
 					len(c.LogicalProcessors),
 				)
 			}


### PR DESCRIPTION
All other fields that contain a total amount of something begin with the word `Total` except for the `pkg/cpu.Processor.NumCores` and `NumThreads` fields. This commit adds new fields to `pkg/cpu.Processor` called `TotalCores` and `TotalHardwareThreads` to bring the names of these fields in-line with all other amount/total fields.

In addition, adds a `TotalHardwareThreads` field to the `pkg/cpu.Info` struct and deprecates the less-explicit `TotalThreads` field.

I'd like to remove the now-deprecated `NumThreads`, `NumCores`, and `TotalThreads` fields before we get to a `v.1.0` series.