### PR TITLE
Improve string and file extension handling: ReplaceAll & filepath.Ext

### DIFF
--- a/pkg/gpu/gpu_windows.go
+++ b/pkg/gpu/gpu_windows.go
@@ -56,7 +56,7 @@ func (i *Info) load() error {
 	// Building dynamic WHERE clause with addresses to create a single query collecting all desired data
 	queryAddresses := []string{}
 	for _, description := range win32VideoControllerDescriptions {
-		var queryAddres = strings.Replace(description.PNPDeviceID, "\\", `\\`, -1)
+		var queryAddres = strings.ReplaceAll(description.PNPDeviceID, "\\", `\\`)
 		queryAddresses = append(queryAddresses, "PNPDeviceID='"+queryAddres+"'")
 	}
 	whereClause := strings.Join(queryAddresses[:], " OR ")
@@ -85,7 +85,7 @@ func (i *Info) load() error {
 
 func GetDevice(id string, entities []win32PnPEntity) *pci.Device {
 	// Backslashing PnP address ID as requested by JSON and VMI query: https://docs.microsoft.com/en-us/windows/win32/wmisdk/where-clause
-	var queryAddress = strings.Replace(id, "\\", `\\`, -1)
+	var queryAddress = strings.ReplaceAll(id, "\\", `\\`)
 	// Preparing default structure
 	var device = &pci.Device{
 		Address: queryAddress,

--- a/pkg/memory/memory_linux.go
+++ b/pkg/memory/memory_linux.go
@@ -242,7 +242,7 @@ func memTotalPhysicalBytesFromSyslog(paths *linuxpath.Paths) int64 {
 	for _, file := range logFiles {
 		if strings.HasPrefix(file.Name(), "syslog") {
 			fullPath := filepath.Join(logDir, file.Name())
-			unzip := strings.HasSuffix(file.Name(), ".gz")
+			unzip := filepath.Ext(file.Name()) == ".gz"
 			var r io.ReadCloser
 			r, err = os.Open(fullPath)
 			if err != nil {

--- a/pkg/snapshot/pack.go
+++ b/pkg/snapshot/pack.go
@@ -32,26 +32,25 @@ func PackFrom(snapshotName, sourceRoot string) error {
 // if the file seems to exist and have existing content already.
 // This is done to avoid accidental overwrites.
 func OpenDestination(snapshotName string) (*os.File, error) {
-    f, err := os.OpenFile(snapshotName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
-    if err != nil {
-        if !errors.Is(err, os.ErrExist) {
-            return nil, err
-        }
-        fs, err := os.Stat(snapshotName)
-        if err != nil {
-            return nil, err
-        }
-        if fs.Size() > 0 {
-            return nil, fmt.Errorf("file %s already exists and is of size > 0", snapshotName)
-        }
-        f, err = os.OpenFile(snapshotName, os.O_WRONLY, 0600)
-        if err != nil {
-            return nil, err
-        }
-    }
-    return f, nil
+	f, err := os.OpenFile(snapshotName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		if !errors.Is(err, os.ErrExist) {
+			return nil, err
+		}
+		fs, err := os.Stat(snapshotName)
+		if err != nil {
+			return nil, err
+		}
+		if fs.Size() > 0 {
+			return nil, fmt.Errorf("file %s already exists and is of size > 0", snapshotName)
+		}
+		f, err = os.OpenFile(snapshotName, os.O_WRONLY, 0600)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return f, nil
 }
-
 
 // PakcWithWriter creates a snapshot sending all the binary data to the
 // given `fw` writer. The snapshot is made from the directory tree whose

--- a/pkg/snapshot/pack.go
+++ b/pkg/snapshot/pack.go
@@ -32,30 +32,26 @@ func PackFrom(snapshotName, sourceRoot string) error {
 // if the file seems to exist and have existing content already.
 // This is done to avoid accidental overwrites.
 func OpenDestination(snapshotName string) (*os.File, error) {
-	var f *os.File
-	var err error
-
-	if _, err = os.Stat(snapshotName); errors.Is(err, os.ErrNotExist) {
-		if f, err = os.Create(snapshotName); err != nil {
-			return nil, err
-		}
-	} else if err != nil {
-		return nil, err
-	} else {
-		f, err := os.OpenFile(snapshotName, os.O_WRONLY, 0600)
-		if err != nil {
-			return nil, err
-		}
-		fs, err := f.Stat()
-		if err != nil {
-			return nil, err
-		}
-		if fs.Size() > 0 {
-			return nil, fmt.Errorf("File %s already exists and is of size >0", snapshotName)
-		}
-	}
-	return f, nil
+    f, err := os.OpenFile(snapshotName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+    if err != nil {
+        if !errors.Is(err, os.ErrExist) {
+            return nil, err
+        }
+        fs, err := os.Stat(snapshotName)
+        if err != nil {
+            return nil, err
+        }
+        if fs.Size() > 0 {
+            return nil, fmt.Errorf("file %s already exists and is of size > 0", snapshotName)
+        }
+        f, err = os.OpenFile(snapshotName, os.O_WRONLY, 0600)
+        if err != nil {
+            return nil, err
+        }
+    }
+    return f, nil
 }
+
 
 // PakcWithWriter creates a snapshot sending all the binary data to the
 // given `fw` writer. The snapshot is made from the directory tree whose


### PR DESCRIPTION
Replaced strings.Replace with updated strings.ReplaceAll

Use filepath.Ext for file extension instead of strings.HasSuffix.