### PR TITLE
fix: only mark non-rotational HDDs as SSD

### DIFF
--- a/pkg/block/block_linux.go
+++ b/pkg/block/block_linux.go
@@ -331,6 +331,9 @@ func disks(ctx *context.Context, paths *linuxpath.Paths) []*Disk {
 		driveType, storageController := diskTypes(dname)
 		// TODO(jaypipes): Move this into diskTypes() once abstracting
 		// diskIsRotational for ease of unit testing
+		// Only reclassify HDD to SSD if non-rotational to avoid changing already correct types.
+		// This addresses changed kernel behavior where rotational detection may be unreliable,
+		// where some kernels report CD-ROM drives as non-rotational, incorrectly classifying them as SSD.
 		if !diskIsRotational(ctx, paths, dname) && driveType == DRIVE_TYPE_HDD {
 			driveType = DRIVE_TYPE_SSD
 		}

--- a/pkg/block/block_linux.go
+++ b/pkg/block/block_linux.go
@@ -331,7 +331,7 @@ func disks(ctx *context.Context, paths *linuxpath.Paths) []*Disk {
 		driveType, storageController := diskTypes(dname)
 		// TODO(jaypipes): Move this into diskTypes() once abstracting
 		// diskIsRotational for ease of unit testing
-		if !diskIsRotational(ctx, paths, dname) {
+		if !diskIsRotational(ctx, paths, dname) && driveType == DRIVE_TYPE_HDD {
 			driveType = DRIVE_TYPE_SSD
 		}
 		size := diskSizeBytes(paths, dname)


### PR DESCRIPTION
**Problem**
Starting with RHCOS 4.19 (possibly other newer kernels), optical drives and some loop devices report rotational=0, causing them to be misclassified as SSD.
RHCOS 4.19+:

```
lsblk -d -o name,rota
NAME  ROTA
loop0    0
loop1    0  
sda      1
sr0      0  ← CD-ROM incorrectly becomes SSD
```

RHCOS <= 4.18:

```
lsblk -d -o name,rota
NAME  ROTA
loop0    0
loop1    1
sda      1
sr0      1  ← CD-ROM correctly stays ODD
```

**The fix**
Only promote devices to SSD when they're actually HDD type devices

This is likely a general kernel behavior change, not RHCOS only, so the fix benefits all Linux distributions.


**Possible impact**
 sr0 stays ODD (fixes the core issue)
loop stays Virtual
Non-rotational sd*/vd*/hd*/xvd* still can be promoted to  SSD
nvme*/mmc* unchanged