### PR TITLE
use ContextFromEnv() when no args passed to Info()

### DIFF
--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -214,6 +214,9 @@ func fromOptions(ctx context.Context, opts *option.Options) context.Context {
 // ContextFromArgs returns a context.Context populated with any old-style
 // options or new-style arguments.
 func ContextFromArgs(args ...any) context.Context {
+	if len(args) == 0 {
+		return ContextFromEnv()
+	}
 	ctx := context.TODO()
 	optsUsed := false
 	opts := &option.Options{}


### PR DESCRIPTION
Restore the behaviour that used to exist before 0.23.0 where if no arguments/options were passed to an `Info()` function, the environment variables like `GHW_DISABLE_WARNINGS` were used.

Fixes Issue #458