### PR TITLE
Populate `Vendor` field for ARM cpus

### DIFF
--- a/pkg/cpu/cpu_linux.go
+++ b/pkg/cpu/cpu_linux.go
@@ -108,6 +108,8 @@ func processorsGet(ctx *context.Context) []*Processor {
 				proc.Vendor = lp.Attrs["vendor_id"]
 			} else if len(lp.Attrs["isa"]) != 0 { // RISCV64
 				proc.Vendor = lp.Attrs["isa"]
+			} else if lp.Attrs["CPU implementer"] == "0x41" { // ARM
+				proc.Vendor = "ARM"
 			}
 			procs[procID] = proc
 		}

--- a/pkg/cpu/cpu_linux_test.go
+++ b/pkg/cpu/cpu_linux_test.go
@@ -49,6 +49,9 @@ func TestArmCPU(t *testing.T) {
 	}
 
 	for _, p := range info.Processors {
+		if p.Vendor == "" {
+			t.Fatalf("Expected not empty vendor field.")
+		}
 		if p.TotalCores == 0 {
 			t.Fatalf("Expected >0 cores but got 0.")
 		}


### PR DESCRIPTION
In ARM  systems, the `/proc/cpuinfo` file does not contain `vendor_id` fields. In the `lscpu` tool, the `CPU implementor` code and a lookup table are used to provide a human-readable vendor name [1].

When running on ARM systems, populate the `CPU.Info.Processors[*].Vendor` field with the "ARM" string.

[1] https://github.com/util-linux/util-linux/pull/564