### PR TITLE
ci: golang: rotate the most 3 recent supported versions

### DIFF
--- a/.github/workflows/fmtcheck.yml
+++ b/.github/workflows/fmtcheck.yml
@@ -31,6 +31,6 @@ jobs:
      - name: setup go
        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
        with:
-         go-version: 1.21
+         go-version: 1.23
      - name: check fmt
        run: 'bash -c "diff -u <(echo -n) <(gofmt -d .)"'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
      - name: setup go
        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
        with:
-         go-version: 1.21
+         go-version: 1.23
      - name: lint
        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
        with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.19', '1.20', '1.21']
+        go: [ '1.21', '1.22', '1.23']
     steps:
      - name: harden runner
        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
@@ -79,7 +79,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        go: [ '1.20', '1.21' ]
+        go: [ '1.22', '1.23' ]
     steps:
      - name: harden runner
        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1


### PR DESCRIPTION
we want to support most 3 recent golang versions
on modern platform and the most modern golang version available on legacy platforms, so let's bump the
versions accordingly