### PR TITLE
fix: Refactor OpenDestination func

### DIFF
--- a/pkg/snapshot/pack.go
+++ b/pkg/snapshot/pack.go
@@ -32,26 +32,21 @@ func PackFrom(snapshotName, sourceRoot string) error {
 // if the file seems to exist and have existing content already.
 // This is done to avoid accidental overwrites.
 func OpenDestination(snapshotName string) (*os.File, error) {
-	var f *os.File
-	var err error
-
-	if _, err = os.Stat(snapshotName); errors.Is(err, os.ErrNotExist) {
-		if f, err = os.Create(snapshotName); err != nil {
+	f, err := os.OpenFile(snapshotName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		if !errors.Is(err, os.ErrExist) {
 			return nil, err
 		}
-	} else if err != nil {
-		return nil, err
-	} else {
-		f, err := os.OpenFile(snapshotName, os.O_WRONLY, 0600)
-		if err != nil {
-			return nil, err
-		}
-		fs, err := f.Stat()
+		fs, err := os.Stat(snapshotName)
 		if err != nil {
 			return nil, err
 		}
 		if fs.Size() > 0 {
-			return nil, fmt.Errorf("File %s already exists and is of size >0", snapshotName)
+			return nil, fmt.Errorf("file %s already exists and is of size > 0", snapshotName)
+		}
+		f, err = os.OpenFile(snapshotName, os.O_WRONLY, 0600)
+		if err != nil {
+			return nil, err
 		}
 	}
 	return f, nil


### PR DESCRIPTION
- Replaced os.Stat call and os.Create with os.OpenFile with O_EXCL to avoid TOCTOU.
- Improved logic to handle file size check only when the file exists.