### PR TITLE
fixed an out of range index access

### DIFF
--- a/pkg/cpu/cpu_darwin.go
+++ b/pkg/cpu/cpu_darwin.go
@@ -84,6 +84,9 @@ func populateSysctlOutput() error {
 	for _, l := range oS {
 		if l != "" {
 			s := strings.SplitN(l, ":", 2)
+			if len(s) < 2 {
+				continue
+			}
 			k, v := strings.TrimSpace(s[0]), strings.TrimSpace(s[1])
 			sysctlOutput[k] = v
 


### PR DESCRIPTION
Crashing thread - found in https://github.com/docker/for-mac/issues/7588

```
 panic: runtime error: index out of range [1] with length 1

goroutine 1124 [running]:
github.com/jaypipes/ghw/pkg/cpu.populateSysctlOutput()
github.com/jaypipes/ghw@v0.13.0/pkg/cpu/cpu_darwin.go:87 +0x204
github.com/jaypipes/ghw/pkg/cpu.(*Info).load(0x14001c11260)
github.com/jaypipes/ghw@v0.13.0/pkg/cpu/cpu_darwin.go:17 +0x20
github.com/jaypipes/ghw/pkg/context.(*Context).Do(0x1400038c780, 0x14001f21c58) 
github.com/jaypipes/ghw@v0.13.0/pkg/context/context.go:125 +0x78
github.com/jaypipes/ghw/pkg/cpu.New({0x0?, 0x14000e14100?, 0x2?})
```