### PR TITLE
Introduce pkg/watchdog to detect hardware watchdogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1201,6 +1201,42 @@ WARNING: Unable to read product_serial: open /sys/class/dmi/id/product_serial: p
 You can ignore them or use the [Disabling warning messages](#disabling-warning-messages)
 feature to quiet things down.
 
+### Watchdog (Linux only)
+
+The `ghw.Watchdog()` function returns a `ghw.WatchdogInfo` struct that
+indicates whether the host system has a hardware watchdog.
+
+The `ghw.WatchdogInfo` struct contains one field:
+
+* `ghw.WatchdogInfo.Present` is a bool indicating whether a hardware watchdog
+  was detected, either as an entry under `/sys/class/watchdog` or as the
+  `/dev/watchdog` character device on older kernels
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/jaypipes/ghw"
+)
+
+func main() {
+	watchdog, err := ghw.Watchdog()
+	if err != nil {
+		fmt.Printf("Error getting watchdog info: %v", err)
+	}
+
+	fmt.Printf("%v\n", watchdog)
+}
+```
+
+Example output from my personal workstation:
+
+```
+watchdog present: true
+```
+
 ## Advanced Usage
 
 ### Disabling warning messages

--- a/alias.go
+++ b/alias.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jaypipes/ghw/pkg/product"
 	"github.com/jaypipes/ghw/pkg/topology"
 	"github.com/jaypipes/ghw/pkg/usb"
+	"github.com/jaypipes/ghw/pkg/watchdog"
 )
 
 var (
@@ -198,4 +199,10 @@ type AcceleratorDevice = accelerator.AcceleratorDevice
 
 var (
 	Accelerator = accelerator.New
+)
+
+type WatchdogInfo = watchdog.Info
+
+var (
+	Watchdog = watchdog.New
 )

--- a/cmd/ghwc/commands/root.go
+++ b/cmd/ghwc/commands/root.go
@@ -105,6 +105,7 @@ func showAll(cmd *cobra.Command, args []string) error {
 			showProduct,
 			showAccelerator,
 			showUSB,
+			showWatchdog,
 		} {
 			err := f(cmd, args)
 			if err != nil {

--- a/cmd/ghwc/commands/watchdog.go
+++ b/cmd/ghwc/commands/watchdog.go
@@ -1,0 +1,43 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/jaypipes/ghw"
+	"github.com/spf13/cobra"
+)
+
+// watchdogCmd represents the `watchdog` command
+var watchdogCmd = &cobra.Command{
+	Use:   "watchdog",
+	Short: "Show watchdog information for the host system",
+	RunE:  showWatchdog,
+}
+
+// showWatchdog shows watchdog information for the host system.
+func showWatchdog(cmd *cobra.Command, args []string) error {
+	watchdog, err := ghw.Watchdog(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("error getting watchdog info: %w", err)
+	}
+
+	switch outputFormat {
+	case outputFormatHuman:
+		fmt.Printf("%v\n", watchdog)
+	case outputFormatJSON:
+		fmt.Printf("%s\n", watchdog.JSONString(pretty))
+	case outputFormatYAML:
+		fmt.Printf("%s", watchdog.YAMLString())
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(watchdogCmd)
+}

--- a/host.go
+++ b/host.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jaypipes/ghw/pkg/product"
 	"github.com/jaypipes/ghw/pkg/topology"
 	"github.com/jaypipes/ghw/pkg/usb"
+	"github.com/jaypipes/ghw/pkg/watchdog"
 )
 
 // HostInfo is a wrapper struct containing information about the host system's
@@ -42,6 +43,7 @@ type HostInfo struct {
 	Product     *product.Info     `json:"product"`
 	PCI         *pci.Info         `json:"pci"`
 	USB         *usb.Info         `json:"usb"`
+	Watchdog    *watchdog.Info    `json:"watchdog"`
 }
 
 // Host returns a pointer to a HostInfo struct that contains fields with
@@ -100,6 +102,10 @@ func Host(args ...any) (*HostInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	watchdogInfo, err := watchdog.New(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	return &HostInfo{
 		CPU:         cpuInfo,
@@ -115,6 +121,7 @@ func Host(args ...any) (*HostInfo, error) {
 		Product:     productInfo,
 		PCI:         pciInfo,
 		USB:         usbInfo,
+		Watchdog:    watchdogInfo,
 	}, nil
 }
 
@@ -122,7 +129,7 @@ func Host(args ...any) (*HostInfo, error) {
 // structs' String-ified output
 func (info *HostInfo) String() string {
 	return fmt.Sprintf(
-		"%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
+		"%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n",
 		info.Block.String(),
 		info.CPU.String(),
 		info.GPU.String(),
@@ -136,6 +143,7 @@ func (info *HostInfo) String() string {
 		info.Product.String(),
 		info.PCI.String(),
 		info.USB.String(),
+		info.Watchdog.String(),
 	)
 }
 

--- a/pkg/linuxpath/path_linux.go
+++ b/pkg/linuxpath/path_linux.go
@@ -16,6 +16,7 @@ import (
 // PathRoots holds the roots of all the filesystem subtrees
 // ghw wants to access.
 type PathRoots struct {
+	Dev  string
 	Etc  string
 	Proc string
 	Run  string
@@ -26,6 +27,7 @@ type PathRoots struct {
 // DefaultPathRoots return the canonical default value for PathRoots
 func DefaultPathRoots() PathRoots {
 	return PathRoots{
+		Dev:  "/dev",
 		Etc:  "/etc",
 		Proc: "/proc",
 		Run:  "/run",
@@ -39,6 +41,9 @@ func DefaultPathRoots() PathRoots {
 func PathRootsFromContext(ctx context.Context) PathRoots {
 	roots := DefaultPathRoots()
 	overrides := config.PathOverrides(ctx)
+	if pathDev, ok := overrides["/dev"]; ok {
+		roots.Dev = pathDev
+	}
 	if pathEtc, ok := overrides["/etc"]; ok {
 		roots.Etc = pathEtc
 	}
@@ -73,7 +78,9 @@ type Paths struct {
 	SysClassDRM            string
 	SysClassDMI            string
 	SysClassNet            string
+	SysClassWatchdog       string
 	RunUdevData            string
+	DevWatchdog            string
 }
 
 // New returns a new Paths struct containing filepath fields relative to the
@@ -97,7 +104,9 @@ func New(ctx context.Context) *Paths {
 		SysClassDRM:            filepath.Join(chroot, roots.Sys, "class", "drm"),
 		SysClassDMI:            filepath.Join(chroot, roots.Sys, "class", "dmi"),
 		SysClassNet:            filepath.Join(chroot, roots.Sys, "class", "net"),
+		SysClassWatchdog:       filepath.Join(chroot, roots.Sys, "class", "watchdog"),
 		RunUdevData:            filepath.Join(chroot, roots.Run, "udev", "data"),
+		DevWatchdog:            filepath.Join(chroot, roots.Dev, "watchdog"),
 	}
 }
 

--- a/pkg/snapshot/clonetree_linux.go
+++ b/pkg/snapshot/clonetree_linux.go
@@ -51,6 +51,7 @@ func ExpectedCloneStaticContent() []string {
 		"/sys/devices/system/node/node*/meminfo",
 		"/sys/devices/system/node/node*/memory*",
 		"/sys/devices/system/node/node*/hugepages/hugepages-*/*",
+		"/sys/class/watchdog/*",
 	}
 }
 

--- a/pkg/watchdog/watchdog.go
+++ b/pkg/watchdog/watchdog.go
@@ -1,0 +1,54 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package watchdog
+
+import (
+	"fmt"
+
+	"github.com/jaypipes/ghw/internal/config"
+	"github.com/jaypipes/ghw/pkg/marshal"
+)
+
+// Info describes the hardware watchdog on the host system.
+type Info struct {
+	Present bool `json:"present"`
+}
+
+// String returns a short string indicating whether a hardware watchdog is
+// present on the host system.
+func (i *Info) String() string {
+	return fmt.Sprintf("watchdog present: %v", i.Present)
+}
+
+// New returns a pointer to an Info struct that contains information about
+// the hardware watchdog on the host system.
+func New(args ...any) (*Info, error) {
+	ctx := config.ContextFromArgs(args...)
+	info := &Info{}
+	if err := info.load(ctx); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+// simple private struct used to encapsulate watchdog information in a
+// top-level "watchdog" YAML/JSON map/object key
+type watchdogPrinter struct {
+	Info *Info `json:"watchdog"`
+}
+
+// YAMLString returns a string with the watchdog information formatted as YAML
+// under a top-level "watchdog:" key
+func (i *Info) YAMLString() string {
+	return marshal.SafeYAML(watchdogPrinter{i})
+}
+
+// JSONString returns a string with the watchdog information formatted as JSON
+// under a top-level "watchdog:" key
+func (i *Info) JSONString(indent bool) string {
+	return marshal.SafeJSON(watchdogPrinter{i}, indent)
+}

--- a/pkg/watchdog/watchdog_linux.go
+++ b/pkg/watchdog/watchdog_linux.go
@@ -1,0 +1,34 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package watchdog
+
+import (
+	"context"
+	"os"
+
+	"github.com/jaypipes/ghw/pkg/linuxpath"
+)
+
+func (i *Info) load(ctx context.Context) error {
+	paths := linuxpath.New(ctx)
+
+	// A registered watchdog driver exposes a directory per device under
+	// /sys/class/watchdog (kernel >= 4.5).
+	entries, err := os.ReadDir(paths.SysClassWatchdog)
+	if err == nil && len(entries) > 0 {
+		i.Present = true
+		return nil
+	}
+
+	// Fall back to the character device for older kernels without the
+	// watchdog sysfs class.
+	if _, err := os.Stat(paths.DevWatchdog); err == nil {
+		i.Present = true
+	}
+
+	return nil
+}

--- a/pkg/watchdog/watchdog_linux_test.go
+++ b/pkg/watchdog/watchdog_linux_test.go
@@ -1,0 +1,72 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package watchdog_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jaypipes/ghw"
+	"github.com/jaypipes/ghw/pkg/watchdog"
+)
+
+func TestWatchdogSysfs(t *testing.T) {
+	root := t.TempDir()
+
+	wdDir := filepath.Join(root, "sys", "class", "watchdog", "watchdog0")
+	if err := os.MkdirAll(wdDir, 0700); err != nil {
+		t.Fatalf("failed to create watchdog sysfs dir: %v", err)
+	}
+
+	info, err := watchdog.New(ghw.WithChroot(root))
+	if err != nil {
+		t.Fatalf("expected nil err, but got %v", err)
+	}
+	if !info.Present {
+		t.Error("expected watchdog to be present with a /sys/class/watchdog entry")
+	}
+}
+
+func TestWatchdogDevNode(t *testing.T) {
+	root := t.TempDir()
+
+	devDir := filepath.Join(root, "dev")
+	if err := os.MkdirAll(devDir, 0700); err != nil {
+		t.Fatalf("failed to create dev dir: %v", err)
+	}
+	// A regular file stands in for the character device; detection only
+	// checks for existence.
+	if err := os.WriteFile(filepath.Join(devDir, "watchdog"), nil, 0600); err != nil {
+		t.Fatalf("failed to create dev/watchdog: %v", err)
+	}
+
+	info, err := watchdog.New(ghw.WithChroot(root))
+	if err != nil {
+		t.Fatalf("expected nil err, but got %v", err)
+	}
+	if !info.Present {
+		t.Error("expected watchdog to be present with a /dev/watchdog node")
+	}
+}
+
+func TestWatchdogAbsent(t *testing.T) {
+	root := t.TempDir()
+
+	// Empty watchdog class directory must not count as present.
+	if err := os.MkdirAll(filepath.Join(root, "sys", "class", "watchdog"), 0700); err != nil {
+		t.Fatalf("failed to create watchdog sysfs dir: %v", err)
+	}
+
+	info, err := watchdog.New(ghw.WithChroot(root))
+	if err != nil {
+		t.Fatalf("expected nil err, but got %v", err)
+	}
+	if info.Present {
+		t.Error("expected watchdog to be absent")
+	}
+}

--- a/pkg/watchdog/watchdog_stub.go
+++ b/pkg/watchdog/watchdog_stub.go
@@ -1,0 +1,19 @@
+//go:build !linux
+// +build !linux
+
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package watchdog
+
+import (
+	"context"
+	"errors"
+	"runtime"
+)
+
+func (i *Info) load(ctx context.Context) error {
+	return errors.New("watchdog load not implemented on " + runtime.GOOS)
+}


### PR DESCRIPTION
Adds a new `pkg/watchdog` package that reports whether the host system has a hardware
watchdog:

- `WatchdogInfo.Present` is true when `/sys/class/watchdog` has at least one entry, or —
  for kernels predating the watchdog sysfs class (< 4.5) — when the `/dev/watchdog`
  character device exists.
- Lookup paths are routed through `linuxpath`; this adds a `Dev` path root alongside the
  existing ones, with a corresponding `"/dev"` key for `WithPathOverrides`.
- `/sys/class/watchdog/*` is added to the snapshot clone content, so detection also works
  against ghw snapshots.
- Wired into `HostInfo`, the `ghw` package aliases (`ghw.Watchdog()`, `ghw.WatchdogInfo`),
  a new `ghwc watchdog` command (including the default human-format output), and the README.

## Testing

- New chroot-based unit tests cover detection via the sysfs class, via the `/dev/watchdog`
  fallback, and the absent case.
- `go build ./... && go vet ./... && go test ./...` pass on Linux; cross-compiles for
  windows/darwin.
- Verified end-to-end on a real machine: `ghwc watchdog` prints `watchdog present: true`,
  and a snapshot round-trip (`snapshot.CloneTreeInto` → `ghw.Watchdog(ghw.WithChroot(dir))`)
  detects it from the cloned tree as well.