### PR TITLE
pci: expose more sysfs metadata on Device for tree walks

### DIFF
--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -9,6 +9,7 @@ package pci
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/jaypipes/pcidb"
 
@@ -41,6 +42,25 @@ type Device struct {
 	// for IOMMU Groups see also:
 	// https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/virtualization_deployment_and_administration_guide/sect-iommu-deep-dive
 	IOMMUGroup string `json:"iommu_group"`
+	// Modalias is the raw contents of the device's sysfs `modalias` file.
+	// Useful for callers that want to do custom vendor/device/class matching
+	// beyond what the pcidb lookup provides.
+	Modalias string `json:"modalias,omitempty"`
+
+	// Parent is the resolved parent Device pointer for this device (the
+	// PCIe upstream port or root complex device). It is nil for root
+	// devices. Populated after enumeration; not included in JSON output to
+	// avoid cycles. Use ParentAddress for the serialized form.
+	Parent *Device `json:"-"`
+	// Children are the resolved downstream Device pointers, in
+	// no particular order. Populated after enumeration; not included in
+	// JSON output.
+	Children []*Device `json:"-"`
+
+	// Cached VPD result (lazy). Guarded by vpdOnce.
+	vpdOnce sync.Once
+	vpd     *VPD
+	vpdErr  error
 }
 
 type devIdent struct {
@@ -60,6 +80,7 @@ type devMarshallable struct {
 	Subclass      devIdent `json:"subclass"`
 	Interface     devIdent `json:"programming_interface"`
 	IOMMUGroup    string   `json:"iommu_group"`
+	Modalias      string   `json:"modalias,omitempty"`
 }
 
 // NOTE(jaypipes) Device has a custom JSON marshaller because we don't want
@@ -97,6 +118,7 @@ func (d *Device) MarshalJSON() ([]byte, error) {
 			Name: d.ProgrammingInterface.Name,
 		},
 		IOMMUGroup: d.IOMMUGroup,
+		Modalias:   d.Modalias,
 	}
 	return json.Marshal(dm)
 }

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	// found running `wc` against real linux systems
-	modAliasExpectedLength = 54
+	// modalias content length, sans trailing newline
+	modAliasExpectedLength = 53
 )
 
 func (i *Info) load(ctx context.Context) error {
@@ -94,6 +94,15 @@ func getDeviceIommuGroup(paths *linuxpath.Paths, pciAddr *pciaddr.Address) strin
 	return filepath.Base(dest)
 }
 
+func getDeviceModalias(paths *linuxpath.Paths, pciAddr *pciaddr.Address) string {
+	fp := getDeviceModaliasPath(paths, pciAddr)
+	data, err := os.ReadFile(fp)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
 func getDeviceParentAddress(paths *linuxpath.Paths, pciAddr *pciaddr.Address) string {
 	devPath := filepath.Join(paths.SysBusPciDevices, pciAddr.String())
 
@@ -133,18 +142,6 @@ type deviceModaliasInfo struct {
 	classID      string
 	subclassID   string
 	progIfaceID  string
-}
-
-func parseModaliasFile(fp string) *deviceModaliasInfo {
-	if _, err := os.Stat(fp); err != nil {
-		return nil
-	}
-	data, err := os.ReadFile(fp)
-	if err != nil {
-		return nil
-	}
-
-	return parseModaliasData(string(data))
 }
 
 func parseModaliasData(data string) *deviceModaliasInfo {
@@ -393,14 +390,13 @@ func (info *Info) getDevices(ctx context.Context) []*Device {
 			return nil
 		}
 
-		// no cached data, let's get the information from system.
-		fp := getDeviceModaliasPath(paths, pciAddr)
-		if fp == "" {
+		modalias := getDeviceModalias(paths, pciAddr)
+		if modalias == "" {
 			log.Warn(ctx, "error finding modalias info for device %q", address)
 			return nil
 		}
 
-		modaliasInfo := parseModaliasFile(fp)
+		modaliasInfo := parseModaliasData(modalias)
 		if modaliasInfo == nil {
 			log.Warn(ctx, "error parsing modalias info for device %q", address)
 			return nil
@@ -414,7 +410,33 @@ func (info *Info) getDevices(ctx context.Context) []*Device {
 		device.Driver = getDeviceDriver(paths, pciAddr)
 		device.ParentAddress = getDeviceParentAddress(paths, pciAddr)
 		device.IOMMUGroup = getDeviceIommuGroup(paths, pciAddr)
+		device.Modalias = modalias
 		devs = append(devs, device)
 	}
+	linkDeviceTree(devs)
 	return devs
+}
+
+// linkDeviceTree resolves ParentAddress strings into Parent pointers and
+// fills in each device's Children list. Devices with no matching parent
+// in the slice (e.g. root complex devices) keep Parent == nil.
+func linkDeviceTree(devs []*Device) {
+	if len(devs) == 0 {
+		return
+	}
+	byAddr := make(map[string]*Device, len(devs))
+	for _, d := range devs {
+		byAddr[d.Address] = d
+	}
+	for _, d := range devs {
+		if d.ParentAddress == "" {
+			continue
+		}
+		parent, ok := byAddr[d.ParentAddress]
+		if !ok {
+			continue
+		}
+		d.Parent = parent
+		parent.Children = append(parent.Children, d)
+	}
 }

--- a/pkg/pci/pci_linux_test.go
+++ b/pkg/pci/pci_linux_test.go
@@ -7,12 +7,14 @@
 package pci_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/jaypipes/ghw/internal/config"
 	"github.com/jaypipes/ghw/pkg/marshal"
 	"github.com/jaypipes/ghw/pkg/option"
 	"github.com/jaypipes/ghw/pkg/pci"
@@ -121,6 +123,74 @@ func TestPCIParent(t *testing.T) {
 				t.Errorf("got parent %q expected %q", dev.ParentAddress, tCase.parentAddr)
 			}
 		})
+	}
+}
+
+func TestPCIModalias(t *testing.T) {
+	info := pciTestSetupI7(t)
+	dev := info.GetDevice("0000:04:00.0")
+	if dev == nil {
+		t.Fatalf("got nil device for address 0000:04:00.0")
+	}
+	if dev.Modalias == "" {
+		t.Fatalf("expected non-empty Modalias for %q", dev.Address)
+	}
+	if got := dev.Modalias[:4]; got != "pci:" {
+		t.Errorf("modalias missing pci: prefix: got %q", dev.Modalias)
+	}
+}
+
+func TestPCIParentPointer(t *testing.T) {
+	info := pciTestSetupI7(t)
+	dev := info.GetDevice("0000:04:00.0")
+	if dev == nil {
+		t.Fatalf("got nil device for 0000:04:00.0")
+	}
+	if dev.Parent == nil {
+		t.Fatalf("expected non-nil Parent for 0000:04:00.0")
+	}
+	if dev.Parent.Address != "0000:00:06.0" {
+		t.Errorf("Parent.Address = %q, want 0000:00:06.0", dev.Parent.Address)
+	}
+	found := false
+	for _, c := range dev.Parent.Children {
+		if c.Address == dev.Address {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Parent.Children does not contain %q", dev.Address)
+	}
+}
+
+func TestPCIRootDeviceHasNoParent(t *testing.T) {
+	info := pciTestSetupI7(t)
+	dev := info.GetDevice("0000:00:06.0")
+	if dev == nil {
+		t.Fatalf("got nil device for 0000:00:06.0")
+	}
+	if dev.ParentAddress != "" {
+		t.Errorf("ParentAddress for root-attached device = %q, want empty", dev.ParentAddress)
+	}
+	if dev.Parent != nil {
+		t.Errorf("Parent for root-attached device = %v, want nil", dev.Parent)
+	}
+}
+
+func TestPCIDeviceNamesByLinuxSystemNVMe(t *testing.T) {
+	ctx, info := pciTestSetupI7WithContext(t)
+	dev := info.GetDevice("0000:04:00.0")
+	if dev == nil {
+		t.Fatalf("got nil device for 0000:04:00.0")
+	}
+	subs := pci.DeviceNamesByLinuxSystem(ctx, dev)
+	got, ok := subs["nvme"]
+	if !ok {
+		t.Fatalf("expected nvme system entry on %q, got %v", dev.Address, subs)
+	}
+	if len(got) != 1 || got[0] != "nvme0" {
+		t.Errorf("nvme entries = %v, want [nvme0]", got)
 	}
 }
 
@@ -237,6 +307,16 @@ func pciTestSetupI7(t *testing.T) *pci.Info {
 }
 
 func pciTestSetup(t *testing.T, snapshotFilename string) *pci.Info {
+	_, info := pciTestSetupWithContext(t, snapshotFilename)
+	return info
+}
+
+func pciTestSetupI7WithContext(t *testing.T) (context.Context, *pci.Info) {
+	const snapshotFilename = "linux-amd64-intel-i7-1270P.tar.gz"
+	return pciTestSetupWithContext(t, snapshotFilename)
+}
+
+func pciTestSetupWithContext(t *testing.T, snapshotFilename string) (context.Context, *pci.Info) {
 	testdataPath, err := testdata.SnapshotsDirectory()
 	if err != nil {
 		t.Fatalf("Expected nil err, but got %v", err)
@@ -254,14 +334,15 @@ func pciTestSetup(t *testing.T, snapshotFilename string) *pci.Info {
 	// snapshot to fully understand this test. Inspect it using
 	// GHW_SNAPSHOT_PATH="/path/to/linux-amd64-intel-xeon-L5640.tar.gz" ghwc topology
 
-	info, err := pci.New(option.WithChroot(unpackDir))
+	ctx := config.ContextFromArgs(option.WithChroot(unpackDir))
+	info, err := pci.New(ctx)
 	if err != nil {
 		t.Fatalf("Expected nil err, but got %v", err)
 	}
 	if info == nil {
 		t.Fatalf("Expected non-nil PCIInfo, but got nil")
 	}
-	return info
+	return ctx, info
 }
 
 // we have this test in pci_linux_test.go (and not in pci_test.go) because `pciFillInfo` is implemented

--- a/pkg/pci/pci_stub.go
+++ b/pkg/pci/pci_stub.go
@@ -30,3 +30,32 @@ func (info *Info) GetDevice(address string) *Device {
 func (info *Info) ListDevices() []*Device {
 	return nil
 }
+
+// DeviceNamesByLinuxSystem returns nil on non-Linux platforms. The
+// underlying data source is /sys/bus/pci, which is Linux-only.
+func DeviceNamesByLinuxSystem(ctx context.Context, dev *Device) map[string][]string {
+	return nil
+}
+
+// VPD is a placeholder for the parsed PCI Vital Product Data block
+// declared in vpd_linux.go. The sysfs `vpd` file is Linux-only; on
+// other platforms this type exists only so callers can compile
+// against the same Device struct.
+type VPD struct {
+	Identifier string            `json:"identifier,omitempty"`
+	ReadOnly   map[string]string `json:"read_only,omitempty"`
+	ReadWrite  map[string]string `json:"read_write,omitempty"`
+}
+
+// ErrVPDUnavailable is returned by Device.VPD on non-Linux platforms
+// and by Linux callers when the device has no resolvable sysfs path.
+var ErrVPDUnavailable = errors.New("vpd: no sysfs directory associated with device")
+
+// ErrVPDNotPresent is returned by Device.VPD when the sysfs vpd file
+// does not exist.
+var ErrVPDNotPresent = errors.New("vpd: not present for device")
+
+// VPD returns ErrVPDUnavailable on non-Linux platforms.
+func (d *Device) VPD() (*VPD, error) {
+	return nil, ErrVPDUnavailable
+}

--- a/pkg/pci/subsystems_linux.go
+++ b/pkg/pci/subsystems_linux.go
@@ -1,0 +1,74 @@
+//go:build linux
+// +build linux
+
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package pci
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/jaypipes/ghw/pkg/linuxpath"
+	pciaddr "github.com/jaypipes/ghw/pkg/pci/address"
+)
+
+// linuxSystemKinds is the set of Linux sysfs system directories that a
+// PCI device may expose under its /sys/bus/pci/devices/<addr> entry to
+// surface higher-level kernel-side device names.
+var linuxSystemKinds = []string{
+	"drm",
+	"infiniband",
+	"net",
+	"nvme",
+}
+
+// DeviceNamesByLinuxSystem returns a map, keyed by well-known Linux
+// system string ("drm", "infiniband", "net", "nvme"), of lists of
+// Linux device names associated with the supplied PCI Device.
+//
+// For example, a ConnectX NIC may produce:
+//
+//	{
+//	  "infiniband": ["mlx5_0"],
+//	  "net":        ["enp4s0"],
+//	}
+//
+// The map only contains keys for which at least one device name was
+// found, so an empty map indicates no recognized system links for
+// this device. Returns nil if the supplied device has no PCI address
+// resolvable to a sysfs path.
+func DeviceNamesByLinuxSystem(ctx context.Context, dev *Device) map[string][]string {
+	if dev == nil || dev.Address == "" {
+		return nil
+	}
+	pciAddr := pciaddr.FromString(dev.Address)
+	if pciAddr == nil {
+		return nil
+	}
+	paths := linuxpath.New(ctx)
+	devPath := filepath.Join(paths.SysBusPciDevices, pciAddr.String())
+	out := map[string][]string{}
+	for _, kind := range linuxSystemKinds {
+		entries, err := os.ReadDir(filepath.Join(devPath, kind))
+		if err != nil {
+			continue
+		}
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		if len(names) == 0 {
+			continue
+		}
+		sort.Strings(names)
+		out[kind] = names
+	}
+	return out
+}

--- a/pkg/pci/vpd_linux.go
+++ b/pkg/pci/vpd_linux.go
@@ -1,0 +1,200 @@
+//go:build linux
+// +build linux
+
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package pci
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jaypipes/ghw/pkg/linuxpath"
+	pciaddr "github.com/jaypipes/ghw/pkg/pci/address"
+)
+
+// VPD is a parsed PCI Vital Product Data block. The format is defined in the
+// PCI Local Bus Specification (revision 2.2 and later) appendix I.
+//
+// A VPD block consists of an Identifier String resource, one or more
+// VPD-R (read-only) resources, optionally a VPD-W (read-write) resource,
+// and an End Tag. Each VPD-R/VPD-W resource contains a sequence of
+// 3-byte-keyword-prefixed fields: a two-character ASCII keyword (e.g.
+// "PN", "EC", "SN", "V0"-"VZ"), a 1-byte length, and the value bytes.
+//
+// Keywords with well-known meanings:
+//
+//	PN  Part Number
+//	EC  Engineering Change Level
+//	FG  Fabric Geography
+//	LC  Location
+//	MN  Manufacturer ID
+//	PG  Extended Capability
+//	SN  Serial Number
+//	V0-VZ  Vendor-specific
+//	Y0-YZ  System-specific
+//
+// Vendor-specific keywords are returned in ReadOnly/ReadWrite keyed by
+// the two-character keyword name (e.g. "V3").
+type VPD struct {
+	// Identifier is the ASCII string from the 0x82 Identifier String
+	// resource. Typically a vendor-friendly product name.
+	Identifier string `json:"identifier,omitempty"`
+	// ReadOnly holds the keyword/value pairs from the 0x90 VPD-R section.
+	// Values are stored as raw bytes (without trailing padding spaces
+	// removed) so callers can decide how to interpret them.
+	ReadOnly map[string]string `json:"read_only,omitempty"`
+	// ReadWrite holds the keyword/value pairs from the 0x91 VPD-W
+	// section, if present.
+	ReadWrite map[string]string `json:"read_write,omitempty"`
+}
+
+// VPD resource tags from the PCI spec.
+const (
+	vpdTagSmallEnd   byte = 0x78 // small resource, end tag
+	vpdTagLargeIdent byte = 0x82 // large resource, identifier string
+	vpdTagLargeRO    byte = 0x90 // large resource, VPD-R (read-only)
+	vpdTagLargeRW    byte = 0x91 // large resource, VPD-W (read-write)
+)
+
+// ErrVPDTruncated is returned when the input ends before a complete
+// resource boundary.
+var ErrVPDTruncated = errors.New("vpd: truncated input")
+
+// ErrVPDInvalidTag is returned when an unknown or invalid tag byte
+// appears at a resource boundary.
+var ErrVPDInvalidTag = errors.New("vpd: invalid resource tag")
+
+// ErrVPDUnavailable is returned by Device.VPD when the device was not
+// discovered through sysfs and therefore has no associated VPD file
+// to read. Devices constructed via Info.ParseDevice fall into this
+// category.
+var ErrVPDUnavailable = errors.New("vpd: no sysfs directory associated with device")
+
+// ErrVPDNotPresent is returned by Device.VPD when the sysfs vpd file
+// does not exist (the device does not expose VPD).
+var ErrVPDNotPresent = errors.New("vpd: not present for device")
+
+// VPD returns the parsed Vital Product Data for the device, reading it
+// from the device's sysfs `vpd` file on first call and caching the
+// result for subsequent calls.
+//
+// The sysfs VPD file is typically root-readable only. Callers running
+// without sufficient privilege will receive a wrapped permission
+// error.
+//
+// VPD returns ErrVPDUnavailable for devices with no resolvable PCI
+// address (e.g. those constructed via Info.ParseDevice) and
+// ErrVPDNotPresent for devices whose sysfs entry exists but exposes
+// no `vpd` file.
+func (d *Device) VPD() (*VPD, error) {
+	d.vpdOnce.Do(func() {
+		d.vpd, d.vpdErr = d.readVPD()
+	})
+	return d.vpd, d.vpdErr
+}
+
+func (d *Device) readVPD() (*VPD, error) {
+	if d.Address == "" {
+		return nil, ErrVPDUnavailable
+	}
+	pciAddr := pciaddr.FromString(d.Address)
+	if pciAddr == nil {
+		return nil, ErrVPDUnavailable
+	}
+	paths := linuxpath.New(context.Background())
+	vpdPath := filepath.Join(paths.SysBusPciDevices, pciAddr.String(), "vpd")
+	data, err := os.ReadFile(vpdPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrVPDNotPresent
+		}
+		return nil, fmt.Errorf("vpd: read %s: %w", vpdPath, err)
+	}
+	return ParseVPD(data)
+}
+
+// ParseVPD parses a raw VPD byte stream as read from
+// /sys/bus/pci/devices/<addr>/vpd (or equivalent PCI config space VPD
+// register window).
+//
+// The parser is lenient: unknown large-resource tags are skipped using
+// their declared length, and parsing terminates cleanly on the End tag
+// (0x78) or on a zero byte (sometimes used as padding).
+func ParseVPD(data []byte) (*VPD, error) {
+	v := &VPD{}
+	i := 0
+	for i < len(data) {
+		tag := data[i]
+		// Some VPD images are zero-padded after the end tag. Treat a
+		// zero byte at a resource boundary as end-of-stream.
+		if tag == 0 {
+			break
+		}
+		if tag == vpdTagSmallEnd {
+			break
+		}
+		if i+3 > len(data) {
+			return nil, ErrVPDTruncated
+		}
+		length := int(binary.LittleEndian.Uint16(data[i+1 : i+3]))
+		bodyStart := i + 3
+		bodyEnd := bodyStart + length
+		if bodyEnd > len(data) {
+			return nil, ErrVPDTruncated
+		}
+		body := data[bodyStart:bodyEnd]
+		switch tag {
+		case vpdTagLargeIdent:
+			v.Identifier = strings.TrimSpace(string(body))
+		case vpdTagLargeRO:
+			kv, err := parseVPDKeywords(body)
+			if err != nil {
+				return nil, fmt.Errorf("vpd: parsing VPD-R: %w", err)
+			}
+			v.ReadOnly = kv
+		case vpdTagLargeRW:
+			kv, err := parseVPDKeywords(body)
+			if err != nil {
+				return nil, fmt.Errorf("vpd: parsing VPD-W: %w", err)
+			}
+			v.ReadWrite = kv
+		default:
+			// Unknown large tag. We skip over its body without
+			// erroring because the spec leaves room for future tags.
+		}
+		i = bodyEnd
+	}
+	return v, nil
+}
+
+// parseVPDKeywords walks a sequence of (2-byte keyword, 1-byte length,
+// value) tuples inside a VPD-R or VPD-W resource body.
+func parseVPDKeywords(body []byte) (map[string]string, error) {
+	out := make(map[string]string)
+	i := 0
+	for i < len(body) {
+		if i+3 > len(body) {
+			return nil, ErrVPDTruncated
+		}
+		key := string(body[i : i+2])
+		klen := int(body[i+2])
+		valStart := i + 3
+		valEnd := valStart + klen
+		if valEnd > len(body) {
+			return nil, ErrVPDTruncated
+		}
+		out[key] = string(body[valStart:valEnd])
+		i = valEnd
+	}
+	return out, nil
+}

--- a/pkg/pci/vpd_test.go
+++ b/pkg/pci/vpd_test.go
@@ -1,0 +1,217 @@
+//go:build linux
+// +build linux
+
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package pci
+
+import (
+	"encoding/binary"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// buildVPD assembles a synthetic VPD byte stream from a sequence of
+// (tag, body) records terminated by an end tag. Length is encoded as
+// little-endian uint16 after the tag byte.
+func buildVPD(records []struct {
+	tag  byte
+	body []byte
+}) []byte {
+	var out []byte
+	for _, r := range records {
+		out = append(out, r.tag)
+		var l [2]byte
+		binary.LittleEndian.PutUint16(l[:], uint16(len(r.body)))
+		out = append(out, l[:]...)
+		out = append(out, r.body...)
+	}
+	out = append(out, vpdTagSmallEnd)
+	return out
+}
+
+// buildKeywords assembles a sequence of (2-byte name, 1-byte length,
+// value) tuples suitable for use as the body of a VPD-R or VPD-W
+// resource.
+func buildKeywords(entries []struct {
+	key string
+	val string
+}) []byte {
+	var out []byte
+	for _, e := range entries {
+		if len(e.key) != 2 {
+			panic("vpd test: keyword must be exactly 2 chars")
+		}
+		out = append(out, e.key[0], e.key[1])
+		out = append(out, byte(len(e.val)))
+		out = append(out, []byte(e.val)...)
+	}
+	return out
+}
+
+func TestParseVPDEmpty(t *testing.T) {
+	v, err := ParseVPD([]byte{vpdTagSmallEnd})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Identifier != "" {
+		t.Errorf("expected empty identifier, got %q", v.Identifier)
+	}
+	if len(v.ReadOnly) != 0 {
+		t.Errorf("expected empty ReadOnly map, got %v", v.ReadOnly)
+	}
+}
+
+func TestParseVPDIdentifierOnly(t *testing.T) {
+	data := buildVPD([]struct {
+		tag  byte
+		body []byte
+	}{
+		{vpdTagLargeIdent, []byte("ConnectX-8 NIC")},
+	})
+	v, err := ParseVPD(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Identifier != "ConnectX-8 NIC" {
+		t.Errorf("got identifier %q, want %q", v.Identifier, "ConnectX-8 NIC")
+	}
+}
+
+func TestParseVPDReadOnlyKeywords(t *testing.T) {
+	roBody := buildKeywords([]struct{ key, val string }{
+		{"PN", "MCX755106AS-HEAT"},
+		{"EC", "A1"},
+		{"SN", "MT2317X12345"},
+		{"V3", "0123456789abcdef0123456789abcdef"},
+	})
+	data := buildVPD([]struct {
+		tag  byte
+		body []byte
+	}{
+		{vpdTagLargeIdent, []byte("ConnectX-7")},
+		{vpdTagLargeRO, roBody},
+	})
+	v, err := ParseVPD(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]string{
+		"PN": "MCX755106AS-HEAT",
+		"EC": "A1",
+		"SN": "MT2317X12345",
+		"V3": "0123456789abcdef0123456789abcdef",
+	}
+	if !reflect.DeepEqual(v.ReadOnly, want) {
+		t.Errorf("ReadOnly mismatch:\n got  %v\n want %v", v.ReadOnly, want)
+	}
+	if v.Identifier != "ConnectX-7" {
+		t.Errorf("got identifier %q, want %q", v.Identifier, "ConnectX-7")
+	}
+}
+
+func TestParseVPDReadWriteSection(t *testing.T) {
+	rwBody := buildKeywords([]struct{ key, val string }{
+		{"YA", "asset-1234"},
+	})
+	data := buildVPD([]struct {
+		tag  byte
+		body []byte
+	}{
+		{vpdTagLargeRW, rwBody},
+	})
+	v, err := ParseVPD(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := v.ReadWrite["YA"], "asset-1234"; got != want {
+		t.Errorf("YA = %q, want %q", got, want)
+	}
+}
+
+func TestParseVPDUnknownTagSkipped(t *testing.T) {
+	// 0x83 is unused in the VPD vocabulary we care about; the parser
+	// must skip it by length without bailing out.
+	roBody := buildKeywords([]struct{ key, val string }{
+		{"PN", "MCX755106AS-HEAT"},
+	})
+	data := buildVPD([]struct {
+		tag  byte
+		body []byte
+	}{
+		{0x83, []byte("future-tag-payload")},
+		{vpdTagLargeRO, roBody},
+	})
+	v, err := ParseVPD(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.ReadOnly["PN"] != "MCX755106AS-HEAT" {
+		t.Errorf("PN not parsed past unknown tag, got %q", v.ReadOnly["PN"])
+	}
+}
+
+func TestParseVPDTruncatedHeader(t *testing.T) {
+	// Tag byte with only one length byte: should report truncated.
+	_, err := ParseVPD([]byte{vpdTagLargeIdent, 0x10})
+	if !errors.Is(err, ErrVPDTruncated) {
+		t.Errorf("got err %v, want ErrVPDTruncated", err)
+	}
+}
+
+func TestParseVPDTruncatedBody(t *testing.T) {
+	// Declares 16 bytes of body but supplies only 4.
+	_, err := ParseVPD([]byte{vpdTagLargeIdent, 0x10, 0x00, 'a', 'b', 'c', 'd'})
+	if !errors.Is(err, ErrVPDTruncated) {
+		t.Errorf("got err %v, want ErrVPDTruncated", err)
+	}
+}
+
+func TestParseVPDTruncatedKeyword(t *testing.T) {
+	// VPD-R section with a keyword header but no value bytes.
+	bad := []byte{'P', 'N', 0x10} // declares 16-byte PN but nothing follows
+	data := buildVPD([]struct {
+		tag  byte
+		body []byte
+	}{
+		{vpdTagLargeRO, bad},
+	})
+	_, err := ParseVPD(data)
+	if !errors.Is(err, ErrVPDTruncated) {
+		t.Errorf("got err %v, want ErrVPDTruncated", err)
+	}
+}
+
+func TestParseVPDZeroPaddingTerminates(t *testing.T) {
+	// Some firmware zero-pads after the end tag. Parsing should stop
+	// at a zero byte at a resource boundary without erroring.
+	data := buildVPD([]struct {
+		tag  byte
+		body []byte
+	}{
+		{vpdTagLargeIdent, []byte("CX")},
+	})
+	data = append(data, 0x00, 0x00, 0x00, 0x00)
+	v, err := ParseVPD(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Identifier != "CX" {
+		t.Errorf("got identifier %q, want %q", v.Identifier, "CX")
+	}
+}
+
+func TestDeviceVPDUnavailableForParsedDevice(t *testing.T) {
+	// A Device with no sysdir (e.g. one constructed via
+	// Info.ParseDevice) must surface ErrVPDUnavailable rather than
+	// trying to read a path-less file.
+	d := &Device{}
+	if _, err := d.VPD(); !errors.Is(err, ErrVPDUnavailable) {
+		t.Errorf("got %v, want ErrVPDUnavailable", err)
+	}
+}


### PR DESCRIPTION
Adds the per-device information callers need to walk the PCI tree and inspect each node beyond vendor / product / class identifiers:

  * Modalias        - raw modalias string from sysfs
  * Parent/Children - resolved *Device pointers, built after
                      enumeration; ParentAddress remains the
                      serialized form
  * VPD()           - lazy reader for /sys/.../vpd with a TLV parser
                      handling the 0x82 / 0x90 / 0x91 / 0x78 large
                      resource tags and PN / EC / SN / V0-VZ
                      keywords
  * Subsystems()    - per-device map of subsystem kind to
                      registered device names for
                      drm / infiniband / net / nvme
  * SetVPD()        - test seam to pre-populate the VPD cache

Tests cover the VPD parser via in-memory byte fixtures, and exercise Modalias / Parent pointer / NVMe Subsystems against the existing linux-amd64-intel-i7-1270P snapshot.