### PR TITLE
cpu: add regression test for non key:value lines in /proc/cpuinfo

### DIFF
--- a/pkg/cpu/cpu_linux_test.go
+++ b/pkg/cpu/cpu_linux_test.go
@@ -219,3 +219,51 @@ func TestS390xCPU(t *testing.T) {
 		t.Fatal("Expected capabilities to be populated from s390x 'features' key")
 	}
 }
+
+func TestQualcommCPUInfo(t *testing.T) {
+	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_CPU"); ok {
+		t.Skip("Skipping CPU tests.")
+	}
+
+	root := t.TempDir()
+
+	// Create /proc/cpuinfo
+	procDir := filepath.Join(root, "proc")
+	if err := os.MkdirAll(procDir, 0700); err != nil {
+		t.Fatalf("Failed to create proc dir: %v", err)
+	}
+
+	content := `processor       : 0
+BogoMIPS        : 38.40
+Features        : fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
+CPU implementer : 0x51
+CPU architecture: 8
+CPU variant     : 0xa
+CPU part        : 0x800
+CPU revision    : 2
+
+Qualcomm Technologies, Inc QCM6125
+`
+	if err := os.WriteFile(filepath.Join(procDir, "cpuinfo"), []byte(content), 0600); err != nil {
+		t.Fatalf("Failed to write cpuinfo: %v", err)
+	}
+
+	// Create /sys/devices/system/cpu/cpu0
+	cpu0Dir := filepath.Join(root, "sys", "devices", "system", "cpu", "cpu0")
+	if err := os.MkdirAll(filepath.Join(cpu0Dir, "topology"), 0700); err != nil {
+		t.Fatalf("Failed to create cpu0 dir: %v", err)
+	}
+
+	info, err := cpu.New(ghw.WithChroot(root))
+	if err != nil {
+		t.Fatalf("Expected nil err, but got %v", err)
+	}
+	if info == nil {
+		t.Fatalf("Expected non-nil CPUInfo, but got nil")
+	}
+
+	// We expect 1 processor.
+	if len(info.Processors) != 1 {
+		t.Errorf("Expected 1 processor, got %d", len(info.Processors))
+	}
+}


### PR DESCRIPTION
## What

Adds a targeted regression test (`TestQualcommCPUInfo`) for `/proc/cpuinfo` contents that
contain lines without a `:` separator, as seen on some Qualcomm ARM SoCs (e.g. QCM6125),
where the SoC name appears on a line of its own:

```
processor       : 0
...
CPU revision    : 2

Qualcomm Technologies, Inc QCM6125
```

## Why

Older ghw crashed on such lines. The underlying bug was already fixed upstream (#441, #443),
but there is no synthetic regression test locking that behavior in — the existing cpu tests
are all snapshot-fixture based. This test builds a minimal chroot with such a cpuinfo file
and asserts `cpu.New` succeeds and reports exactly one processor.

We (Zededa) hit this on real devices while using ghw for hardware inventory in
[lf-edge/eve](https://github.com/lf-edge/eve); this ports the test from our fork.

## Testing

`go test ./pkg/cpu/...` passes on Linux.