### PR TITLE
Add USB devices

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -21,6 +21,7 @@ import (
 	pciaddress "github.com/jaypipes/ghw/pkg/pci/address"
 	"github.com/jaypipes/ghw/pkg/product"
 	"github.com/jaypipes/ghw/pkg/topology"
+	"github.com/jaypipes/ghw/pkg/usb"
 )
 
 type WithOption = option.Option
@@ -66,6 +67,10 @@ const (
 
 var (
 	Memory = memory.New
+)
+
+var (
+	USB = usb.New
 )
 
 type BlockInfo = block.Info

--- a/cmd/ghwc/commands/root.go
+++ b/cmd/ghwc/commands/root.go
@@ -72,6 +72,7 @@ func showAll(cmd *cobra.Command, args []string) error {
 			showBaseboard,
 			showProduct,
 			showAccelerator,
+			showUSB,
 		} {
 			err := f(cmd, args)
 			if err != nil {

--- a/cmd/ghwc/commands/usb.go
+++ b/cmd/ghwc/commands/usb.go
@@ -1,0 +1,47 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/jaypipes/ghw"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// usbCmd represents the `usb` command
+var usbCmd = &cobra.Command{
+	Use:   "usb",
+	Short: "Show USB information for the host system",
+	RunE:  showUSB,
+}
+
+// showUSB show usb information for the host system.
+func showUSB(cmd *cobra.Command, args []string) error {
+	usb, err := ghw.USB()
+	if err != nil {
+		return errors.Wrap(err, "error getting network info")
+	}
+
+	switch outputFormat {
+	case outputFormatHuman:
+		fmt.Printf("%v\n", usb)
+		for _, usb := range usb.Devices {
+			fmt.Printf(" %+v\n", usb)
+		}
+	case outputFormatJSON:
+		fmt.Printf("%s\n", usb.JSONString(pretty))
+	case outputFormatYAML:
+		fmt.Printf("%s", usb.YAMLString())
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(usbCmd)
+}

--- a/host.go
+++ b/host.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/jaypipes/ghw/pkg/context"
+	"github.com/jaypipes/ghw/pkg/usb"
 
 	"github.com/jaypipes/ghw/pkg/accelerator"
 	"github.com/jaypipes/ghw/pkg/baseboard"
@@ -42,6 +43,7 @@ type HostInfo struct {
 	Baseboard   *baseboard.Info   `json:"baseboard"`
 	Product     *product.Info     `json:"product"`
 	PCI         *pci.Info         `json:"pci"`
+	USB         *usb.Info         `json:"usb"`
 }
 
 // Host returns a pointer to a HostInfo struct that contains fields with
@@ -97,6 +99,11 @@ func Host(opts ...*WithOption) (*HostInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	usbInfo, err := usb.New(opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	return &HostInfo{
 		ctx:         ctx,
 		CPU:         cpuInfo,
@@ -111,6 +118,7 @@ func Host(opts ...*WithOption) (*HostInfo, error) {
 		Baseboard:   baseboardInfo,
 		Product:     productInfo,
 		PCI:         pciInfo,
+		USB:         usbInfo,
 	}, nil
 }
 
@@ -118,7 +126,7 @@ func Host(opts ...*WithOption) (*HostInfo, error) {
 // structs' String-ified output
 func (info *HostInfo) String() string {
 	return fmt.Sprintf(
-		"%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
+		"%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
 		info.Block.String(),
 		info.CPU.String(),
 		info.GPU.String(),
@@ -131,6 +139,7 @@ func (info *HostInfo) String() string {
 		info.Baseboard.String(),
 		info.Product.String(),
 		info.PCI.String(),
+		info.USB.String(),
 	)
 }
 

--- a/pkg/linuxpath/path_linux.go
+++ b/pkg/linuxpath/path_linux.go
@@ -56,6 +56,7 @@ func PathRootsFromContext(ctx *context.Context) PathRoots {
 }
 
 type Paths struct {
+	SysRoot                string
 	VarLog                 string
 	ProcMeminfo            string
 	ProcCpuinfo            string
@@ -66,6 +67,7 @@ type Paths struct {
 	SysDevicesSystemMemory string
 	SysDevicesSystemCPU    string
 	SysBusPciDevices       string
+	SysBusUsbDevices       string
 	SysClassDRM            string
 	SysClassDMI            string
 	SysClassNet            string
@@ -77,6 +79,7 @@ type Paths struct {
 func New(ctx *context.Context) *Paths {
 	roots := PathRootsFromContext(ctx)
 	return &Paths{
+		SysRoot:                filepath.Join(ctx.Chroot, roots.Sys),
 		VarLog:                 filepath.Join(ctx.Chroot, roots.Var, "log"),
 		ProcMeminfo:            filepath.Join(ctx.Chroot, roots.Proc, "meminfo"),
 		ProcCpuinfo:            filepath.Join(ctx.Chroot, roots.Proc, "cpuinfo"),
@@ -87,6 +90,7 @@ func New(ctx *context.Context) *Paths {
 		SysDevicesSystemMemory: filepath.Join(ctx.Chroot, roots.Sys, "devices", "system", "memory"),
 		SysDevicesSystemCPU:    filepath.Join(ctx.Chroot, roots.Sys, "devices", "system", "cpu"),
 		SysBusPciDevices:       filepath.Join(ctx.Chroot, roots.Sys, "bus", "pci", "devices"),
+		SysBusUsbDevices:       filepath.Join(ctx.Chroot, roots.Sys, "bus", "usb", "devices"),
 		SysClassDRM:            filepath.Join(ctx.Chroot, roots.Sys, "class", "drm"),
 		SysClassDMI:            filepath.Join(ctx.Chroot, roots.Sys, "class", "dmi"),
 		SysClassNet:            filepath.Join(ctx.Chroot, roots.Sys, "class", "net"),

--- a/pkg/snapshot/clonetree.go
+++ b/pkg/snapshot/clonetree.go
@@ -40,6 +40,7 @@ func CloneTreeInto(scratchDir string) error {
 func ExpectedCloneContent() []string {
 	fileSpecs := ExpectedCloneStaticContent()
 	fileSpecs = append(fileSpecs, ExpectedCloneNetContent()...)
+	fileSpecs = append(fileSpecs, ExpectedCloneUSBContent()...)
 	fileSpecs = append(fileSpecs, ExpectedClonePCIContent()...)
 	fileSpecs = append(fileSpecs, ExpectedCloneGPUContent()...)
 	return fileSpecs

--- a/pkg/snapshot/clonetree_stub.go
+++ b/pkg/snapshot/clonetree_stub.go
@@ -28,3 +28,7 @@ func ExpectedCloneNetContent() []string {
 func ExpectedClonePCIContent() []string {
 	return []string{}
 }
+
+func ExpectedCloneUSBContent() []string {
+	return []string{}
+}

--- a/pkg/snapshot/clonetree_usb_linux.go
+++ b/pkg/snapshot/clonetree_usb_linux.go
@@ -1,0 +1,45 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package snapshot
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// ExpectedCloneUSBContent returns a slice of strings pertaning to the USB interfaces
+func ExpectedCloneUSBContent() []string {
+	const sysBusUSB = "/sys/bus/usb/devices/"
+
+	paths := []string{sysBusUSB}
+	usbDevicesDirs, err := os.ReadDir(sysBusUSB)
+	if err != nil {
+		return []string{}
+	}
+
+	for _, dir := range usbDevicesDirs {
+		susBusUSBLink := filepath.Join(sysBusUSB, dir.Name())
+		paths = append(paths, susBusUSBLink)
+
+		fullDir, err := os.Readlink(susBusUSBLink)
+		if err != nil {
+			continue
+		}
+		if !filepath.IsAbs(fullDir) {
+			fullDir, err = filepath.Abs(filepath.Join(sysBusUSB, fullDir))
+			if err != nil {
+				continue
+			}
+		}
+		for _, fileName := range []string{"uevent", "interface", "product"} {
+			paths = append(paths, filepath.Join(fullDir, fileName))
+		}
+
+	}
+
+	return paths
+}

--- a/pkg/usb/usb.go
+++ b/pkg/usb/usb.go
@@ -1,0 +1,115 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package usb
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jaypipes/ghw/pkg/context"
+	"github.com/jaypipes/ghw/pkg/marshal"
+	"github.com/jaypipes/ghw/pkg/option"
+)
+
+type Device struct {
+	Driver     string `json:"driver"`
+	Type       string `json:"type"`
+	VendorID   string `json:"vendor_id"`
+	ProductID  string `json:"product_id"`
+	Product    string `json:"product"`
+	RevisionID string `json:"revision_id"`
+	Interface  string `json:"interface"`
+}
+
+func (d Device) String() string {
+	kvs := []struct {
+		name  string
+		value string
+	}{
+		{"driver", d.Driver},
+		{"type", d.Type},
+		{"vendorID", d.VendorID},
+		{"productID", d.ProductID},
+		{"product", d.Product},
+		{"revisionID", d.RevisionID},
+		{"interface", d.Interface},
+	}
+
+	var str strings.Builder
+
+	i := 0
+	for _, s := range kvs {
+		k := s.name
+		v := s.value
+
+		if v == "" {
+			continue
+		}
+		needsQuotationMarks := strings.ContainsAny(v, " \t")
+
+		if i > 0 {
+			str.WriteString(" ")
+		}
+		i++
+		str.WriteString(k)
+		str.WriteString("=")
+		if needsQuotationMarks {
+			str.WriteString("\"")
+		}
+		str.WriteString(v)
+		if needsQuotationMarks {
+			str.WriteString("\"")
+		}
+
+	}
+
+	return str.String()
+}
+
+// Info describes all network interface controllers (NICs) in the host system.
+type Info struct {
+	ctx     *context.Context
+	Devices []*Device `json:"devices"`
+}
+
+// String returns a short string with information about the networking on the
+// host system.
+func (i *Info) String() string {
+	return fmt.Sprintf(
+		"USB (%d USBs)",
+		len(i.Devices),
+	)
+}
+
+// New returns a pointer to an Info struct that contains information about the
+// network interface controllers (NICs) on the host system
+func New(opts ...*option.Option) (*Info, error) {
+	ctx := context.New(opts...)
+	info := &Info{ctx: ctx}
+	if err := ctx.Do(info.load); err != nil {
+		return nil, err
+	}
+
+	return info, nil
+}
+
+// simple private struct used to encapsulate usb information in a
+// top-level "usb" YAML/JSON map/object key
+type usbPrinter struct {
+	Info *Info `json:"usb"`
+}
+
+// YAMLString returns a string with the net information formatted as YAML
+// under a top-level "net:" key
+func (i *Info) YAMLString() string {
+	return marshal.SafeYAML(i.ctx, usbPrinter{i})
+}
+
+// JSONString returns a string with the net information formatted as JSON
+// under a top-level "net:" key
+func (i *Info) JSONString(indent bool) string {
+	return marshal.SafeJSON(i.ctx, usbPrinter{i}, indent)
+}

--- a/pkg/usb/usb_linux.go
+++ b/pkg/usb/usb_linux.go
@@ -1,0 +1,115 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package usb
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jaypipes/ghw/pkg/context"
+	"github.com/jaypipes/ghw/pkg/linuxpath"
+)
+
+func (i *Info) load() error {
+	var errs []error
+
+	i.Devices, errs = usbs(i.ctx)
+
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("error(s) happened during reading usb info: %+v", errs)
+}
+
+func fillUSBFromUevent(dir string, dev *Device) (err error) {
+	ueventFp, err := os.Open(filepath.Join(dir, "uevent"))
+	if err != nil {
+		return
+	}
+	defer func() {
+		err = ueventFp.Close()
+	}()
+
+	sc := bufio.NewScanner(ueventFp)
+	for sc.Scan() {
+		line := sc.Text()
+
+		splits := strings.SplitN(line, "=", 2)
+		if len(splits) != 2 {
+			continue
+		}
+
+		key := strings.ToUpper(splits[0])
+		val := splits[1]
+
+		switch key {
+		case "DRIVER":
+			dev.Driver = val
+		case "TYPE":
+			dev.Type = val
+		case "PRODUCT":
+			splits := strings.SplitN(val, "/", 3)
+			if len(splits) != 3 {
+				continue
+			}
+			dev.VendorID = splits[0]
+			dev.ProductID = splits[1]
+			dev.RevisionID = splits[2]
+		}
+	}
+	return nil
+}
+
+func slurp(path string) string {
+	bs, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+
+	return string(bytes.TrimSpace(bs))
+}
+
+func usbs(ctx *context.Context) ([]*Device, []error) {
+	devs := make([]*Device, 0)
+	errs := []error{}
+
+	paths := linuxpath.New(ctx)
+	usbDevicesDirs, err := os.ReadDir(paths.SysBusUsbDevices)
+	if err != nil {
+		return devs, []error{err}
+	}
+
+	for _, dir := range usbDevicesDirs {
+		fullDir, err := os.Readlink(filepath.Join(paths.SysBusUsbDevices, dir.Name()))
+		if err != nil {
+			continue
+		}
+		if !filepath.IsAbs(fullDir) {
+			fullDir, err = filepath.Abs(filepath.Join(paths.SysBusUsbDevices, fullDir))
+			if err != nil {
+				continue
+			}
+		}
+
+		dev := Device{}
+
+		err = fillUSBFromUevent(fullDir, &dev)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		dev.Interface = slurp(filepath.Join(fullDir, "interface"))
+		dev.Product = slurp(filepath.Join(fullDir, "product"))
+
+		devs = append(devs, &dev)
+	}
+
+	return devs, errs
+}

--- a/pkg/usb/usb_stub.go
+++ b/pkg/usb/usb_stub.go
@@ -1,0 +1,19 @@
+//go:build !linux
+// +build !linux
+
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package usb
+
+import (
+	"runtime"
+
+	"errors"
+)
+
+func (i *Info) load() error {
+	return errors.New("usb load not implemented on " + runtime.GOOS)
+}

--- a/pkg/usb/usb_test.go
+++ b/pkg/usb/usb_test.go
@@ -1,0 +1,57 @@
+//go:build linux
+// +build linux
+
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package usb
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestUSB(t *testing.T) {
+	usbDir, err := os.MkdirTemp("", "TestUSB")
+	if err != nil {
+		t.Fatalf("could not create temp directory: %v", err)
+	}
+
+	data := `
+DEVTYPE=usb_interface
+DRIVER=usbhid
+PRODUCT=46a/a087/101
+TYPE=0/0/0
+INTERFACE=3/1/2
+MODALIAS=usb:v046ApA087d0101dc00dsc00dp00ic03isc01ip02in00
+	`
+
+	err = os.WriteFile(filepath.Join(usbDir, "uevent"), []byte(data), 0600)
+	if err != nil {
+		t.Fatalf("could not write uevent file in %s: %+v", usbDir, err)
+	}
+
+	var d Device
+	err = fillUSBFromUevent(usbDir, &d)
+	if err != nil {
+		t.Fatalf("could not fill USB info from uevent file: %v", err)
+	}
+
+	deviceExpected := Device{
+		Driver:     "usbhid",
+		Type:       "0/0/0",
+		VendorID:   "46a",
+		ProductID:  "a087",
+		RevisionID: "101",
+	}
+
+	if !reflect.DeepEqual(d, deviceExpected) {
+		t.Fatalf("expected: %+v, but got %+v", deviceExpected, d)
+	}
+
+}


### PR DESCRIPTION
This PR adds USB devices to the list of devices.

The code basically iterates over `/sys/bus/usb/devices`, follows the symlinks and reads `uevent`, `interface` and `product`.

For the snapshot, the symlinks in `/sys/bus/usb/devices` are added as well as the aforementioned files.