### PR TITLE
linux: fall back to DeviceTree when DMI is unavailable

### DIFF
--- a/pkg/baseboard/baseboard_linux.go
+++ b/pkg/baseboard/baseboard_linux.go
@@ -9,14 +9,33 @@ import (
 	"context"
 
 	"github.com/jaypipes/ghw/pkg/linuxdmi"
+	"github.com/jaypipes/ghw/pkg/linuxdt"
+	"github.com/jaypipes/ghw/pkg/util"
 )
 
 func (i *Info) load(ctx context.Context) error {
+	if !linuxdmi.Available(ctx) && linuxdt.Available(ctx) {
+		return i.loadDeviceTree(ctx)
+	}
+
 	i.AssetTag = linuxdmi.Item(ctx, "board_asset_tag")
 	i.SerialNumber = linuxdmi.Item(ctx, "board_serial")
 	i.Vendor = linuxdmi.Item(ctx, "board_vendor")
 	i.Version = linuxdmi.Item(ctx, "board_version")
 	i.Product = linuxdmi.Item(ctx, "board_name")
+
+	return nil
+}
+
+// loadDeviceTree populates baseboard information from the DeviceTree on systems
+// without DMI/SMBIOS. The DeviceTree carries the model, vendor and serial
+// number, so the asset tag and version stay unknown.
+func (i *Info) loadDeviceTree(ctx context.Context) error {
+	i.AssetTag = util.UNKNOWN
+	i.SerialNumber = linuxdt.SerialNumber(ctx)
+	i.Vendor = linuxdt.Vendor(ctx)
+	i.Version = util.UNKNOWN
+	i.Product = linuxdt.Model(ctx)
 
 	return nil
 }

--- a/pkg/baseboard/baseboard_linux_test.go
+++ b/pkg/baseboard/baseboard_linux_test.go
@@ -1,0 +1,62 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package baseboard_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jaypipes/ghw"
+	"github.com/jaypipes/ghw/pkg/baseboard"
+	"github.com/jaypipes/ghw/pkg/util"
+)
+
+func deviceTreeChroot(t *testing.T, props map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	base := filepath.Join(root, "sys", "firmware", "devicetree", "base")
+	for name, content := range props {
+		path := filepath.Join(base, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestBaseboardDeviceTree(t *testing.T) {
+	// Mixtile Blade 3: compatible prefix "rockchip" despite model "Mixtile Blade 3".
+	root := deviceTreeChroot(t, map[string]string{
+		"model":         "Mixtile Blade 3 v1.0.1\x00",
+		"compatible":    "rockchip,rk3588-blade3-v101-linux\x00rockchip,rk3588\x00",
+		"serial-number": "6bb18c7ac387ae18\x00",
+	})
+
+	info, err := baseboard.New(ghw.WithChroot(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.Product, "Mixtile Blade 3 v1.0.1"; got != want {
+		t.Errorf("product: got %q, want %q", got, want)
+	}
+	// Vendor is the compatible prefix, taken verbatim (a downstream-kernel quirk).
+	if got, want := info.Vendor, "rockchip"; got != want {
+		t.Errorf("vendor: got %q, want %q", got, want)
+	}
+	if got, want := info.SerialNumber, "6bb18c7ac387ae18"; got != want {
+		t.Errorf("serial: got %q, want %q", got, want)
+	}
+	if got := info.AssetTag; got != util.UNKNOWN {
+		t.Errorf("asset tag: got %q, want %q", got, util.UNKNOWN)
+	}
+	if got := info.Version; got != util.UNKNOWN {
+		t.Errorf("version: got %q, want %q", got, util.UNKNOWN)
+	}
+}

--- a/pkg/bios/bios_linux.go
+++ b/pkg/bios/bios_linux.go
@@ -9,12 +9,34 @@ import (
 	"context"
 
 	"github.com/jaypipes/ghw/pkg/linuxdmi"
+	"github.com/jaypipes/ghw/pkg/linuxdt"
+	"github.com/jaypipes/ghw/pkg/util"
 )
 
 func (i *Info) load(ctx context.Context) error {
+	if !linuxdmi.Available(ctx) && linuxdt.Available(ctx) {
+		return i.loadDeviceTree(ctx)
+	}
+
 	i.Vendor = linuxdmi.Item(ctx, "bios_vendor")
 	i.Version = linuxdmi.Item(ctx, "bios_version")
 	i.Date = linuxdmi.Item(ctx, "bios_date")
+
+	return nil
+}
+
+// loadDeviceTree populates BIOS/firmware information from the DeviceTree on
+// systems without DMI/SMBIOS. U-Boot exposes its version under the "chosen"
+// node; when present we report it as a "U-Boot" firmware. The DeviceTree has no
+// firmware date, so that stays unknown.
+func (i *Info) loadDeviceTree(ctx context.Context) error {
+	i.Vendor = util.UNKNOWN
+	i.Version = util.UNKNOWN
+	i.Date = util.UNKNOWN
+	if version := linuxdt.UBootVersion(ctx); version != util.UNKNOWN {
+		i.Vendor = "U-Boot"
+		i.Version = version
+	}
 
 	return nil
 }

--- a/pkg/bios/bios_linux_test.go
+++ b/pkg/bios/bios_linux_test.go
@@ -1,0 +1,72 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package bios_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jaypipes/ghw"
+	"github.com/jaypipes/ghw/pkg/bios"
+	"github.com/jaypipes/ghw/pkg/util"
+)
+
+func deviceTreeChroot(t *testing.T, props map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	base := filepath.Join(root, "sys", "firmware", "devicetree", "base")
+	for name, content := range props {
+		path := filepath.Join(base, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestBIOSDeviceTreeUBoot(t *testing.T) {
+	root := deviceTreeChroot(t, map[string]string{
+		"compatible":            "radxa,nio-12l\x00mediatek,mt8395\x00",
+		"chosen/u-boot,version": "2022.10_armbian-2022.10-S40c5\x00",
+	})
+
+	info, err := bios.New(ghw.WithChroot(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.Vendor, "U-Boot"; got != want {
+		t.Errorf("vendor: got %q, want %q", got, want)
+	}
+	if got, want := info.Version, "2022.10_armbian-2022.10-S40c5"; got != want {
+		t.Errorf("version: got %q, want %q", got, want)
+	}
+	if got := info.Date; got != util.UNKNOWN {
+		t.Errorf("date: got %q, want %q", got, util.UNKNOWN)
+	}
+}
+
+func TestBIOSDeviceTreeNoUBoot(t *testing.T) {
+	// Raspberry Pi: no chosen/u-boot,version (uses its own bootloader).
+	root := deviceTreeChroot(t, map[string]string{
+		"compatible": "raspberrypi,4-model-b\x00brcm,bcm2711\x00",
+	})
+
+	info, err := bios.New(ghw.WithChroot(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, got := range map[string]string{
+		"vendor": info.Vendor, "version": info.Version, "date": info.Date,
+	} {
+		if got != util.UNKNOWN {
+			t.Errorf("%s: got %q, want %q", name, got, util.UNKNOWN)
+		}
+	}
+}

--- a/pkg/chassis/chassis_linux.go
+++ b/pkg/chassis/chassis_linux.go
@@ -9,10 +9,15 @@ import (
 	"context"
 
 	"github.com/jaypipes/ghw/pkg/linuxdmi"
+	"github.com/jaypipes/ghw/pkg/linuxdt"
 	"github.com/jaypipes/ghw/pkg/util"
 )
 
 func (i *Info) load(ctx context.Context) error {
+	if !linuxdmi.Available(ctx) && linuxdt.Available(ctx) {
+		return i.loadDeviceTree(ctx)
+	}
+
 	i.AssetTag = linuxdmi.Item(ctx, "chassis_asset_tag")
 	i.SerialNumber = linuxdmi.Item(ctx, "chassis_serial")
 	i.Type = linuxdmi.Item(ctx, "chassis_type")
@@ -23,6 +28,25 @@ func (i *Info) load(ctx context.Context) error {
 	i.TypeDescription = typeDesc
 	i.Vendor = linuxdmi.Item(ctx, "chassis_vendor")
 	i.Version = linuxdmi.Item(ctx, "chassis_version")
+
+	return nil
+}
+
+// loadDeviceTree populates chassis information from the DeviceTree on systems
+// without DMI/SMBIOS. The DeviceTree has no asset tag concept, and only some
+// boards expose a chassis-type, so several fields remain unknown.
+func (i *Info) loadDeviceTree(ctx context.Context) error {
+	i.AssetTag = util.UNKNOWN
+	i.SerialNumber = linuxdt.SerialNumber(ctx)
+	i.Vendor = linuxdt.Vendor(ctx)
+	i.Version = linuxdt.Model(ctx)
+
+	i.Type = linuxdt.ChassisType(ctx)
+	typeDesc, found := chassisTypeDescriptions[i.Type]
+	if !found {
+		typeDesc = util.UNKNOWN
+	}
+	i.TypeDescription = typeDesc
 
 	return nil
 }

--- a/pkg/chassis/chassis_linux_test.go
+++ b/pkg/chassis/chassis_linux_test.go
@@ -1,0 +1,127 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package chassis_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jaypipes/ghw"
+	"github.com/jaypipes/ghw/pkg/chassis"
+	"github.com/jaypipes/ghw/pkg/util"
+)
+
+// writeFiles writes name->content files (names may be nested subpaths) rooted at
+// dir, creating parent directories as needed.
+func writeFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// deviceTreeChroot builds a chroot whose DeviceTree base holds the given
+// properties and which has no DMI, so the DeviceTree fallback is exercised.
+func deviceTreeChroot(t *testing.T, props map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFiles(t, filepath.Join(root, "sys", "firmware", "devicetree", "base"), props)
+	return root
+}
+
+func TestChassisDeviceTreeRPi(t *testing.T) {
+	root := deviceTreeChroot(t, map[string]string{
+		"model":         "Raspberry Pi 4 Model B Rev 1.4\x00",
+		"compatible":    "raspberrypi,4-model-b\x00brcm,bcm2711\x00",
+		"serial-number": "10000000196f8c53\x00",
+	})
+
+	info, err := chassis.New(ghw.WithChroot(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.Vendor, "raspberrypi"; got != want {
+		t.Errorf("vendor: got %q, want %q", got, want)
+	}
+	if got, want := info.Version, "Raspberry Pi 4 Model B Rev 1.4"; got != want {
+		t.Errorf("version: got %q, want %q", got, want)
+	}
+	if got, want := info.SerialNumber, "10000000196f8c53"; got != want {
+		t.Errorf("serial: got %q, want %q", got, want)
+	}
+	if got := info.AssetTag; got != util.UNKNOWN {
+		t.Errorf("asset tag: got %q, want %q", got, util.UNKNOWN)
+	}
+	// No chassis-type on the Pi -> Type/TypeDescription unknown.
+	if got := info.Type; got != util.UNKNOWN {
+		t.Errorf("type: got %q, want %q", got, util.UNKNOWN)
+	}
+	if got := info.TypeDescription; got != util.UNKNOWN {
+		t.Errorf("type description: got %q, want %q", got, util.UNKNOWN)
+	}
+}
+
+func TestChassisDeviceTreeChassisType(t *testing.T) {
+	// radxa NIO 12L: has chassis-type, no serial-number.
+	root := deviceTreeChroot(t, map[string]string{
+		"model":        "Radxa NIO 12L\x00",
+		"compatible":   "radxa,nio-12l\x00mediatek,mt8395\x00",
+		"chassis-type": "embedded\x00",
+	})
+
+	info, err := chassis.New(ghw.WithChroot(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.Vendor, "radxa"; got != want {
+		t.Errorf("vendor: got %q, want %q", got, want)
+	}
+	if got, want := info.Type, "34"; got != want {
+		t.Errorf("type: got %q, want %q", got, want)
+	}
+	if got, want := info.TypeDescription, "Embedded PC"; got != want {
+		t.Errorf("type description: got %q, want %q", got, want)
+	}
+	if got := info.SerialNumber; got != util.UNKNOWN {
+		t.Errorf("serial: got %q, want %q", got, util.UNKNOWN)
+	}
+}
+
+func TestChassisDMITakesPrecedence(t *testing.T) {
+	root := t.TempDir()
+	// Both DMI and DeviceTree present: DMI must win.
+	writeFiles(t, filepath.Join(root, "sys", "class", "dmi", "id"), map[string]string{
+		"chassis_vendor":  "Acme Corp\n",
+		"chassis_type":    "3\n",
+		"chassis_serial":  "DMI-SERIAL\n",
+		"chassis_version": "1.0\n",
+	})
+	writeFiles(t, filepath.Join(root, "sys", "firmware", "devicetree", "base"), map[string]string{
+		"compatible":    "raspberrypi,4-model-b\x00",
+		"serial-number": "DT-SERIAL\x00",
+	})
+
+	info, err := chassis.New(ghw.WithChroot(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.Vendor, "Acme Corp"; got != want {
+		t.Errorf("vendor: got %q, want %q (DMI should take precedence)", got, want)
+	}
+	if got, want := info.SerialNumber, "DMI-SERIAL"; got != want {
+		t.Errorf("serial: got %q, want %q (DMI should take precedence)", got, want)
+	}
+	if got, want := info.TypeDescription, "Desktop"; got != want {
+		t.Errorf("type description: got %q, want %q", got, want)
+	}
+}

--- a/pkg/cpu/cpu_linux.go
+++ b/pkg/cpu/cpu_linux.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/jaypipes/ghw/internal/log"
+	"github.com/jaypipes/ghw/pkg/linuxdt"
 	"github.com/jaypipes/ghw/pkg/linuxpath"
 	"github.com/jaypipes/ghw/pkg/util"
 )
@@ -117,6 +118,14 @@ func processorsGet(ctx context.Context) []*Processor {
 				proc.Model = lp.Attrs["uarch"]
 			} else if len(lp.Attrs["machine"]) != 0 {
 				proc.Model = lp.Attrs["machine"]
+			}
+			// Last resort: many ARM/RISC-V boards expose no useful model in
+			// /proc/cpuinfo. Fall back to the DeviceTree SoC compatible, e.g.
+			// "rockchip,rk3576".
+			if proc.Model == "" && linuxdt.Available(ctx) {
+				if soc := linuxdt.SoC(ctx); soc != util.UNKNOWN {
+					proc.Model = soc
+				}
 			}
 			// 3. Vendor Detection
 			if len(lp.Attrs["vendor_id"]) != 0 {

--- a/pkg/cpu/cpu_linux_test.go
+++ b/pkg/cpu/cpu_linux_test.go
@@ -84,6 +84,50 @@ func TestArmCPU(t *testing.T) {
 	}
 }
 
+// writeFile creates path (with parent dirs) under a chroot and writes data.
+func writeCPUFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCPUModelFromDeviceTree verifies that a board whose /proc/cpuinfo carries
+// no model attribute falls back to the DeviceTree SoC compatible (the last
+// entry of "compatible", e.g. "rockchip,rk3576").
+func TestCPUModelFromDeviceTree(t *testing.T) {
+	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_CPU"); ok {
+		t.Skip("Skipping CPU tests.")
+	}
+
+	root := t.TempDir()
+
+	// A /proc/cpuinfo with a single logical processor and no model attribute.
+	writeCPUFile(t, filepath.Join(root, "proc", "cpuinfo"),
+		[]byte("processor\t: 0\nFeatures\t: fp asimd\n\n"))
+
+	cpuBase := filepath.Join(root, "sys", "devices", "system", "cpu", "cpu0", "topology")
+	writeCPUFile(t, filepath.Join(cpuBase, "physical_package_id"), []byte("0\n"))
+	writeCPUFile(t, filepath.Join(cpuBase, "core_id"), []byte("0\n"))
+
+	writeCPUFile(t, filepath.Join(root, "sys", "firmware", "devicetree", "base", "compatible"),
+		[]byte("seeed,recomputer-rk3576-devkit\x00rockchip,rk3576\x00"))
+
+	info, err := cpu.New(ghw.WithChroot(root))
+	if err != nil {
+		t.Fatalf("Expected nil err, but got %v", err)
+	}
+	if len(info.Processors) != 1 {
+		t.Fatalf("Expected 1 processor but got %d", len(info.Processors))
+	}
+	if got, want := info.Processors[0].Model, "rockchip,rk3576"; got != want {
+		t.Errorf("Expected model %q from DeviceTree, but got %q", want, got)
+	}
+}
+
 func TestCheckCPUTopologyFilesForOfflineCPU(t *testing.T) {
 	if _, ok := os.LookupEnv("GHW_TESTING_SKIP_CPU"); ok {
 		t.Skip("Skipping CPU tests.")

--- a/pkg/linuxdmi/dmi_linux.go
+++ b/pkg/linuxdmi/dmi_linux.go
@@ -16,6 +16,15 @@ import (
 	"github.com/jaypipes/ghw/pkg/util"
 )
 
+// Available returns true if DMI/SMBIOS data is exposed by the kernel, i.e. the
+// host has a populated /sys/class/dmi/id directory. It is used to decide whether
+// to fall back to other sources (such as the DeviceTree) for hardware identity.
+func Available(ctx context.Context) bool {
+	paths := linuxpath.New(ctx)
+	fi, err := os.Stat(filepath.Join(paths.SysClassDMI, "id"))
+	return err == nil && fi.IsDir()
+}
+
 func Item(ctx context.Context, value string) string {
 	paths := linuxpath.New(ctx)
 	path := filepath.Join(paths.SysClassDMI, "id", value)

--- a/pkg/linuxdt/dt_linux.go
+++ b/pkg/linuxdt/dt_linux.go
@@ -1,0 +1,149 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+// Package linuxdt reads identity information from the Linux DeviceTree, exposed
+// by the kernel under /sys/firmware/devicetree/base. It is the DeviceTree
+// counterpart to the linuxdmi package and is used as a fallback on systems (most
+// ARM/RISC-V boards) that have no DMI/SMBIOS tables.
+//
+// All knowledge of DeviceTree property names and layout lives here: callers ask
+// for a piece of identity (Model, Vendor, SerialNumber, ...) and never deal with
+// raw property paths.
+package linuxdt
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jaypipes/ghw/internal/log"
+	"github.com/jaypipes/ghw/pkg/linuxpath"
+	"github.com/jaypipes/ghw/pkg/util"
+)
+
+// Available returns true if the DeviceTree firmware tree is present, i.e. the
+// host exposes /sys/firmware/devicetree/base.
+func Available(ctx context.Context) bool {
+	paths := linuxpath.New(ctx)
+	fi, err := os.Stat(paths.SysFirmwareDeviceTree)
+	return err == nil && fi.IsDir()
+}
+
+// Model returns the DeviceTree "model" string (e.g. "Raspberry Pi 4 Model B
+// Rev 1.4"), or util.UNKNOWN if absent.
+func Model(ctx context.Context) string {
+	return property(ctx, "model")
+}
+
+// SerialNumber returns the DeviceTree "serial-number" string, or util.UNKNOWN if
+// absent (not all boards provide one).
+func SerialNumber(ctx context.Context) string {
+	return property(ctx, "serial-number")
+}
+
+// Vendor returns the manufacturer/vendor prefix derived from the first entry of
+// the "compatible" property (the substring before the first comma, e.g.
+// "raspberrypi" from "raspberrypi,4-model-b"), or util.UNKNOWN if absent.
+func Vendor(ctx context.Context) string {
+	compatible := propertyList(ctx, "compatible")
+	if len(compatible) == 0 {
+		return util.UNKNOWN
+	}
+	vendor, _, _ := strings.Cut(compatible[0], ",")
+	if vendor == "" {
+		return util.UNKNOWN
+	}
+	return vendor
+}
+
+// SoC returns the System-on-Chip identifier taken from the most specific (last)
+// entry of the "compatible" list, e.g. "rockchip,rk3576" from
+// "seeed,recomputer-rk3576-devkit\0rockchip,rk3576\0". The compatible list runs
+// from most specific board to the underlying SoC, so the last entry is the SoC.
+// Returns util.UNKNOWN if there is no compatible property.
+func SoC(ctx context.Context) string {
+	compatible := propertyList(ctx, "compatible")
+	if len(compatible) == 0 {
+		return util.UNKNOWN
+	}
+	return compatible[len(compatible)-1]
+}
+
+// chassisTypeCodes maps the standardized DeviceTree "chassis-type" property
+// values to the equivalent SMBIOS chassis type codes that ghw uses throughout,
+// so callers can treat a DeviceTree-sourced chassis type identically to a
+// DMI-sourced one.
+var chassisTypeCodes = map[string]string{
+	"desktop":     "3",  // Desktop
+	"laptop":      "9",  // Laptop
+	"convertible": "31", // Convertible
+	"server":      "17", // Main server chassis
+	"tablet":      "30", // Tablet
+	"handset":     "11", // Hand held
+	"watch":       "1",  // Other (no SMBIOS equivalent)
+	"embedded":    "34", // Embedded PC
+	"all-in-one":  "13", // All in one
+}
+
+// ChassisType returns the SMBIOS chassis type code corresponding to the
+// standardized DeviceTree "chassis-type" property (e.g. "34" for "embedded"), or
+// util.UNKNOWN if the property is absent or unrecognized. Only some boards
+// expose it.
+func ChassisType(ctx context.Context) string {
+	if code, ok := chassisTypeCodes[property(ctx, "chassis-type")]; ok {
+		return code
+	}
+	return util.UNKNOWN
+}
+
+// UBootVersion returns the U-Boot firmware version recorded by the bootloader in
+// the "chosen" node, or util.UNKNOWN if absent (boards using another bootloader
+// do not provide it).
+func UBootVersion(ctx context.Context) string {
+	return property(ctx, "chosen/u-boot,version")
+}
+
+// property reads a single string property from the DeviceTree base node and
+// returns it with trailing NUL byte(s) and surrounding whitespace stripped. name
+// may be a relative subpath, e.g. "chosen/u-boot,version". It returns
+// util.UNKNOWN if the property is missing or cannot be read.
+func property(ctx context.Context, name string) string {
+	paths := linuxpath.New(ctx)
+	path := filepath.Join(paths.SysFirmwareDeviceTree, name)
+
+	log.Debug(ctx, "reading from %q", path)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		log.Warn(ctx, "Unable to read %s: %s\n", name, err)
+		return util.UNKNOWN
+	}
+
+	return strings.TrimSpace(strings.Trim(string(b), "\x00"))
+}
+
+// propertyList reads a NUL-separated string list property (for example
+// "compatible") from the DeviceTree base node. It returns nil if the property is
+// missing or cannot be read.
+func propertyList(ctx context.Context, name string) []string {
+	paths := linuxpath.New(ctx)
+	path := filepath.Join(paths.SysFirmwareDeviceTree, name)
+
+	log.Debug(ctx, "reading from %q", path)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		log.Warn(ctx, "Unable to read %s: %s\n", name, err)
+		return nil
+	}
+
+	var items []string
+	for _, item := range strings.Split(string(b), "\x00") {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			items = append(items, item)
+		}
+	}
+	return items
+}

--- a/pkg/linuxdt/dt_linux_test.go
+++ b/pkg/linuxdt/dt_linux_test.go
@@ -1,0 +1,130 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package linuxdt_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jaypipes/ghw"
+	"github.com/jaypipes/ghw/pkg/linuxdt"
+	"github.com/jaypipes/ghw/pkg/util"
+)
+
+// chrootWith creates a fake /sys/firmware/devicetree/base tree under a temp dir
+// and returns a context chrooted to it. props maps a (possibly nested, e.g.
+// "chosen/u-boot,version") property name to its raw bytes.
+func chrootWith(t *testing.T, props map[string][]byte) context.Context {
+	t.Helper()
+	root := t.TempDir()
+	base := filepath.Join(root, "sys", "firmware", "devicetree", "base")
+	for name, val := range props {
+		path := filepath.Join(base, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, val, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return ghw.WithChroot(root)(context.TODO())
+}
+
+func TestAvailable(t *testing.T) {
+	ctx := chrootWith(t, map[string][]byte{
+		"model": []byte("Raspberry Pi 4 Model B Rev 1.4\x00"),
+	})
+	if !linuxdt.Available(ctx) {
+		t.Error("expected DeviceTree to be available")
+	}
+
+	emptyCtx := ghw.WithChroot(t.TempDir())(context.TODO())
+	if linuxdt.Available(emptyCtx) {
+		t.Error("expected DeviceTree to be unavailable when base dir is absent")
+	}
+}
+
+func TestModelAndSerial(t *testing.T) {
+	// Trailing NUL must be stripped.
+	ctx := chrootWith(t, map[string][]byte{
+		"model":         []byte("Raspberry Pi 4 Model B Rev 1.4\x00"),
+		"serial-number": []byte("10000000196f8c53\x00"),
+	})
+	if got, want := linuxdt.Model(ctx), "Raspberry Pi 4 Model B Rev 1.4"; got != want {
+		t.Errorf("model: got %q, want %q", got, want)
+	}
+	if got, want := linuxdt.SerialNumber(ctx), "10000000196f8c53"; got != want {
+		t.Errorf("serial: got %q, want %q", got, want)
+	}
+
+	// Absent properties return util.UNKNOWN.
+	bare := chrootWith(t, map[string][]byte{"model": []byte("Some Board\x00")})
+	if got := linuxdt.SerialNumber(bare); got != util.UNKNOWN {
+		t.Errorf("missing serial: got %q, want %q", got, util.UNKNOWN)
+	}
+}
+
+func TestVendor(t *testing.T) {
+	// Vendor is the prefix of the first NUL-separated "compatible" entry.
+	ctx := chrootWith(t, map[string][]byte{
+		"compatible": []byte("raspberrypi,4-model-b\x00brcm,bcm2711\x00"),
+	})
+	if got, want := linuxdt.Vendor(ctx), "raspberrypi"; got != want {
+		t.Errorf("vendor: got %q, want %q", got, want)
+	}
+
+	noCompat := chrootWith(t, map[string][]byte{"model": []byte("Some Board\x00")})
+	if got := linuxdt.Vendor(noCompat); got != util.UNKNOWN {
+		t.Errorf("vendor without compatible: got %q, want %q", got, util.UNKNOWN)
+	}
+}
+
+func TestSoC(t *testing.T) {
+	// The SoC is the last (most specific) entry of the "compatible" list.
+	ctx := chrootWith(t, map[string][]byte{
+		"compatible": []byte("seeed,recomputer-rk3576-devkit\x00rockchip,rk3576\x00"),
+	})
+	if got, want := linuxdt.SoC(ctx), "rockchip,rk3576"; got != want {
+		t.Errorf("soc: got %q, want %q", got, want)
+	}
+
+	noCompat := chrootWith(t, map[string][]byte{"model": []byte("Some Board\x00")})
+	if got := linuxdt.SoC(noCompat); got != util.UNKNOWN {
+		t.Errorf("soc without compatible: got %q, want %q", got, util.UNKNOWN)
+	}
+}
+
+func TestChassisType(t *testing.T) {
+	// "embedded" maps to the SMBIOS "Embedded PC" code (34).
+	ctx := chrootWith(t, map[string][]byte{
+		"chassis-type": []byte("embedded\x00"),
+	})
+	if got, want := linuxdt.ChassisType(ctx), "34"; got != want {
+		t.Errorf("chassis-type: got %q, want %q", got, want)
+	}
+
+	noType := chrootWith(t, map[string][]byte{"model": []byte("Some Board\x00")})
+	if got := linuxdt.ChassisType(noType); got != util.UNKNOWN {
+		t.Errorf("missing chassis-type: got %q, want %q", got, util.UNKNOWN)
+	}
+}
+
+func TestUBootVersion(t *testing.T) {
+	// Lives in the nested "chosen" node, with a comma in the property name.
+	ctx := chrootWith(t, map[string][]byte{
+		"chosen/u-boot,version": []byte("2026.04_armbian-2026.04\x00"),
+	})
+	if got, want := linuxdt.UBootVersion(ctx), "2026.04_armbian-2026.04"; got != want {
+		t.Errorf("u-boot version: got %q, want %q", got, want)
+	}
+
+	noUBoot := chrootWith(t, map[string][]byte{"model": []byte("Some Board\x00")})
+	if got := linuxdt.UBootVersion(noUBoot); got != util.UNKNOWN {
+		t.Errorf("missing u-boot version: got %q, want %q", got, util.UNKNOWN)
+	}
+}

--- a/pkg/linuxpath/path_linux.go
+++ b/pkg/linuxpath/path_linux.go
@@ -79,6 +79,7 @@ type Paths struct {
 	SysClassDMI            string
 	SysClassNet            string
 	SysClassWatchdog       string
+	SysFirmwareDeviceTree  string
 	RunUdevData            string
 	DevWatchdog            string
 }
@@ -105,6 +106,7 @@ func New(ctx context.Context) *Paths {
 		SysClassDMI:            filepath.Join(chroot, roots.Sys, "class", "dmi"),
 		SysClassNet:            filepath.Join(chroot, roots.Sys, "class", "net"),
 		SysClassWatchdog:       filepath.Join(chroot, roots.Sys, "class", "watchdog"),
+		SysFirmwareDeviceTree:  filepath.Join(chroot, roots.Sys, "firmware", "devicetree", "base"),
 		RunUdevData:            filepath.Join(chroot, roots.Run, "udev", "data"),
 		DevWatchdog:            filepath.Join(chroot, roots.Dev, "watchdog"),
 	}

--- a/pkg/product/product_linux.go
+++ b/pkg/product/product_linux.go
@@ -9,9 +9,15 @@ import (
 	"context"
 
 	"github.com/jaypipes/ghw/pkg/linuxdmi"
+	"github.com/jaypipes/ghw/pkg/linuxdt"
+	"github.com/jaypipes/ghw/pkg/util"
 )
 
 func (i *Info) load(ctx context.Context) error {
+	if !linuxdmi.Available(ctx) && linuxdt.Available(ctx) {
+		return i.loadDeviceTree(ctx)
+	}
+
 	i.Family = linuxdmi.Item(ctx, "product_family")
 	i.Name = linuxdmi.Item(ctx, "product_name")
 	i.Vendor = linuxdmi.Item(ctx, "sys_vendor")
@@ -19,6 +25,21 @@ func (i *Info) load(ctx context.Context) error {
 	i.UUID = linuxdmi.Item(ctx, "product_uuid")
 	i.SKU = linuxdmi.Item(ctx, "product_sku")
 	i.Version = linuxdmi.Item(ctx, "product_version")
+
+	return nil
+}
+
+// loadDeviceTree populates product information from the DeviceTree on systems
+// without DMI/SMBIOS. The DeviceTree only carries the model, vendor and serial
+// number, so the remaining fields stay unknown.
+func (i *Info) loadDeviceTree(ctx context.Context) error {
+	i.Family = util.UNKNOWN
+	i.Name = linuxdt.Model(ctx)
+	i.Vendor = linuxdt.Vendor(ctx)
+	i.SerialNumber = linuxdt.SerialNumber(ctx)
+	i.UUID = util.UNKNOWN
+	i.SKU = util.UNKNOWN
+	i.Version = util.UNKNOWN
 
 	return nil
 }

--- a/pkg/product/product_linux_test.go
+++ b/pkg/product/product_linux_test.go
@@ -1,0 +1,80 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package product_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jaypipes/ghw"
+	"github.com/jaypipes/ghw/pkg/product"
+	"github.com/jaypipes/ghw/pkg/util"
+)
+
+func deviceTreeChroot(t *testing.T, props map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	base := filepath.Join(root, "sys", "firmware", "devicetree", "base")
+	for name, content := range props {
+		path := filepath.Join(base, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestProductDeviceTree(t *testing.T) {
+	root := deviceTreeChroot(t, map[string]string{
+		"model":         "Raspberry Pi 4 Model B Rev 1.4\x00",
+		"compatible":    "raspberrypi,4-model-b\x00brcm,bcm2711\x00",
+		"serial-number": "10000000196f8c53\x00",
+	})
+
+	info, err := product.New(ghw.WithChroot(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.Name, "Raspberry Pi 4 Model B Rev 1.4"; got != want {
+		t.Errorf("name: got %q, want %q", got, want)
+	}
+	if got, want := info.Vendor, "raspberrypi"; got != want {
+		t.Errorf("vendor: got %q, want %q", got, want)
+	}
+	if got, want := info.SerialNumber, "10000000196f8c53"; got != want {
+		t.Errorf("serial: got %q, want %q", got, want)
+	}
+	for name, got := range map[string]string{
+		"family": info.Family, "uuid": info.UUID, "sku": info.SKU, "version": info.Version,
+	} {
+		if got != util.UNKNOWN {
+			t.Errorf("%s: got %q, want %q", name, got, util.UNKNOWN)
+		}
+	}
+}
+
+func TestProductDeviceTreeNoSerial(t *testing.T) {
+	// amlogic odroid: no serial-number property.
+	root := deviceTreeChroot(t, map[string]string{
+		"model":      "Hardkernel ODROID-HC4\x00",
+		"compatible": "hardkernel,odroid-hc4\x00amlogic,sm1\x00",
+	})
+
+	info, err := product.New(ghw.WithChroot(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := info.Vendor, "hardkernel"; got != want {
+		t.Errorf("vendor: got %q, want %q", got, want)
+	}
+	if got := info.SerialNumber; got != util.UNKNOWN {
+		t.Errorf("serial: got %q, want %q", got, util.UNKNOWN)
+	}
+}


### PR DESCRIPTION
DMI/SMBIOS is absent on most DeviceTree-based systems (ARM/RISC-V boards), leaving chassis, product, baseboard, bios and cpu info all unknown. When DMI is unavailable but the DeviceTree is present, populate identity from /sys/firmware/devicetree/base instead:

  - chassis/product/baseboard: model, vendor (compatible prefix), serial-number
  - chassis type: map DeviceTree chassis-type to the SMBIOS type code
  - bios: `chosen/u-boot,version` reported as U-Boot firmware
  - cpu: SoC compatible (last entry) as processor model when cpuinfo has none

DMI remains preferred when present. All DeviceTree property knowledge is encapsulated in the new `linuxdt` package via semantic accessors.