### PR TITLE
fix(snapshot): contain tar entry paths within destination directory

### DIFF
--- a/pkg/snapshot/unpack.go
+++ b/pkg/snapshot/unpack.go
@@ -9,9 +9,11 @@ package snapshot
 import (
 	"archive/tar"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const (
@@ -71,6 +73,11 @@ func Untar(root string, r io.Reader) error {
 		target := filepath.Join(root, header.Name)
 		mode := os.FileMode(header.Mode)
 
+		cleanRoot := filepath.Clean(root) + string(os.PathSeparator)
+		if !strings.HasPrefix(filepath.Clean(target)+string(os.PathSeparator), cleanRoot) {
+			return fmt.Errorf("tar entry %q would escape destination directory", header.Name)
+		}
+
 		switch header.Typeflag {
 		case tar.TypeDir:
 			err = os.MkdirAll(target, mode)
@@ -92,6 +99,10 @@ func Untar(root string, r io.Reader) error {
 			dst.Close()
 
 		case tar.TypeSymlink:
+			resolvedLink := filepath.Join(filepath.Dir(target), header.Linkname)
+			if !strings.HasPrefix(filepath.Clean(resolvedLink)+string(os.PathSeparator), cleanRoot) {
+				return fmt.Errorf("symlink target %q would escape destination directory", header.Linkname)
+			}
 			err = os.Symlink(header.Linkname, target)
 			if err != nil {
 				return err


### PR DESCRIPTION
The Untar helper in pkg/snapshot/unpack.go joins tar entry names to the destination root without checking whether the result stays inside it. A crafted snapshot archive with entries like ../../etc/cron.d/evil can write files outside the intended directory.

Added a filepath.Clean prefix check that rejects any entry - including symlinks whose target resolves outside root - before any file or directory is created.