### PR TITLE
Get WWN for multipath block devices

### DIFF
--- a/pkg/block/block_linux.go
+++ b/pkg/block/block_linux.go
@@ -208,6 +208,10 @@ func diskWWN(paths *linuxpath.Paths, disk string) string {
 	if wwn, ok := info["ID_WWN"]; ok {
 		return wwn
 	}
+	// Device Mapper devices get DM_WWN instead of ID_WWN_WITH_EXTENSION
+	if wwn, ok := info["DM_WWN"]; ok {
+		return wwn
+	}
 	return util.UNKNOWN
 }
 


### PR DESCRIPTION
Device Mapper devices have `DM_WWN` set in udev in place of `ID_WWN_WITH_VENDOR_EXTENSION`. Reading `DM_WWN` allows us to see the WWN for multipath fibre channel or iSCSI block devices.

Because `DM_WWN` contains the vendor extension, there is no corresponding change to `WWNNoExtension`.