### PR TITLE
use ContextFromEnv() as the base context when args are passed

### DIFF
--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -213,11 +213,17 @@ func fromOptions(ctx context.Context, opts *option.Options) context.Context {
 
 // ContextFromArgs returns a context.Context populated with any old-style
 // options or new-style arguments.
+//
+// The environment-derived context (see ContextFromEnv) is used as the base, so
+// variables like GHW_CHROOT continue to take effect when callers also pass
+// Modifiers or Options. Any value present in the supplied args wins over the
+// env-derived value. If an explicit context.Context is passed as an arg, it
+// fully replaces the env-derived base.
 func ContextFromArgs(args ...any) context.Context {
+	ctx := ContextFromEnv()
 	if len(args) == 0 {
-		return ContextFromEnv()
+		return ctx
 	}
-	ctx := context.TODO()
 	optsUsed := false
 	opts := &option.Options{}
 	for _, arg := range args {

--- a/internal/config/context_test.go
+++ b/internal/config/context_test.go
@@ -1,0 +1,69 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package config_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jaypipes/ghw/internal/config"
+	"github.com/jaypipes/ghw/pkg/option"
+)
+
+// TestContextFromArgsHonorsEnvChrootWithModifiers ensures that GHW_CHROOT is
+// honored even when callers also pass Modifiers. Regression test for the
+// behavior change introduced in 0.23.0 where, when args were supplied, the
+// base context was context.TODO() and the GHW_CHROOT environment variable was
+// silently ignored.
+func TestContextFromArgsHonorsEnvChrootWithModifiers(t *testing.T) {
+	t.Setenv("GHW_CHROOT", "/from-env")
+
+	ctx := config.ContextFromArgs(config.WithDisableTools())
+
+	if got := config.Chroot(ctx); got != "/from-env" {
+		t.Fatalf("Expected chroot to come from GHW_CHROOT (/from-env), got %q", got)
+	}
+	if config.ToolsEnabled(ctx) {
+		t.Fatalf("Expected WithDisableTools modifier to be applied")
+	}
+}
+
+// TestContextFromArgsExplicitChrootOverridesEnv ensures that a chroot passed
+// via WithChroot wins over GHW_CHROOT.
+func TestContextFromArgsExplicitChrootOverridesEnv(t *testing.T) {
+	t.Setenv("GHW_CHROOT", "/from-env")
+
+	ctx := config.ContextFromArgs(config.WithChroot("/from-arg"))
+
+	if got := config.Chroot(ctx); got != "/from-arg" {
+		t.Fatalf("Expected explicit WithChroot to override env, got %q", got)
+	}
+}
+
+// TestContextFromArgsExplicitContextReplacesBase ensures that an explicit
+// context.Context arg fully replaces the env-derived base context.
+func TestContextFromArgsExplicitContextReplacesBase(t *testing.T) {
+	t.Setenv("GHW_CHROOT", "/from-env")
+
+	ctx := config.ContextFromArgs(context.Background())
+
+	if got := config.Chroot(ctx); got != "/" {
+		t.Fatalf("Expected explicit context.Background() to replace env-derived base (default chroot \"/\"), got %q", got)
+	}
+}
+
+// TestContextFromArgsOldStyleOptionChrootOverridesEnv ensures that the
+// old-style option.WithChroot also overrides GHW_CHROOT.
+func TestContextFromArgsOldStyleOptionChrootOverridesEnv(t *testing.T) {
+	t.Setenv("GHW_CHROOT", "/from-env")
+
+	ctx := config.ContextFromArgs(option.WithChroot("/from-old-opt"))
+
+	if got := config.Chroot(ctx); got != "/from-old-opt" {
+		t.Fatalf("Expected old-style option.WithChroot to override env, got %q", got)
+	}
+}


### PR DESCRIPTION
Commit 4e7ac7a restored pre-0.23.0 behaviour for the zero-args call path, but the with-args path still starts from context.TODO() and silently drops environment variables like GHW_CHROOT, GHW_DISABLE_WARNINGS, and GHW_DISABLE_TOOLS.

In pre-0.23.0 ghw, option.Merge always called EnvOrDefaultChroot() (and its siblings) as defaults regardless of which options the caller passed, so e.g. `block.New(WithDisableTools())` still picked up GHW_CHROOT. The 0.23.0 refactor lost that, breaking downstream callers that set the env var and expected it to compose with other options. A common pattern is test mocks that export GHW_CHROOT and rely on consumers (including indirect ones via libraries that call block.New with a couple of modifiers) to honour it.

Use ContextFromEnv() as the base inside ContextFromArgs so env-derived values survive unless overridden by an explicit Modifier, Option, or context.Context arg.

Includes regression tests covering each of: Modifier-only args, WithChroot override of env, old-style option.WithChroot override of env, and explicit context.Context replacement of the env-derived base.

NOTE: debugged and co-authored with Claude AI