### PR TITLE
fix PCI address in filepath for graphics cards

### DIFF
--- a/pkg/gpu/gpu_linux.go
+++ b/pkg/gpu/gpu_linux.go
@@ -90,8 +90,11 @@ func (i *Info) load() error {
 			continue
 		}
 		pathParts := strings.Split(dest, "/")
+		// The PCI address of the graphics card is the *last* PCI address in
+		// the filepath...
 		pciAddress := ""
-		for _, part := range pathParts {
+		for x := len(pathParts) - 1; x >= 0; x-- {
+			part := pathParts[x]
 			if reValidPCIAddress.MatchString(part) {
 				pciAddress = part
 				break


### PR DESCRIPTION
Ensure we take only the last PCI address in the `/sys/class/drm` sysfs output as the PCI Address of the graphics card. For some graphics cards, they are on a PCI bridge or host bus adapter that was erroneously being identified as the PCI Address of the graphics card itself.

Consider this `ll /sys/class/drm` output on one of my workstations:

```
lrwxrwxrwx 1 root root    0 Mar  9 17:57 card0 -> ../../devices/pci0000:00/0000:00:02.0/drm/card0
lrwxrwxrwx 1 root root    0 Mar  9 17:57 card0-DP-1 -> ../../devices/pci0000:00/0000:00:02.0/drm/card0/card0-DP-1
lrwxrwxrwx 1 root root    0 Mar  9 17:57 card0-HDMI-A-1 -> ../../devices/pci0000:00/0000:00:02.0/drm/card0/card0-HDMI-A-1
lrwxrwxrwx 1 root root    0 Mar  9 17:57 card0-HDMI-A-2 -> ../../devices/pci0000:00/0000:00:02.0/drm/card0/card0-HDMI-A-2
lrwxrwxrwx 1 root root    0 Mar  9 17:57 card1 -> ../../devices/pci0000:00/0000:00:01.0/0000:01:00.0/drm/card1
lrwxrwxrwx 1 root root    0 Mar  9 17:57 card1-DP-2 -> ../../devices/pci0000:00/0000:00:01.0/0000:01:00.0/drm/card1/card1-DP-2
lrwxrwxrwx 1 root root    0 Mar  9 17:57 card1-DP-3 -> ../../devices/pci0000:00/0000:00:01.0/0000:01:00.0/drm/card1/card1-DP-3
lrwxrwxrwx 1 root root    0 Mar  9 17:57 card1-DP-4 -> ../../devices/pci0000:00/0000:00:01.0/0000:01:00.0/drm/card1/card1-DP-4
lrwxrwxrwx 1 root root    0 Mar  9 17:57 card1-HDMI-A-3 -> ../../devices/pci0000:00/0000:00:01.0/0000:01:00.0/drm/card1/card1-HDMI-A-3
lrwxrwxrwx 1 root root    0 Mar  9 17:57 renderD128 -> ../../devices/pci0000:00/0000:00:02.0/drm/renderD128
lrwxrwxrwx 1 root root    0 Mar  9 17:57 renderD129 -> ../../devices/pci0000:00/0000:00:01.0/0000:01:00.0/drm/renderD129
```

Before this fix, `card1` was getting the PCI Address of `0000.:00:01.0` which was incorrect. After this fix, the PCI Address for `card` is the correct `000:01:00.0` which is the NVIDIA GPU itself not the Intel PCI bridge.

Fixes Issue #407