### PR TITLE
pci: add parent device address

### DIFF
--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -59,6 +59,7 @@ type devMarshallable struct {
 	Class         devIdent `json:"class"`
 	Subclass      devIdent `json:"subclass"`
 	Interface     devIdent `json:"programming_interface"`
+	IOMMUGroup    string   `json:"iommu_group"`
 }
 
 // NOTE(jaypipes) Device has a custom JSON marshaller because we don't want
@@ -95,6 +96,7 @@ func (d *Device) MarshalJSON() ([]byte, error) {
 			ID:   d.ProgrammingInterface.ID,
 			Name: d.ProgrammingInterface.Name,
 		},
+		IOMMUGroup: d.IOMMUGroup,
 	}
 	return json.Marshal(dm)
 }

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -21,11 +21,13 @@ import (
 
 type Device struct {
 	// The PCI address of the device
-	Address   string         `json:"address"`
-	Vendor    *pcidb.Vendor  `json:"vendor"`
-	Product   *pcidb.Product `json:"product"`
-	Revision  string         `json:"revision"`
-	Subsystem *pcidb.Product `json:"subsystem"`
+	Address string `json:"address"`
+	// The PCI address of the parent device
+	ParentAddress string         `json:"parent_address"`
+	Vendor        *pcidb.Vendor  `json:"vendor"`
+	Product       *pcidb.Product `json:"product"`
+	Revision      string         `json:"revision"`
+	Subsystem     *pcidb.Product `json:"subsystem"`
 	// optional subvendor/sub-device information
 	Class *pcidb.Class `json:"class"`
 	// optional sub-class for the device
@@ -47,15 +49,16 @@ type devIdent struct {
 }
 
 type devMarshallable struct {
-	Driver    string   `json:"driver"`
-	Address   string   `json:"address"`
-	Vendor    devIdent `json:"vendor"`
-	Product   devIdent `json:"product"`
-	Revision  string   `json:"revision"`
-	Subsystem devIdent `json:"subsystem"`
-	Class     devIdent `json:"class"`
-	Subclass  devIdent `json:"subclass"`
-	Interface devIdent `json:"programming_interface"`
+	Driver        string   `json:"driver"`
+	Address       string   `json:"address"`
+	ParentAddress string   `json:"parent_address"`
+	Vendor        devIdent `json:"vendor"`
+	Product       devIdent `json:"product"`
+	Revision      string   `json:"revision"`
+	Subsystem     devIdent `json:"subsystem"`
+	Class         devIdent `json:"class"`
+	Subclass      devIdent `json:"subclass"`
+	Interface     devIdent `json:"programming_interface"`
 }
 
 // NOTE(jaypipes) Device has a custom JSON marshaller because we don't want
@@ -64,8 +67,9 @@ type devMarshallable struct {
 // human-readable name of the vendor, product, class, etc.
 func (d *Device) MarshalJSON() ([]byte, error) {
 	dm := devMarshallable{
-		Driver:  d.Driver,
-		Address: d.Address,
+		Driver:        d.Driver,
+		Address:       d.Address,
+		ParentAddress: d.ParentAddress,
 		Vendor: devIdent{
 			ID:   d.Vendor.ID,
 			Name: d.Vendor.Name,

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -106,6 +106,24 @@ func getDeviceIommuGroup(ctx *context.Context, pciAddr *pciaddr.Address) string 
 	return filepath.Base(dest)
 }
 
+func getDeviceParentAddress(ctx *context.Context, pciAddr *pciaddr.Address) string {
+	paths := linuxpath.New(ctx)
+	devPath := filepath.Join(paths.SysBusPciDevices, pciAddr.String())
+
+	dest, err := os.Readlink(devPath)
+	if err != nil {
+		return ""
+	}
+
+	parentAddr := filepath.Base(filepath.Dir(dest))
+
+	if pciaddr.FromString(parentAddr) == nil {
+		return ""
+	}
+
+	return parentAddr
+}
+
 func getDeviceDriver(ctx *context.Context, pciAddr *pciaddr.Address) string {
 	paths := linuxpath.New(ctx)
 	driverPath := filepath.Join(paths.SysBusPciDevices, pciAddr.String(), "driver")
@@ -342,6 +360,7 @@ func (info *Info) GetDevice(address string) *Device {
 		device.Node = getDeviceNUMANode(info.ctx, pciAddr)
 	}
 	device.Driver = getDeviceDriver(info.ctx, pciAddr)
+	device.ParentAddress = getDeviceParentAddress(info.ctx, pciAddr)
 	device.IOMMUGroup = getDeviceIommuGroup(info.ctx, pciAddr)
 	return device
 }

--- a/pkg/pci/pci_linux_test.go
+++ b/pkg/pci/pci_linux_test.go
@@ -24,6 +24,7 @@ import (
 
 type pciTestCase struct {
 	addr       string
+	parentAddr string
 	node       int
 	revision   string
 	driver     string
@@ -90,6 +91,28 @@ func TestPCIDeviceRevision(t *testing.T) {
 			}
 			if dev.Revision != tCase.revision {
 				t.Errorf("device %q got revision %q expected %q", tCase.addr, dev.Revision, tCase.revision)
+			}
+		})
+	}
+}
+
+// nolint: gocyclo
+func TestPCIParent(t *testing.T) {
+	info := pciTestSetupI7(t)
+	tCases := []pciTestCase{
+		{
+			addr:       "0000:04:00.0",
+			parentAddr: "0000:00:06.0",
+		},
+	}
+	for _, tCase := range tCases {
+		t.Run(fmt.Sprintf("%s (%s)", tCase.addr, tCase.parentAddr), func(t *testing.T) {
+			dev := info.GetDevice(tCase.addr)
+			if dev == nil {
+				t.Fatalf("got nil device for address %q", tCase.addr)
+			}
+			if dev.ParentAddress != tCase.parentAddr {
+				t.Errorf("got parent %q expected %q", dev.ParentAddress, tCase.parentAddr)
 			}
 		})
 	}


### PR DESCRIPTION
the parent device address is important, too (like IOMMU group), when using pci-passthrough as the both devices should be passed through together