### PR TITLE
fix: gpu path parsing on linux

### DIFF
--- a/pkg/gpu/gpu_linux.go
+++ b/pkg/gpu/gpu_linux.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	validPCIAddress = `\b(0{0,4}:\d{2}:\d{2}.\d:?\w*)`
+	validPCIAddress = `\b(0{0,4}:[[:xdigit:]]{2}:[[:xdigit:]]{2}\.[[:xdigit:]]:?\w*)`
 )
 
 var reValidPCIAddress = regexp.MustCompile(validPCIAddress)

--- a/pkg/linuxpath/path_linux_test.go
+++ b/pkg/linuxpath/path_linux_test.go
@@ -11,10 +11,13 @@ package linuxpath_test
 
 import (
 	"os"
-
+	"path/filepath"
+	"slices"
+	"sort"
 	"testing"
 
 	"github.com/jaypipes/ghw/pkg/context"
+	"github.com/jaypipes/ghw/pkg/gpu"
 	"github.com/jaypipes/ghw/pkg/linuxpath"
 	"github.com/jaypipes/ghw/pkg/option"
 )
@@ -95,5 +98,55 @@ func TestPathChrootAndSpecifics(t *testing.T) {
 	expectedPath = "/redirect/host2-sys/bus/pci/devices"
 	if path != expectedPath {
 		t.Fatalf("Expected path.SysBusPciDevices to return %q but got %q", expectedPath, path)
+	}
+}
+
+func TestGpuPathRegexp(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Make sure that last element of path is unique across other paths.
+	var paths = []string{
+		"../../devices/pci0000:00/0000:00:03.1/0000:07:00.0/drm/card0",
+		"../../devices/pci0000:00/0000:00:0d.0/0000:01:00.1/drm/card1",
+		"../../devices/pci0000:25/0000:25:01.0/0000:26:00.0/drm/card2",
+		"../../devices/pci0000:89/0000:89:01.0/0000:8a:00.0/drm/card3",
+	}
+
+	// Expecting third element from paths above.
+	var expectedAddrs = []string{
+		"0000:07:00.0", "0000:01:00.1", "0000:26:00.0", "0000:8a:00.0",
+	}
+
+	drmPath := filepath.Join(tmp, "/sys/class/drm")
+	err := os.MkdirAll(drmPath, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, target := range paths {
+		linkname := filepath.Join(drmPath, filepath.Base(target))
+		err := os.Symlink(target, linkname)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	info, err := gpu.New(option.WithChroot(tmp))
+	if err != nil {
+		t.Fatalf("Expected nil err, but got %v", err)
+	}
+
+	if len(info.GraphicsCards) != len(expectedAddrs) {
+		t.Fatalf("Expected %d graphics cards, got %d", len(expectedAddrs), len(info.GraphicsCards))
+	}
+	foundAddrs := make([]string, 0)
+	for _, card := range info.GraphicsCards {
+		foundAddrs = append(foundAddrs, card.Address)
+	}
+
+	sort.Strings(expectedAddrs)
+	sort.Strings(foundAddrs)
+
+	if !slices.Equal(expectedAddrs, foundAddrs) {
+		t.Fatalf("Some cards not found")
 	}
 }


### PR DESCRIPTION
PCI addresses in `/sys/class/drm` sysfs contains hexadecimal digits. This fix replaces `\d` with `[[:xdigit:]]` in PCI address parser regexp.

Closes #411.